### PR TITLE
Clean up parsing behavior tests, and test on all difficulties

### DIFF
--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
@@ -64,6 +64,12 @@ namespace YARG.Core.UnitTests.Parsing
             string difficultyName = DifficultyToNameLookup[difficulty];
             builder.Append($"[{difficultyName}{instrumentName}]\n{{\n");
 
+            bool canForce = gameMode is GameMode.Guitar or GameMode.GHLGuitar;
+            bool canTap = gameMode is GameMode.Guitar or GameMode.GHLGuitar;
+            bool canCymbal = gameMode is GameMode.Drums;
+            bool canDoubleKick = gameMode is GameMode.Drums;
+            bool canDynamics = gameMode is GameMode.Drums;
+
             var noteLookup = InstrumentToNoteLookupLookup[gameMode];
             for (int index = 0; index < data.Count; index++)
             {
@@ -80,19 +86,19 @@ namespace YARG.Core.UnitTests.Parsing
                 };
 
                 int chartNumber = noteLookup[rawNote];
-                if ((flags & Flags.DoubleKick) != 0)
+                if (canDoubleKick && (flags & Flags.DoubleKick) != 0)
                     chartNumber = NOTE_OFFSET_INSTRUMENT_PLUS;
 
                 builder.Append($"  {tick} = N {chartNumber} {note.length}\n");
-                if (gameMode != GameMode.Drums && (flags & Flags.Forced) != 0)
+                if (canForce && (flags & Flags.Forced) != 0)
                     builder.Append($"  {tick} = N 5 0\n");
-                if (gameMode != GameMode.Drums && (flags & Flags.Tap) != 0)
+                if (canTap && (flags & Flags.Tap) != 0)
                     builder.Append($"  {tick} = N 6 0\n");
-                if (gameMode == GameMode.Drums && (flags & Flags.ProDrums_Cymbal) != 0)
+                if (canCymbal && (flags & Flags.ProDrums_Cymbal) != 0)
                     builder.Append($"  {tick} = N {NOTE_OFFSET_PRO_DRUMS + chartNumber} 0\n");
-                if (gameMode == GameMode.Drums && (flags & Flags.ProDrums_Accent) != 0)
+                if (canDynamics && (flags & Flags.ProDrums_Accent) != 0)
                     builder.Append($"  {tick} = N {NOTE_OFFSET_DRUMS_ACCENT + chartNumber} 0\n");
-                if (gameMode == GameMode.Drums && (flags & Flags.ProDrums_Ghost) != 0)
+                if (canDynamics && (flags & Flags.ProDrums_Ghost) != 0)
                     builder.Append($"  {tick} = N {NOTE_OFFSET_DRUMS_GHOST + chartNumber} 0\n");
             }
             builder.Append("}\n");

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
@@ -57,7 +57,7 @@ namespace YARG.Core.UnitTests.Parsing
             { GameMode.GHLGuitar, GhlGuitarNoteLookup },
         };
 
-        private static void GenerateSection(StringBuilder builder, List<NoteData> data, MoonInstrument instrument, Difficulty difficulty)
+        private static void GenerateSection(StringBuilder builder, List<MoonNote> data, MoonInstrument instrument, Difficulty difficulty)
         {
             string instrumentName = InstrumentToNameLookup[instrument];
             var gameMode = MoonSong.InstumentToChartGameMode(instrument);
@@ -71,7 +71,15 @@ namespace YARG.Core.UnitTests.Parsing
                 var note = data[index];
                 var flags = note.flags;
 
-                int chartNumber = noteLookup[note.number];
+                // Not technically necessary, but might as well lol
+                int rawNote = gameMode switch {
+                    GameMode.Guitar => (int)note.guitarFret,
+                    GameMode.GHLGuitar => (int)note.ghliveGuitarFret,
+                    GameMode.Drums => (int)note.drumPad,
+                    _ => note.rawNote
+                };
+
+                int chartNumber = noteLookup[rawNote];
                 if ((flags & Flags.DoubleKick) != 0)
                     chartNumber = NOTE_OFFSET_INSTRUMENT_PLUS;
 

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
+using MoonscraperEngine;
 using NUnit.Framework;
 
 namespace YARG.Core.UnitTests.Parsing
@@ -120,9 +121,12 @@ namespace YARG.Core.UnitTests.Parsing
                 """; // Trailing newline is deliberate
 
             var chartBuilder = new StringBuilder(header, 1000);
-            GenerateSection(chartBuilder, GuitarNotes, MoonInstrument.Guitar, Difficulty.Expert);
-            GenerateSection(chartBuilder, GhlGuitarNotes, MoonInstrument.GHLiveGuitar, Difficulty.Expert);
-            GenerateSection(chartBuilder, DrumsNotes, MoonInstrument.Drums, Difficulty.Expert);
+            foreach (var difficulty in EnumX<Difficulty>.Values)
+            {
+                GenerateSection(chartBuilder, GuitarNotes, MoonInstrument.Guitar, difficulty);
+                GenerateSection(chartBuilder, GhlGuitarNotes, MoonInstrument.GHLiveGuitar, difficulty);
+                GenerateSection(chartBuilder, DrumsNotes, MoonInstrument.Drums, difficulty);
+            }
             return chartBuilder.ToString();
         }
 
@@ -145,9 +149,12 @@ namespace YARG.Core.UnitTests.Parsing
             {
                 VerifyMetadata(song);
                 VerifySync(song);
-                VerifyTrack(song, GuitarNotes, MoonInstrument.Guitar, Difficulty.Expert);
-                VerifyTrack(song, GhlGuitarNotes, MoonInstrument.GHLiveGuitar, Difficulty.Expert);
-                VerifyTrack(song, DrumsNotes, MoonInstrument.Drums, Difficulty.Expert);
+                foreach (var difficulty in EnumX<Difficulty>.Values)
+                {
+                    VerifyTrack(song, GuitarNotes, MoonInstrument.Guitar, difficulty);
+                    VerifyTrack(song, GhlGuitarNotes, MoonInstrument.GHLiveGuitar, difficulty);
+                    VerifyTrack(song, DrumsNotes, MoonInstrument.Drums, difficulty);
+                }
             });
         }
     }

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
@@ -118,11 +118,22 @@ namespace YARG.Core.UnitTests.Parsing
                     note.length = 0;
 
                 // Note ons
-                GenerateNotesForDifficulty<NoteOnEvent>(chunk, gameMode, Difficulty.Expert, note, deltaTime, VELOCITY, lastNoteStartDelta);
+                // *MUST* be generated on all difficulties before note offs! Otherwise notes will be placed incorrectly
+                long currentDelta = deltaTime;
+                foreach (var difficulty in EnumX<Difficulty>.Values)
+                {
+                    GenerateNotesForDifficulty<NoteOnEvent>(chunk, gameMode, difficulty, note, currentDelta, VELOCITY, lastNoteStartDelta);
+                    currentDelta = 0;
+                }
 
                 // Note offs
                 long endDelta = Math.Max(note.length, 1);
-                GenerateNotesForDifficulty<NoteOffEvent>(chunk, gameMode, Difficulty.Expert, note, endDelta, 0, lastNoteStartDelta);
+                currentDelta = endDelta;
+                foreach (var difficulty in EnumX<Difficulty>.Values)
+                {
+                    GenerateNotesForDifficulty<NoteOffEvent>(chunk, gameMode, difficulty, note, currentDelta, 0, lastNoteStartDelta);
+                    currentDelta = 0;
+                }
 
                 deltaTime = RESOLUTION - endDelta;
                 lastNoteStartDelta = RESOLUTION;
@@ -236,9 +247,12 @@ namespace YARG.Core.UnitTests.Parsing
             {
                 VerifyMetadata(song);
                 VerifySync(song);
-                VerifyTrack(song, GuitarNotes, MoonInstrument.Guitar, Difficulty.Expert);
-                VerifyTrack(song, GhlGuitarNotes, MoonInstrument.GHLiveGuitar, Difficulty.Expert);
-                VerifyTrack(song, DrumsNotes, MoonInstrument.Drums, Difficulty.Expert);
+                foreach (var difficulty in EnumX<Difficulty>.Values)
+                {
+                    VerifyTrack(song, GuitarNotes, MoonInstrument.Guitar, difficulty);
+                    VerifyTrack(song, GhlGuitarNotes, MoonInstrument.GHLiveGuitar, difficulty);
+                    VerifyTrack(song, DrumsNotes, MoonInstrument.Drums, difficulty);
+                }
             });
         }
     }

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -13,6 +13,8 @@ namespace YARG.Core.UnitTests.Parsing
         public const int NUMERATOR = 4;
         public const int DENOMINATOR_POW2 = 2;
 
+        public const uint HOPO_THRESHOLD = (uint)(SongConfig.FORCED_NOTE_TICK_THRESHOLD * RESOLUTION / SongConfig.STANDARD_BEAT_RESOLUTION);
+
         private static MoonNote NewNote(GuitarFret fret, uint length = 0, Flags flags = Flags.None)
             => new(0, (int)fret, length, flags);
         private static MoonNote NewNote(GHLiveGuitarFret fret, uint length = 0, Flags flags = Flags.None)

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -8,109 +8,98 @@ namespace YARG.Core.UnitTests.Parsing
 
     public class ParseBehaviorTests
     {
-        public struct NoteData
-        {
-            public int number;
-            public int length;
-            public Flags flags;
-
-            public NoteData(int number, int length = 0, Flags flags = Flags.None)
-            {
-                this.number = number;
-                this.length = length;
-                this.flags = flags;
-            }
-
-            public NoteData(GuitarFret fret, int length = 0, Flags flags = Flags.None) : this((int)fret, length, flags) { }
-            public NoteData(GHLiveGuitarFret fret, int length = 0, Flags flags = Flags.None) : this((int)fret, length, flags) { }
-            public NoteData(DrumPad pad, int length = 0, Flags flags = Flags.None) : this((int)pad, length, flags) { }
-        }
-
         public const uint RESOLUTION = 192;
         public const double TEMPO = 120.0;
         public const int NUMERATOR = 4;
         public const int DENOMINATOR_POW2 = 2;
 
-        public static readonly List<NoteData> GuitarNotes = new()
+        private static MoonNote NewNote(GuitarFret fret, uint length = 0, Flags flags = Flags.None)
+            => new(0, (int)fret, length, flags);
+        private static MoonNote NewNote(GHLiveGuitarFret fret, uint length = 0, Flags flags = Flags.None)
+            => new(0, (int)fret, length, flags);
+        private static MoonNote NewNote(DrumPad pad, uint length = 0, Flags flags = Flags.None)
+            => new(0, (int)pad, length, flags);
+
+        public static readonly List<MoonNote> GuitarNotes = new()
         {
-            new NoteData(GuitarFret.Green),
-            new NoteData(GuitarFret.Red),
-            new NoteData(GuitarFret.Yellow),
-            new NoteData(GuitarFret.Blue),
-            new NoteData(GuitarFret.Orange),
-            new NoteData(GuitarFret.Open),
+            NewNote(GuitarFret.Green),
+            NewNote(GuitarFret.Red),
+            NewNote(GuitarFret.Yellow),
+            NewNote(GuitarFret.Blue),
+            NewNote(GuitarFret.Orange),
+            NewNote(GuitarFret.Open),
 
-            new NoteData(GuitarFret.Green, flags: Flags.Forced),
-            new NoteData(GuitarFret.Red, flags: Flags.Forced),
-            new NoteData(GuitarFret.Yellow, flags: Flags.Forced),
-            new NoteData(GuitarFret.Blue, flags: Flags.Forced),
-            new NoteData(GuitarFret.Orange, flags: Flags.Forced),
-            new NoteData(GuitarFret.Open, flags: Flags.Forced),
+            NewNote(GuitarFret.Green, flags: Flags.Forced),
+            NewNote(GuitarFret.Red, flags: Flags.Forced),
+            NewNote(GuitarFret.Yellow, flags: Flags.Forced),
+            NewNote(GuitarFret.Blue, flags: Flags.Forced),
+            NewNote(GuitarFret.Orange, flags: Flags.Forced),
+            NewNote(GuitarFret.Open, flags: Flags.Forced),
 
-            new NoteData(GuitarFret.Green, flags: Flags.Tap),
-            new NoteData(GuitarFret.Red, flags: Flags.Tap),
-            new NoteData(GuitarFret.Yellow, flags: Flags.Tap),
-            new NoteData(GuitarFret.Blue, flags: Flags.Tap),
-            new NoteData(GuitarFret.Orange, flags: Flags.Tap),
+            NewNote(GuitarFret.Green, flags: Flags.Tap),
+            NewNote(GuitarFret.Red, flags: Flags.Tap),
+            NewNote(GuitarFret.Yellow, flags: Flags.Tap),
+            NewNote(GuitarFret.Blue, flags: Flags.Tap),
+            NewNote(GuitarFret.Orange, flags: Flags.Tap),
         };
 
-        public static readonly List<NoteData> GhlGuitarNotes = new()
+        public static readonly List<MoonNote> GhlGuitarNotes = new()
         {
-            new NoteData(GHLiveGuitarFret.Black1),
-            new NoteData(GHLiveGuitarFret.Black2),
-            new NoteData(GHLiveGuitarFret.Black3),
-            new NoteData(GHLiveGuitarFret.White1),
-            new NoteData(GHLiveGuitarFret.White2),
-            new NoteData(GHLiveGuitarFret.White3),
-            new NoteData(GHLiveGuitarFret.Open),
+            NewNote(GHLiveGuitarFret.Black1),
+            NewNote(GHLiveGuitarFret.Black2),
+            NewNote(GHLiveGuitarFret.Black3),
+            NewNote(GHLiveGuitarFret.White1),
+            NewNote(GHLiveGuitarFret.White2),
+            NewNote(GHLiveGuitarFret.White3),
+            NewNote(GHLiveGuitarFret.Open),
 
-            new NoteData(GHLiveGuitarFret.Black1, flags: Flags.Forced),
-            new NoteData(GHLiveGuitarFret.Black2, flags: Flags.Forced),
-            new NoteData(GHLiveGuitarFret.Black3, flags: Flags.Forced),
-            new NoteData(GHLiveGuitarFret.White1, flags: Flags.Forced),
-            new NoteData(GHLiveGuitarFret.White2, flags: Flags.Forced),
-            new NoteData(GHLiveGuitarFret.White3, flags: Flags.Forced),
-            new NoteData(GHLiveGuitarFret.Open, flags: Flags.Forced),
+            NewNote(GHLiveGuitarFret.Black1, flags: Flags.Forced),
+            NewNote(GHLiveGuitarFret.Black2, flags: Flags.Forced),
+            NewNote(GHLiveGuitarFret.Black3, flags: Flags.Forced),
+            NewNote(GHLiveGuitarFret.White1, flags: Flags.Forced),
+            NewNote(GHLiveGuitarFret.White2, flags: Flags.Forced),
+            NewNote(GHLiveGuitarFret.White3, flags: Flags.Forced),
+            NewNote(GHLiveGuitarFret.Open, flags: Flags.Forced),
 
-            new NoteData(GHLiveGuitarFret.Black1, flags: Flags.Tap),
-            new NoteData(GHLiveGuitarFret.Black2, flags: Flags.Tap),
-            new NoteData(GHLiveGuitarFret.Black3, flags: Flags.Tap),
-            new NoteData(GHLiveGuitarFret.White1, flags: Flags.Tap),
-            new NoteData(GHLiveGuitarFret.White2, flags: Flags.Tap),
-            new NoteData(GHLiveGuitarFret.White3, flags: Flags.Tap),
+            NewNote(GHLiveGuitarFret.Black1, flags: Flags.Tap),
+            NewNote(GHLiveGuitarFret.Black2, flags: Flags.Tap),
+            NewNote(GHLiveGuitarFret.Black3, flags: Flags.Tap),
+            NewNote(GHLiveGuitarFret.White1, flags: Flags.Tap),
+            NewNote(GHLiveGuitarFret.White2, flags: Flags.Tap),
+            NewNote(GHLiveGuitarFret.White3, flags: Flags.Tap),
         };
 
-        public static readonly List<NoteData> DrumsNotes = new()
+        public static readonly List<MoonNote> DrumsNotes = new()
         {
-            new NoteData(DrumPad.Kick),
-            new NoteData(DrumPad.Kick, flags: Flags.DoubleKick),
+            NewNote(DrumPad.Kick),
+            NewNote(DrumPad.Kick, flags: Flags.DoubleKick),
 
-            new NoteData(DrumPad.Red, length: 16),
-            new NoteData(DrumPad.Yellow, length: 16),
-            new NoteData(DrumPad.Blue, length: 16),
-            new NoteData(DrumPad.Orange, length: 16),
-            new NoteData(DrumPad.Green, length: 16),
-            new NoteData(DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            new NoteData(DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-            new NoteData(DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewNote(DrumPad.Red, length: 16),
+            NewNote(DrumPad.Yellow, length: 16),
+            NewNote(DrumPad.Blue, length: 16),
+            NewNote(DrumPad.Orange, length: 16),
+            NewNote(DrumPad.Green, length: 16),
+            NewNote(DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+            NewNote(DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-            new NoteData(DrumPad.Red, flags: Flags.ProDrums_Accent),
-            new NoteData(DrumPad.Yellow, flags: Flags.ProDrums_Accent),
-            new NoteData(DrumPad.Blue, flags: Flags.ProDrums_Accent),
-            new NoteData(DrumPad.Orange, flags: Flags.ProDrums_Accent),
-            new NoteData(DrumPad.Green, flags: Flags.ProDrums_Accent),
-            new NoteData(DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
-            new NoteData(DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
-            new NoteData(DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+            NewNote(DrumPad.Red, flags: Flags.ProDrums_Accent),
+            NewNote(DrumPad.Yellow, flags: Flags.ProDrums_Accent),
+            NewNote(DrumPad.Blue, flags: Flags.ProDrums_Accent),
+            NewNote(DrumPad.Orange, flags: Flags.ProDrums_Accent),
+            NewNote(DrumPad.Green, flags: Flags.ProDrums_Accent),
+            NewNote(DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+            NewNote(DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+            NewNote(DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
 
-            new NoteData(DrumPad.Red, flags: Flags.ProDrums_Ghost),
-            new NoteData(DrumPad.Yellow, flags: Flags.ProDrums_Ghost),
-            new NoteData(DrumPad.Blue, flags: Flags.ProDrums_Ghost),
-            new NoteData(DrumPad.Orange, flags: Flags.ProDrums_Ghost),
-            new NoteData(DrumPad.Green, flags: Flags.ProDrums_Ghost),
-            new NoteData(DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
-            new NoteData(DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
-            new NoteData(DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Red, flags: Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Yellow, flags: Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Blue, flags: Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Orange, flags: Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Green, flags: Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+            NewNote(DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
         };
 
         public static void VerifyMetadata(MoonSong song)
@@ -143,7 +132,7 @@ namespace YARG.Core.UnitTests.Parsing
             });
         }
 
-        public static void VerifyTrack(MoonSong song, List<NoteData> data, MoonInstrument instrument, Difficulty difficulty)
+        public static void VerifyTrack(MoonSong song, List<MoonNote> data, MoonInstrument instrument, Difficulty difficulty)
         {
             Assert.Multiple(() =>
             {
@@ -156,7 +145,7 @@ namespace YARG.Core.UnitTests.Parsing
                 for (int index = 0; index < data.Count; index++)
                 {
                     uint tick = RESOLUTION * (uint)index;
-                    var note = data[index];
+                    var originalNote = data[index];
                     SongObjectHelper.FindObjectsAtPosition(tick, chart.notes, out int start, out int length);
                     Assert.That(start, Is.Not.EqualTo(SongObjectHelper.NOTFOUND), $"Note at position {tick} was not parsed on {difficulty} {instrument}!");
                     Assert.That(length, Is.AtLeast(1), $"Note at position {tick} was not parsed on {difficulty} {instrument}!");
@@ -164,11 +153,11 @@ namespace YARG.Core.UnitTests.Parsing
                     if (start == SongObjectHelper.NOTFOUND || length != 1)
                         continue;
 
-                    var moonNote = chart.notes[start];
-                    Assert.That(moonNote.tick, Is.EqualTo(tick), $"Note position does not match! (Note {note.number} on {difficulty} {instrument})");
-                    Assert.That(moonNote.rawNote, Is.EqualTo(note.number), $"Raw note does not match! (Tick {tick} on {difficulty} {instrument})");
-                    Assert.That(moonNote.length, Is.EqualTo(note.length), $"Note length does not match! (Note {note.number} at {tick} on {difficulty} {instrument})");
-                    Assert.That(moonNote.flags, Is.EqualTo(note.flags), $"Note flags do not match! (Note {note.number} at {tick} on {difficulty} {instrument})");
+                    var parsedNote = chart.notes[start];
+                    Assert.That(parsedNote.tick, Is.EqualTo(tick), $"Note position does not match! (Note {originalNote.rawNote} on {difficulty} {instrument})");
+                    Assert.That(parsedNote.rawNote, Is.EqualTo(originalNote.rawNote), $"Raw note does not match! (Tick {tick} on {difficulty} {instrument})");
+                    Assert.That(parsedNote.length, Is.EqualTo(originalNote.length), $"Note length does not match! (Note {originalNote.rawNote} at {tick} on {difficulty} {instrument})");
+                    Assert.That(parsedNote.flags, Is.EqualTo(originalNote.flags), $"Note flags do not match! (Note {originalNote.rawNote} at {tick} on {difficulty} {instrument})");
                 }
             });
         }

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -691,9 +691,6 @@ namespace MoonscraperChartEditor.Song.IO
                 { MidIOHelper.SOLO_NOTE, (in EventProcessParams eventProcessParams) => {
                     ProcessNoteOnEventAsEvent(eventProcessParams, MidIOHelper.SOLO_EVENT_TEXT, MidIOHelper.SOLO_END_EVENT_TEXT, tickEndOffset: SOLO_END_CORRECTION_OFFSET);
                 }},
-                { MidIOHelper.DOUBLE_KICK_NOTE, (in EventProcessParams eventProcessParams) => {
-                    ProcessNoteOnEventAsNote(eventProcessParams, MoonSong.Difficulty.Expert, (int)MoonNote.DrumPad.Kick, MoonNote.Flags.InstrumentPlus);
-                }},
 
                 { MidIOHelper.STARPOWER_DRUM_FILL_0, ProcessNoteOnEventAsDrumFill },
                 { MidIOHelper.STARPOWER_DRUM_FILL_1, ProcessNoteOnEventAsDrumFill },
@@ -765,6 +762,14 @@ namespace MoonscraperChartEditor.Song.IO
                             processFnDict.Add(key, (in EventProcessParams eventProcessParams) =>
                             {
                                 ProcessNoteOnEventAsNote(eventProcessParams, difficulty, fret, defaultFlags);
+                            });
+                        }
+
+                        // Double-kick
+                        if (pad == MoonNote.DrumPad.Kick)
+                        {
+                            processFnDict.Add(key - 1, (in EventProcessParams eventProcessParams) => {
+                                ProcessNoteOnEventAsNote(eventProcessParams, difficulty, fret, MoonNote.Flags.InstrumentPlus);
                             });
                         }
                     }


### PR DESCRIPTION
Summary:

- Use MoonNote instead of a purpose-made data type for storing chart generation data
- Clean up and rework a number of things. mostly .mid stuff
- Generate and test all difficulties instead of just Expert

Fixes from testing:

- Parse double-kick notes on all difficulties in .mid