### PR TITLE
Implement vocals unit tests

### DIFF
--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
@@ -437,7 +437,25 @@ namespace YARG.Core.UnitTests.Parsing
                 else if (ev1.absoluteTick < ev2.absoluteTick)
                     return -1;
 
-                return 0;
+                // Determine priority for certain types of events
+                return (ev1.midiEvent, ev2.midiEvent) switch {
+                    // Same-type note events should be sorted by note number
+                    // Not *entirely* necessary, but without this then
+                    // sorting is inconsistent and will throw an exception
+                    (NoteOnEvent on1, NoteOnEvent on2) =>
+                        on1.NoteNumber > on2.NoteNumber ? 1
+                        : on1.NoteNumber < on2.NoteNumber ? -1
+                        : 0,
+                    (NoteOffEvent off1, NoteOffEvent off2) =>
+                        off1.NoteNumber > off2.NoteNumber ? 1
+                        : off1.NoteNumber < off2.NoteNumber ? -1
+                        : 0,
+                    // Note on events should come last, and note offs first
+                    (NoteOnEvent, _) => 1,
+                    (NoteOffEvent, _) => -1,
+                    // The ordering of other events doesn't matter
+                    _ => 0
+                };
             });
 
             // Calculate delta time

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
@@ -37,6 +37,11 @@ namespace YARG.Core.UnitTests.Parsing
             { MoonInstrument.ProGuitar_22Fret, PRO_GUITAR_22_FRET_TRACK },
             { MoonInstrument.ProBass_17Fret,   PRO_BASS_17_FRET_TRACK },
             { MoonInstrument.ProBass_22Fret,   PRO_BASS_22_FRET_TRACK },
+
+            { MoonInstrument.Vocals,   VOCALS_TRACK },
+            { MoonInstrument.Harmony1, HARMONY_1_TRACK },
+            { MoonInstrument.Harmony2, HARMONY_2_TRACK },
+            { MoonInstrument.Harmony3, HARMONY_3_TRACK },
         };
 
 #pragma warning disable IDE0230 // Use UTF-8 string literal
@@ -132,12 +137,45 @@ namespace YARG.Core.UnitTests.Parsing
             { SpecialPhrase.Type.ProDrums_Activation, new[] { DRUM_FILL_NOTE_0, DRUM_FILL_NOTE_1, DRUM_FILL_NOTE_2, DRUM_FILL_NOTE_3, DRUM_FILL_NOTE_4 } },
         };
 
+        private static readonly Dictionary<int, int> VocalsNoteOffsetLookup = BuildVocalsNoteLookup();
+
+        private static Dictionary<int, int> BuildVocalsNoteLookup()
+        {
+            var lookup = new Dictionary<int, int>()
+            {
+                { 0,   PERCUSSION_NOTE},
+            };
+            
+            for (int i = VOCALS_RANGE_START; i <= VOCALS_RANGE_END; i++)
+            {
+                lookup.Add(i, i);
+            }
+
+            return lookup;
+        }
+
+        private static readonly Dictionary<Difficulty, int> VocalsDifficultyStartOffsetLookup = new()
+        {
+            { Difficulty.Expert, 0 },
+            { Difficulty.Hard,   0 },
+            { Difficulty.Medium, 0 },
+            { Difficulty.Easy,   0 },
+        };
+
+        private static readonly Dictionary<SpecialPhrase.Type, byte[]> VocalsSpecialPhraseLookup = new()
+        {
+            { SpecialPhrase.Type.Starpower,      new[] { STARPOWER_NOTE } },
+            { SpecialPhrase.Type.Versus_Player1, new[] { LYRICS_PHRASE_1 } },
+            { SpecialPhrase.Type.Versus_Player2, new[] { LYRICS_PHRASE_2 } },
+        };
+
         private static readonly Dictionary<GameMode, Dictionary<int, int>> InstrumentNoteOffsetLookup = new()
         {
             { GameMode.Guitar,    GuitarNoteOffsetLookup },
             { GameMode.Drums,     DrumsNoteOffsetLookup },
             { GameMode.GHLGuitar, GhlGuitarNoteOffsetLookup },
             { GameMode.ProGuitar, ProGuitarNoteOffsetLookup },
+            { GameMode.Vocals,    VocalsNoteOffsetLookup },
         };
 
         private static readonly Dictionary<GameMode, Dictionary<MoonNoteType, int>> InstrumentForceOffsetLookup = new()
@@ -146,6 +184,7 @@ namespace YARG.Core.UnitTests.Parsing
             { GameMode.Drums,     new() },
             { GameMode.GHLGuitar, GhlGuitarForceOffsetLookup },
             { GameMode.ProGuitar, ProGuitarForceOffsetLookup },
+            { GameMode.Vocals,     new() },
         };
 
         private static readonly Dictionary<GameMode, Dictionary<Flags, byte>> InstrumentChannelFlagLookup = new()
@@ -154,6 +193,7 @@ namespace YARG.Core.UnitTests.Parsing
             { GameMode.Drums,     new() },
             { GameMode.GHLGuitar, new() },
             { GameMode.ProGuitar, ProGuitarChannelFlagLookup },
+            { GameMode.Vocals,     new() },
         };
 
         private static readonly Dictionary<GameMode, Dictionary<Difficulty, int>> InstrumentDifficultyStartLookup = new()
@@ -162,6 +202,7 @@ namespace YARG.Core.UnitTests.Parsing
             { GameMode.Drums,     DRUMS_DIFF_START_LOOKUP },
             { GameMode.GHLGuitar, GHL_GUITAR_DIFF_START_LOOKUP },
             { GameMode.ProGuitar, PRO_GUITAR_DIFF_START_LOOKUP },
+            { GameMode.Vocals,    VocalsDifficultyStartOffsetLookup },
         };
 
         private static readonly Dictionary<GameMode, Dictionary<SpecialPhrase.Type, byte[]>> InstrumentSpecialPhraseLookup = new()
@@ -170,6 +211,7 @@ namespace YARG.Core.UnitTests.Parsing
             { GameMode.Drums,     DrumsSpecialPhraseLookup },
             { GameMode.GHLGuitar, GhlGuitarSpecialPhraseLookup },
             { GameMode.ProGuitar, ProGuitarSpecialPhraseLookup },
+            { GameMode.Vocals,    VocalsSpecialPhraseLookup },
         };
 #pragma warning restore IDE0230
 
@@ -216,6 +258,8 @@ namespace YARG.Core.UnitTests.Parsing
             var gameMode = MoonSong.InstumentToChartGameMode(instrument);
             var timedEvents = new MidiEventList();
 
+            bool singleDifficulty = gameMode is GameMode.Vocals;
+
             // Text event flags to enable extended features
             if (gameMode == GameMode.Drums)
                 timedEvents.Add((0, new TextEvent(CHART_DYNAMICS_TEXT_BRACKET)));
@@ -225,6 +269,9 @@ namespace YARG.Core.UnitTests.Parsing
             long lastNoteTick = 0;
             foreach (var difficulty in EnumX<Difficulty>.Values)
             {
+                if (singleDifficulty && difficulty != Difficulty.Expert)
+                    continue;
+
                 var chart = sourceSong.GetChart(instrument, difficulty);
                 foreach (var chartObj in chart.chartObjects)
                 {
@@ -295,6 +342,7 @@ namespace YARG.Core.UnitTests.Parsing
                 GameMode.GHLGuitar => (int)note.ghliveGuitarFret,
                 GameMode.ProGuitar => (int)note.proGuitarString,
                 GameMode.Drums => (int)note.drumPad,
+                GameMode.Vocals => note.vocalsPitch,
                 _ => note.rawNote
             };
 
@@ -319,6 +367,10 @@ namespace YARG.Core.UnitTests.Parsing
             // Pro Guitar channel flags
             if (!channelFlagLookup.TryGetValue(flags, out byte channel))
                 channel = 0;
+
+            // Vocals percussion note
+            if (gameMode is GameMode.Vocals && (flags & Flags.Vocals_Percussion) != 0)
+                noteNumber = PERCUSSION_NOTE;
 
             // Main note
             var midiNote = new TNoteEvent()
@@ -362,10 +414,13 @@ namespace YARG.Core.UnitTests.Parsing
             if (phrase.length < (SUSTAIN_CUTOFF_THRESHOLD))
                 phrase.length = 0;
 
+            // Get note number (ignore if not supported by the game mode)
+            if (!InstrumentSpecialPhraseLookup[gameMode].TryGetValue(phrase.type, out byte[]? notesToAdd))
+                return;
+
             // Write notes
             long startTick = phrase.tick;
             long endTick = startTick + Math.Max(phrase.length, 1);
-            byte[] notesToAdd = InstrumentSpecialPhraseLookup[gameMode][phrase.type];
             foreach (byte note in notesToAdd)
             {
                 events.Add((startTick, new NoteOnEvent() { NoteNumber = S(note), Velocity = S(VELOCITY) }));
@@ -413,10 +468,6 @@ namespace YARG.Core.UnitTests.Parsing
 
             foreach (var instrument in EnumX<MoonInstrument>.Values)
             {
-                var gameMode = MoonSong.InstumentToChartGameMode(instrument);
-                if (!InstrumentNoteOffsetLookup.ContainsKey(gameMode))
-                    continue;
-
                 var chunk = GenerateTrackChunk(sourceSong, instrument);
                 midi.Chunks.Add(chunk);
             }

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -1,4 +1,5 @@
 using MoonscraperChartEditor.Song;
+using MoonscraperChartEditor.Song.IO;
 using MoonscraperEngine;
 using NUnit.Framework;
 
@@ -29,14 +30,16 @@ namespace YARG.Core.UnitTests.Parsing
         {
         };
 
+        private static MoonNote NewNote(int index, int rawNote, uint length = 0, Flags flags = Flags.None)
+            => new((uint)(index * RESOLUTION), rawNote, length, flags);
         private static MoonNote NewNote(int index, GuitarFret fret, uint length = 0, Flags flags = Flags.None)
-            => new((uint)(index * RESOLUTION), (int)fret, length, flags);
+            => NewNote(index, (int)fret, length, flags);
         private static MoonNote NewNote(int index, GHLiveGuitarFret fret, uint length = 0, Flags flags = Flags.None)
-            => new((uint)(index * RESOLUTION), (int)fret, length, flags);
+            => NewNote(index, (int)fret, length, flags);
         private static MoonNote NewNote(int index, DrumPad pad, uint length = 0, Flags flags = Flags.None)
-            => new((uint)(index * RESOLUTION), (int)pad, length, flags);
+            => NewNote(index, (int)pad, length, flags);
         private static MoonNote NewNote(int index, ProGuitarString str, int fret, uint length = 0, Flags flags = Flags.None)
-            => new((uint)(index * RESOLUTION), MoonNote.MakeProGuitarRawNote(str, fret), length, flags);
+            => NewNote(index, MoonNote.MakeProGuitarRawNote(str, fret), length, flags);
         private static SpecialPhrase NewSpecial(int index, SpecialPhrase.Type type, uint length = 0)
             => new((uint)(index * RESOLUTION), length, type);
 
@@ -261,6 +264,78 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(69, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
         };
 
+        private const byte VOCALS_RANGE_START = MidIOHelper.VOCALS_RANGE_START;
+
+        public static readonly List<ChartObject> VocalsNotes = new()
+        {
+            NewSpecial(0, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+            NewSpecial(0, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
+            NewNote(0, VOCALS_RANGE_START + 0, length: RESOLUTION / 2),
+            NewNote(1, VOCALS_RANGE_START + 1, length: RESOLUTION / 2),
+            NewNote(2, VOCALS_RANGE_START + 2, length: RESOLUTION / 2),
+            NewNote(3, VOCALS_RANGE_START + 3, length: RESOLUTION / 2),
+            NewNote(4, VOCALS_RANGE_START + 4, length: RESOLUTION / 2),
+            NewNote(5, VOCALS_RANGE_START + 5, length: RESOLUTION / 2),
+            NewNote(6, VOCALS_RANGE_START + 6, length: RESOLUTION / 2),
+            NewNote(7, VOCALS_RANGE_START + 7, length: RESOLUTION / 2),
+            NewNote(8, VOCALS_RANGE_START + 8, length: RESOLUTION / 2),
+            NewNote(9, VOCALS_RANGE_START + 9, length: RESOLUTION / 2),
+            NewNote(10, VOCALS_RANGE_START + 10, length: RESOLUTION / 2),
+            NewNote(11, VOCALS_RANGE_START + 11, length: RESOLUTION / 2),
+
+            NewSpecial(12, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+            NewSpecial(12, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
+            NewSpecial(12, SpecialPhrase.Type.Starpower, RESOLUTION * 12),
+            NewNote(12, VOCALS_RANGE_START + 12, length: RESOLUTION / 2),
+            NewNote(13, VOCALS_RANGE_START + 13, length: RESOLUTION / 2),
+            NewNote(14, VOCALS_RANGE_START + 14, length: RESOLUTION / 2),
+            NewNote(15, VOCALS_RANGE_START + 15, length: RESOLUTION / 2),
+            NewNote(16, VOCALS_RANGE_START + 16, length: RESOLUTION / 2),
+            NewNote(17, VOCALS_RANGE_START + 17, length: RESOLUTION / 2),
+            NewNote(18, VOCALS_RANGE_START + 18, length: RESOLUTION / 2),
+            NewNote(19, VOCALS_RANGE_START + 19, length: RESOLUTION / 2),
+            NewNote(20, VOCALS_RANGE_START + 20, length: RESOLUTION / 2),
+            NewNote(21, VOCALS_RANGE_START + 21, length: RESOLUTION / 2),
+            NewNote(22, VOCALS_RANGE_START + 22, length: RESOLUTION / 2),
+            NewNote(23, VOCALS_RANGE_START + 23, length: RESOLUTION / 2),
+
+            NewSpecial(24, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+            NewSpecial(24, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
+            NewSpecial(24, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
+            NewNote(24, VOCALS_RANGE_START + 24, length: RESOLUTION / 2),
+            NewNote(25, VOCALS_RANGE_START + 25, length: RESOLUTION / 2),
+            NewNote(26, VOCALS_RANGE_START + 26, length: RESOLUTION / 2),
+            NewNote(27, VOCALS_RANGE_START + 27, length: RESOLUTION / 2),
+            NewNote(28, VOCALS_RANGE_START + 28, length: RESOLUTION / 2),
+            NewNote(29, VOCALS_RANGE_START + 29, length: RESOLUTION / 2),
+            NewNote(30, VOCALS_RANGE_START + 30, length: RESOLUTION / 2),
+            NewNote(31, VOCALS_RANGE_START + 31, length: RESOLUTION / 2),
+            NewNote(32, VOCALS_RANGE_START + 32, length: RESOLUTION / 2),
+            NewNote(33, VOCALS_RANGE_START + 33, length: RESOLUTION / 2),
+            NewNote(34, VOCALS_RANGE_START + 34, length: RESOLUTION / 2),
+            NewNote(35, VOCALS_RANGE_START + 35, length: RESOLUTION / 2),
+
+            NewSpecial(36, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
+            NewSpecial(36, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 13),
+            NewNote(36, VOCALS_RANGE_START + 36, length: RESOLUTION / 2),
+            NewNote(37, VOCALS_RANGE_START + 37, length: RESOLUTION / 2),
+            NewNote(38, VOCALS_RANGE_START + 38, length: RESOLUTION / 2),
+            NewNote(39, VOCALS_RANGE_START + 39, length: RESOLUTION / 2),
+            NewNote(40, VOCALS_RANGE_START + 40, length: RESOLUTION / 2),
+            NewNote(41, VOCALS_RANGE_START + 41, length: RESOLUTION / 2),
+            NewNote(42, VOCALS_RANGE_START + 42, length: RESOLUTION / 2),
+            NewNote(43, VOCALS_RANGE_START + 43, length: RESOLUTION / 2),
+            NewNote(44, VOCALS_RANGE_START + 44, length: RESOLUTION / 2),
+            NewNote(45, VOCALS_RANGE_START + 45, length: RESOLUTION / 2),
+            NewNote(46, VOCALS_RANGE_START + 46, length: RESOLUTION / 2),
+            NewNote(47, VOCALS_RANGE_START + 47, length: RESOLUTION / 2),
+            NewNote(48, VOCALS_RANGE_START + 48, length: RESOLUTION / 2),
+
+            NewSpecial(49, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
+            NewSpecial(49, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 1),
+            NewNote(49, 0, flags: Flags.Vocals_Percussion),
+        };
+
         public static MoonSong GenerateSong()
         {
             var song = new MoonSong();
@@ -282,7 +357,7 @@ namespace YARG.Core.UnitTests.Parsing
                 GameMode.GHLGuitar => GhlGuitarTrack,
                 GameMode.ProGuitar => ProGuitarTrack,
                 GameMode.Drums => DrumsTrack,
-                GameMode.Vocals => new(), // TODO
+                GameMode.Vocals => VocalsNotes,
                 _ => throw new NotImplementedException($"No note data for game mode {gameMode}")
             };
         }

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -1026,10 +1026,11 @@ namespace MoonscraperChartEditor.Song.IO
 
             for (int i = MidIOHelper.VOCALS_RANGE_START; i <= MidIOHelper.VOCALS_RANGE_END; i++)
             {
+                int rawNote = i; // Capture the note value
                 processFnDict.Add(i, (in EventProcessParams eventProcessParams) => {
                     foreach (var difficulty in EnumX<MoonSong.Difficulty>.Values)
                     {
-                        ProcessNoteOnEventAsNote(eventProcessParams, difficulty, i);
+                        ProcessNoteOnEventAsNote(eventProcessParams, difficulty, rawNote);
                     };
                 });
             }

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -219,8 +219,9 @@ namespace MoonscraperChartEditor.Song.IO
                         break;
 
                     case MidIOHelper.VOCALS_TRACK:
+                        // Parse lyrics to global track, and then parse as an instrument
                         ReadTextEventsIntoGlobalEventsAsLyrics(track, song);
-                        break;
+                        goto default;
 
                     default:
                         MoonSong.MoonInstrument instrument;

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -1016,14 +1016,20 @@ namespace MoonscraperChartEditor.Song.IO
                 }},
 
                 { MidIOHelper.PERCUSSION_NOTE, (in EventProcessParams eventProcessParams) => {
-                    ProcessNoteOnEventAsNote(eventProcessParams, MoonSong.Difficulty.Expert, 0, MoonNote.Flags.Vocals_Percussion);
+                    foreach (var difficulty in EnumX<MoonSong.Difficulty>.Values)
+                    {
+                        ProcessNoteOnEventAsNote(eventProcessParams, difficulty, 0, MoonNote.Flags.Vocals_Percussion);
+                    };
                 }},
             };
 
             for (int i = MidIOHelper.VOCALS_RANGE_START; i <= MidIOHelper.VOCALS_RANGE_END; i++)
             {
                 processFnDict.Add(i, (in EventProcessParams eventProcessParams) => {
-                    ProcessNoteOnEventAsNote(eventProcessParams, MoonSong.Difficulty.Expert, i);
+                    foreach (var difficulty in EnumX<MoonSong.Difficulty>.Values)
+                    {
+                        ProcessNoteOnEventAsNote(eventProcessParams, difficulty, i);
+                    };
                 });
             }
 


### PR DESCRIPTION
Vocals parsing was just entirely busted lol, this is why you test.

Fixes made after testing:

- Vocals are now parsed onto all 4 difficulties, for consistency and to avoid having to add a hack to only verify Expert on vocals.
- MIDI event sorting in .mid generation now orders note off events before note ons, to prevent issues where consecutive notes with the same number could get parsed as duplicates.
  - I was gonna do this initially, but didn't consider it important, and then it came back to cause issues here lol
- `PART VOCALS` was not being parsed at all since it was still handled specially to load lyrics into global events, now it also transfers over to the instrument handling case afterwards.
- Vocals notes were not being parsed correctly due to incorrect variable captures in the delegate.