### PR TITLE
Remove `[Flags]` attribute from SpecialPhrase.Type

### DIFF
--- a/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
@@ -8,7 +8,6 @@ namespace MoonscraperChartEditor.Song
     [Serializable]
     public class SpecialPhrase : ChartObject
     {
-        [Flags]
         public enum Type
         {
             Starpower,


### PR DESCRIPTION
Forgot to remove it when refactoring special phrases lol