### PR TITLE
Clean up/re-organize note types and add some new things to them

### DIFF
--- a/YARG.Core/Chart/Events/ChartEvent.cs
+++ b/YARG.Core/Chart/Events/ChartEvent.cs
@@ -5,13 +5,13 @@ namespace YARG.Core.Chart
     /// </summary>
     public abstract class ChartEvent
     {
-        public double Time { get; }
+        public double Time       { get; }
         public double TimeLength { get; }
-        public double TimeEnd => Time + TimeLength;
+        public double TimeEnd    => Time + TimeLength;
 
-        public uint Tick { get; }
+        public uint Tick       { get; }
         public uint TickLength { get; }
-        public uint TickEnd => Tick + TickLength;
+        public uint TickEnd    => Tick + TickLength;
 
         public ChartEvent(double time, double timeLength, uint tick, uint tickLength)
         {

--- a/YARG.Core/Chart/Events/TextEvent.cs
+++ b/YARG.Core/Chart/Events/TextEvent.cs
@@ -7,8 +7,8 @@ namespace YARG.Core.Chart
     {
         public string Text { get; }
 
-        public TextEvent(string text, double time, double timeLength, uint tick, uint tickLength)
-            : base(time, timeLength, tick, tickLength)
+        public TextEvent(string text, double time, uint tick)
+            : base(time, 0, tick, 0)
         {
             Text = text;
         }

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -8,7 +8,7 @@ namespace YARG.Core.Chart
 
         public int Pad { get; }
 
-        public DrumNoteType Type { get; }
+        public DrumNoteType Type { get; set; }
 
         public bool IsNeutral => Type == DrumNoteType.Neutral;
         public bool IsAccent  => Type == DrumNoteType.Accent;

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -8,25 +8,25 @@ namespace YARG.Core.Chart
 
         public int Pad { get; }
 
-        public bool IsGhost  => (_drumFlags & DrumNoteFlags.DrumGhost) != 0;
-        public bool IsAccent => (_drumFlags & DrumNoteFlags.DrumAccent) != 0;
+        public DrumNoteType Type { get; }
 
-        public DrumNote(FourLaneDrumPad pad, DrumNoteFlags drumFlags,
+        public DrumNote(FourLaneDrumPad pad, DrumNoteType noteType, DrumNoteFlags drumFlags,
             NoteFlags flags, double time, uint tick)
-            : this((int)pad, drumFlags, flags, time, tick) 
+            : this((int)pad, noteType, drumFlags, flags, time, tick) 
         {
         }
 
-        public DrumNote(FiveLaneDrumPad pad, DrumNoteFlags drumFlags,
+        public DrumNote(FiveLaneDrumPad pad, DrumNoteType noteType, DrumNoteFlags drumFlags,
             NoteFlags flags, double time, uint tick)
-            : this((int)pad, drumFlags, flags, time, tick) 
+            : this((int)pad, noteType, drumFlags, flags, time, tick) 
         {
         }
 
-        public DrumNote(int pad, DrumNoteFlags drumFlags, NoteFlags flags, double time, uint tick)
+        public DrumNote(int pad, DrumNoteType noteType, DrumNoteFlags drumFlags, NoteFlags flags, double time, uint tick)
             : base(flags, time, 0, tick, 0) 
         {
             Pad = pad;
+            Type = noteType;
             _drumFlags = drumFlags;
         }
     }
@@ -56,12 +56,16 @@ namespace YARG.Core.Chart
         Green,
     }
 
+    public enum DrumNoteType
+    {
+        Neutral,
+        Ghost,
+        Accent,
+    }
+
     [Flags]
     public enum DrumNoteFlags
     {
         None = 0,
-
-        DrumGhost  = 1 << 1,
-        DrumAccent = 1 << 2,
     }
 }

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -10,6 +10,8 @@ namespace YARG.Core.Chart
 
         public DrumNoteType Type { get; }
 
+        public bool IsStarPowerActivator => (_drumFlags & DrumNoteFlags.StarPowerActivator) != 0;
+
         public DrumNote(FourLaneDrumPad pad, DrumNoteType noteType, DrumNoteFlags drumFlags,
             NoteFlags flags, double time, uint tick)
             : this((int)pad, noteType, drumFlags, flags, time, tick) 
@@ -67,5 +69,7 @@ namespace YARG.Core.Chart
     public enum DrumNoteFlags
     {
         None = 0,
+
+        StarPowerActivator = 1 << 0,
     }
 }

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -1,18 +1,33 @@
+﻿using System;
+
 namespace YARG.Core.Chart
 {
     public class DrumNote : Note 
     {
         public int Pad { get; }
 
-        public bool IsCymbal => (_flags & NoteFlags.Cymbal) != 0;
+        private readonly DrumNoteFlags _drumFlags;
 
-        public bool IsGhost  => (_flags & NoteFlags.DrumGhost) != 0;
-        public bool IsAccent => (_flags & NoteFlags.DrumAccent) != 0;
+        public bool IsCymbal => (_drumFlags & DrumNoteFlags.Cymbal) != 0;
 
-        public DrumNote(int pad, NoteFlags flags, double time, uint tick)
+        public bool IsGhost  => (_drumFlags & DrumNoteFlags.DrumGhost) != 0;
+        public bool IsAccent => (_drumFlags & DrumNoteFlags.DrumAccent) != 0;
+
+        public DrumNote(int pad, DrumNoteFlags drumFlags, NoteFlags flags, double time, uint tick)
             : base(flags, time, 0, tick, 0) 
         {
             Pad = pad;
+            _drumFlags = drumFlags;
         }
+    }
+
+    [Flags]
+    public enum DrumNoteFlags
+    {
+        None = 0,
+
+        Cymbal     = 1 << 0,
+        DrumGhost  = 1 << 1,
+        DrumAccent = 1 << 2,
     }
 }

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -4,9 +4,9 @@ namespace YARG.Core.Chart
 {
     public class DrumNote : Note 
     {
-        public int Pad { get; }
-
         private readonly DrumNoteFlags _drumFlags;
+
+        public int Pad { get; }
 
         public bool IsCymbal => (_drumFlags & DrumNoteFlags.Cymbal) != 0;
 

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -1,4 +1,4 @@
-﻿namespace YARG.Core.Chart
+namespace YARG.Core.Chart
 {
     public class DrumNote : Note 
     {
@@ -9,8 +9,8 @@
         public bool IsGhost  => (_flags & NoteFlags.DrumGhost) != 0;
         public bool IsAccent => (_flags & NoteFlags.DrumAccent) != 0;
 
-        public DrumNote(Note previousNote, double time, uint tick, int pad, NoteFlags flags)
-            : base(previousNote, time, 0, tick, 0, flags) 
+        public DrumNote(int pad, NoteFlags flags, double time, uint tick)
+            : base(flags, time, 0, tick, 0) 
         {
             Pad = pad;
         }

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -10,6 +10,10 @@ namespace YARG.Core.Chart
 
         public DrumNoteType Type { get; }
 
+        public bool IsNeutral => Type == DrumNoteType.Neutral;
+        public bool IsAccent  => Type == DrumNoteType.Accent;
+        public bool IsGhost   => Type == DrumNoteType.Ghost;
+
         public bool IsStarPowerActivator => (_drumFlags & DrumNoteFlags.StarPowerActivator) != 0;
 
         public DrumNote(FourLaneDrumPad pad, DrumNoteType noteType, DrumNoteFlags drumFlags,

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -8,10 +8,20 @@ namespace YARG.Core.Chart
 
         public int Pad { get; }
 
-        public bool IsCymbal => (_drumFlags & DrumNoteFlags.Cymbal) != 0;
-
         public bool IsGhost  => (_drumFlags & DrumNoteFlags.DrumGhost) != 0;
         public bool IsAccent => (_drumFlags & DrumNoteFlags.DrumAccent) != 0;
+
+        public DrumNote(FourLaneDrumPad pad, DrumNoteFlags drumFlags,
+            NoteFlags flags, double time, uint tick)
+            : this((int)pad, drumFlags, flags, time, tick) 
+        {
+        }
+
+        public DrumNote(FiveLaneDrumPad pad, DrumNoteFlags drumFlags,
+            NoteFlags flags, double time, uint tick)
+            : this((int)pad, drumFlags, flags, time, tick) 
+        {
+        }
 
         public DrumNote(int pad, DrumNoteFlags drumFlags, NoteFlags flags, double time, uint tick)
             : base(flags, time, 0, tick, 0) 
@@ -21,12 +31,36 @@ namespace YARG.Core.Chart
         }
     }
 
+    public enum FourLaneDrumPad
+    {
+        Kick,
+
+        RedDrum,
+        YellowDrum,
+        BlueDrum,
+        GreenDrum,
+
+        YellowCymbal,
+        BlueCymbal,
+        GreenCymbal,
+    }
+
+    public enum FiveLaneDrumPad
+    {
+        Kick,
+
+        Red,
+        Yellow,
+        Blue,
+        Orange,
+        Green,
+    }
+
     [Flags]
     public enum DrumNoteFlags
     {
         None = 0,
 
-        Cymbal     = 1 << 0,
         DrumGhost  = 1 << 1,
         DrumAccent = 1 << 2,
     }

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -1,4 +1,5 @@
-﻿using MoonscraperChartEditor.Song;
+using System;
+using MoonscraperChartEditor.Song;
 
 namespace YARG.Core.Chart
 {
@@ -7,12 +8,12 @@ namespace YARG.Core.Chart
         public int Fret     { get; }
         public int NoteMask { get; private set; }
 
+        private readonly GuitarNoteFlags _guitarFlags;
+
         public bool IsSustain { get; }
 
-        public bool IsChord => (_flags & NoteFlags.Chord) != 0;
-
-        public bool IsExtendedSustain => (_flags & NoteFlags.ExtendedSustain) != 0;
-        public bool IsDisjoint        => (_flags & NoteFlags.Disjoint) != 0;
+        public bool IsExtendedSustain => (_guitarFlags & GuitarNoteFlags.ExtendedSustain) != 0;
+        public bool IsDisjoint        => (_guitarFlags & GuitarNoteFlags.Disjoint) != 0;
 
         private bool _isForced;
 
@@ -65,8 +66,8 @@ namespace YARG.Core.Chart
             }
         }
 
-        public GuitarNote(int fret, MoonNote.MoonNoteType moonNoteType, NoteFlags flags, double time, double timeLength,
-            uint tick, uint tickLength)
+        public GuitarNote(int fret, MoonNote.MoonNoteType moonNoteType, GuitarNoteFlags guitarFlags, NoteFlags flags,
+            double time, double timeLength, uint tick, uint tickLength)
             : base(flags, time, timeLength, tick, tickLength) 
         {
             Fret = fret;
@@ -76,6 +77,8 @@ namespace YARG.Core.Chart
             _isStrum = moonNoteType == MoonNote.MoonNoteType.Strum;
             _isTap = moonNoteType == MoonNote.MoonNoteType.Tap;
             _isHopo = moonNoteType == MoonNote.MoonNoteType.Hopo && !_isTap;
+
+            _guitarFlags = guitarFlags;
 
             NoteMask = 1 << fret - 1;
         }
@@ -89,5 +92,14 @@ namespace YARG.Core.Chart
 
             NoteMask |= 1 << guitarNote.Fret - 1;
         }
+    }
+
+    [Flags]
+    public enum GuitarNoteFlags
+    {
+        None = 0,
+
+        ExtendedSustain = 1 << 0,
+        Disjoint        = 1 << 1,
     }
 }

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -66,6 +66,18 @@ namespace YARG.Core.Chart
             }
         }
 
+        public GuitarNote(FiveFretGuitarFret fret, MoonNote.MoonNoteType moonNoteType, GuitarNoteFlags guitarFlags,
+            NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
+            : this((int)fret, moonNoteType, guitarFlags, flags, time, timeLength, tick, tickLength) 
+        {
+        }
+
+        public GuitarNote(SixFretGuitarFret fret, MoonNote.MoonNoteType moonNoteType, GuitarNoteFlags guitarFlags,
+            NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
+            : this((int)fret, moonNoteType, guitarFlags, flags, time, timeLength, tick, tickLength) 
+        {
+        }
+
         public GuitarNote(int fret, MoonNote.MoonNoteType moonNoteType, GuitarNoteFlags guitarFlags, NoteFlags flags,
             double time, double timeLength, uint tick, uint tickLength)
             : base(flags, time, timeLength, tick, tickLength) 
@@ -90,8 +102,29 @@ namespace YARG.Core.Chart
 
             base.AddChildNote(note);
 
-            NoteMask |= 1 << guitarNote.Fret - 1;
+            NoteMask |= 1 << guitarNote.Fret;
         }
+    }
+
+    public enum FiveFretGuitarFret
+    {
+        Open,
+        Green,
+        Red,
+        Yellow,
+        Blue,
+        Orange,
+    }
+
+    public enum SixFretGuitarFret
+    {
+        Open,
+        Black1,
+        Black2,
+        Black3,
+        White1,
+        White2,
+        White3,
     }
 
     [Flags]

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -7,78 +7,29 @@ namespace YARG.Core.Chart
     {
         private readonly GuitarNoteFlags _guitarFlags;
 
-        private bool _isForced;
-
-        private bool _isStrum;
-        private bool _isHopo;
-        private bool _isTap;
-
         public int Fret     { get; }
         public int NoteMask { get; private set; }
+
+        public GuitarNoteType Type { get; }
 
         public bool IsSustain { get; }
 
         public bool IsExtendedSustain => (_guitarFlags & GuitarNoteFlags.ExtendedSustain) != 0;
         public bool IsDisjoint        => (_guitarFlags & GuitarNoteFlags.Disjoint) != 0;
 
-        public bool IsStrum
-        {
-            get => _isStrum;
-            set
-            {
-                if (value)
-                {
-                    IsHopo = false;
-                    IsTap = false;
-                }
-
-                _isStrum = true;
-            }
-        }
-
-        public bool IsHopo
-        {
-            get => _isHopo;
-            set
-            {
-                if (value)
-                {
-                    IsStrum = false;
-                    IsTap = false;
-                }
-
-                _isHopo = true;
-            }
-        }
-
-        public bool IsTap
-        {
-            get => _isTap;
-            set
-            {
-                if (value)
-                {
-                    IsStrum = false;
-                    IsHopo = false;
-                }
-
-                _isTap = true;
-            }
-        }
-
-        public GuitarNote(FiveFretGuitarFret fret, MoonNote.MoonNoteType moonNoteType, GuitarNoteFlags guitarFlags,
+        public GuitarNote(FiveFretGuitarFret fret, GuitarNoteType noteType, GuitarNoteFlags guitarFlags,
             NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
-            : this((int)fret, moonNoteType, guitarFlags, flags, time, timeLength, tick, tickLength) 
+            : this((int)fret, noteType, guitarFlags, flags, time, timeLength, tick, tickLength) 
         {
         }
 
-        public GuitarNote(SixFretGuitarFret fret, MoonNote.MoonNoteType moonNoteType, GuitarNoteFlags guitarFlags,
+        public GuitarNote(SixFretGuitarFret fret, GuitarNoteType noteType, GuitarNoteFlags guitarFlags,
             NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
-            : this((int)fret, moonNoteType, guitarFlags, flags, time, timeLength, tick, tickLength) 
+            : this((int)fret, noteType, guitarFlags, flags, time, timeLength, tick, tickLength) 
         {
         }
 
-        public GuitarNote(int fret, MoonNote.MoonNoteType moonNoteType, GuitarNoteFlags guitarFlags, NoteFlags flags,
+        public GuitarNote(int fret, GuitarNoteType noteType, GuitarNoteFlags guitarFlags, NoteFlags flags,
             double time, double timeLength, uint tick, uint tickLength)
             : base(flags, time, timeLength, tick, tickLength) 
         {
@@ -86,9 +37,7 @@ namespace YARG.Core.Chart
 
             IsSustain = tickLength > 0;
 
-            _isStrum = moonNoteType == MoonNote.MoonNoteType.Strum;
-            _isTap = moonNoteType == MoonNote.MoonNoteType.Tap;
-            _isHopo = moonNoteType == MoonNote.MoonNoteType.Hopo && !_isTap;
+            Type = noteType;
 
             _guitarFlags = guitarFlags;
 
@@ -125,6 +74,13 @@ namespace YARG.Core.Chart
         White1,
         White2,
         White3,
+    }
+
+    public enum GuitarNoteType
+    {
+        Strum,
+        Hopo,
+        Tap
     }
 
     [Flags]

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -65,8 +65,9 @@ namespace YARG.Core.Chart
             }
         }
 
-        public GuitarNote(Note previousNote, double time, double timeLength, uint tick, uint tickLength, int fret,
-            MoonNote.MoonNoteType moonNoteType, NoteFlags flags) : base(previousNote, time, timeLength, tick, tickLength, flags)
+        public GuitarNote(int fret, MoonNote.MoonNoteType moonNoteType, NoteFlags flags, double time, double timeLength,
+            uint tick, uint tickLength)
+            : base(flags, time, timeLength, tick, tickLength) 
         {
             Fret = fret;
 

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -10,7 +10,7 @@ namespace YARG.Core.Chart
         public int Fret     { get; }
         public int NoteMask { get; private set; }
 
-        public GuitarNoteType Type { get; }
+        public GuitarNoteType Type { get; set; }
 
         public bool IsStrum => Type == GuitarNoteType.Strum;
         public bool IsHopo  => Type == GuitarNoteType.Hopo;

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -12,6 +12,10 @@ namespace YARG.Core.Chart
 
         public GuitarNoteType Type { get; }
 
+        public bool IsStrum => Type == GuitarNoteType.Strum;
+        public bool IsHopo  => Type == GuitarNoteType.Hopo;
+        public bool IsTap   => Type == GuitarNoteType.Tap;
+
         public bool IsSustain { get; }
 
         public bool IsExtendedSustain => (_guitarFlags & GuitarNoteFlags.ExtendedSustain) != 0;

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -16,7 +16,7 @@ namespace YARG.Core.Chart
         public bool IsHopo  => Type == GuitarNoteType.Hopo;
         public bool IsTap   => Type == GuitarNoteType.Tap;
 
-        public bool IsSustain { get; }
+        public bool IsSustain => TickLength > 0;
 
         public bool IsExtendedSustain => (_guitarFlags & GuitarNoteFlags.ExtendedSustain) != 0;
         public bool IsDisjoint        => (_guitarFlags & GuitarNoteFlags.Disjoint) != 0;
@@ -38,9 +38,6 @@ namespace YARG.Core.Chart
             : base(flags, time, timeLength, tick, tickLength) 
         {
             Fret = fret;
-
-            IsSustain = tickLength > 0;
-
             Type = noteType;
 
             _guitarFlags = guitarFlags;

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -5,21 +5,21 @@ namespace YARG.Core.Chart
 {
     public class GuitarNote : Note
     {
-        public int Fret     { get; }
-        public int NoteMask { get; private set; }
-
         private readonly GuitarNoteFlags _guitarFlags;
-
-        public bool IsSustain { get; }
-
-        public bool IsExtendedSustain => (_guitarFlags & GuitarNoteFlags.ExtendedSustain) != 0;
-        public bool IsDisjoint        => (_guitarFlags & GuitarNoteFlags.Disjoint) != 0;
 
         private bool _isForced;
 
         private bool _isStrum;
         private bool _isHopo;
         private bool _isTap;
+
+        public int Fret     { get; }
+        public int NoteMask { get; private set; }
+
+        public bool IsSustain { get; }
+
+        public bool IsExtendedSustain => (_guitarFlags & GuitarNoteFlags.ExtendedSustain) != 0;
+        public bool IsDisjoint        => (_guitarFlags & GuitarNoteFlags.Disjoint) != 0;
 
         public bool IsStrum
         {

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -20,10 +20,9 @@ namespace YARG.Core.Chart
         public bool WasHit { get; private set; }
         public bool WasMissed { get; private set; }
 
-        protected Note(Note previousNote, double time, double timeLength, uint tick, uint tickLength, NoteFlags flags)
+        protected Note(NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
             : base(time, timeLength, tick, tickLength)
         {
-            this.previousNote = previousNote;
             _flags = flags;
         }
 

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -5,7 +5,7 @@ namespace YARG.Core.Chart
 {
     public abstract class Note : ChartEvent
     {
-        private readonly List<Note> _childNotes;
+        private readonly List<Note> _childNotes = new();
         private readonly NoteFlags  _flags;
 
         public Note previousNote;

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace YARG.Core.Chart
@@ -11,11 +11,16 @@ namespace YARG.Core.Chart
         private readonly List<Note>          _childNotes;
         public           IReadOnlyList<Note> ChildNotes => _childNotes;
 		
-        protected NoteFlags _flags;
+        private readonly NoteFlags _flags;
+
+        public bool IsChord => _childNotes.Count > 0;
 		
-        public bool IsStarPowerStart => (_flags & NoteFlags.StarPowerStart) != 0;
         public bool IsStarPower      => (_flags & NoteFlags.StarPower) != 0;
+        public bool IsStarPowerStart => (_flags & NoteFlags.StarPowerStart) != 0;
         public bool IsStarPowerEnd   => (_flags & NoteFlags.StarPowerEnd) != 0;
+		
+        public bool IsSoloStart => (_flags & NoteFlags.SoloStart) != 0;
+        public bool IsSoloEnd   => (_flags & NoteFlags.SoloEnd) != 0;
         
         public bool WasHit { get; private set; }
         public bool WasMissed { get; private set; }
@@ -60,18 +65,13 @@ namespace YARG.Core.Chart
     [Flags]
     public enum NoteFlags 
     {
-        None            = 0,
-        Chord           = 1,
-        ExtendedSustain = 2,
-        Disjoint        = 4,
-        StarPowerStart  = 8,
-        StarPower       = 16,
-        StarPowerEnd    = 32,
-        SoloStart       = 64,
-        SoloEnd         = 128,
-        Cymbal          = 256,
-        DrumGhost       = 512,
-        DrumAccent      = 1024,
-        VocalNonPitched = 2048,
+        None = 0,
+
+        StarPower      = 1 << 0,
+        StarPowerStart = 1 << 1,
+        StarPowerEnd   = 1 << 2,
+
+        SoloStart = 1 << 3,
+        SoloEnd   = 1 << 4,
     }
 }

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -5,13 +5,13 @@ namespace YARG.Core.Chart
 {
     public abstract class Note : ChartEvent
     {
+        private readonly List<Note> _childNotes;
+        private readonly NoteFlags  _flags;
+
         public Note previousNote;
         public Note nextNote;
 
-        private readonly List<Note>          _childNotes;
-        public           IReadOnlyList<Note> ChildNotes => _childNotes;
-		
-        private readonly NoteFlags _flags;
+        public IReadOnlyList<Note> ChildNotes => _childNotes;
 
         public bool IsChord => _childNotes.Count > 0;
 		
@@ -22,7 +22,7 @@ namespace YARG.Core.Chart
         public bool IsSoloStart => (_flags & NoteFlags.SoloStart) != 0;
         public bool IsSoloEnd   => (_flags & NoteFlags.SoloEnd) != 0;
         
-        public bool WasHit { get; private set; }
+        public bool WasHit    { get; private set; }
         public bool WasMissed { get; private set; }
 
         protected Note(NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)

--- a/YARG.Core/Chart/Notes/ProGuitarNote.cs
+++ b/YARG.Core/Chart/Notes/ProGuitarNote.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace YARG.Core.Chart
+{
+    public class ProGuitarNote : Note
+    {
+        private readonly ProGuitarNoteFlags _proFlags;
+
+        public int String   { get; }
+        public int Fret     { get; }
+
+        public ProGuitarNoteType Type { get; }
+
+        public bool IsSustain { get; }
+
+        public bool IsExtendedSustain => (_proFlags & ProGuitarNoteFlags.ExtendedSustain) != 0;
+        public bool IsDisjoint        => (_proFlags & ProGuitarNoteFlags.Disjoint) != 0;
+
+        public bool IsMuted => (_proFlags & ProGuitarNoteFlags.Muted) != 0;
+
+        public ProGuitarNote(int stringNo, int fret, ProGuitarNoteType type, ProGuitarNoteFlags proFlags,
+            NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
+            : base(flags, time, timeLength, tick, tickLength)
+        {
+            String = stringNo;
+            Fret = fret;
+            Type = type;
+
+            _proFlags = proFlags;
+
+            IsSustain = tickLength > 0;
+        }
+    }
+
+    public enum ProGuitarNoteType
+    {
+        Strum,
+        Hopo,
+        Tap,
+    }
+
+    [Flags]
+    public enum ProGuitarNoteFlags
+    {
+        None = 0,
+
+        ExtendedSustain = 1 << 0,
+        Disjoint        = 1 << 1,
+
+        Muted = 1 << 2,
+    }
+}

--- a/YARG.Core/Chart/Notes/ProGuitarNote.cs
+++ b/YARG.Core/Chart/Notes/ProGuitarNote.cs
@@ -9,7 +9,7 @@ namespace YARG.Core.Chart
         public int String   { get; }
         public int Fret     { get; }
 
-        public ProGuitarNoteType Type { get; }
+        public ProGuitarNoteType Type { get; set; }
 
         public bool IsStrum => Type == ProGuitarNoteType.Strum;
         public bool IsHopo  => Type == ProGuitarNoteType.Hopo;

--- a/YARG.Core/Chart/Notes/ProGuitarNote.cs
+++ b/YARG.Core/Chart/Notes/ProGuitarNote.cs
@@ -15,7 +15,7 @@ namespace YARG.Core.Chart
         public bool IsHopo  => Type == ProGuitarNoteType.Hopo;
         public bool IsTap   => Type == ProGuitarNoteType.Tap;
 
-        public bool IsSustain { get; }
+        public bool IsSustain => TickLength > 0;
 
         public bool IsExtendedSustain => (_proFlags & ProGuitarNoteFlags.ExtendedSustain) != 0;
         public bool IsDisjoint        => (_proFlags & ProGuitarNoteFlags.Disjoint) != 0;
@@ -31,8 +31,6 @@ namespace YARG.Core.Chart
             Type = type;
 
             _proFlags = proFlags;
-
-            IsSustain = tickLength > 0;
         }
     }
 

--- a/YARG.Core/Chart/Notes/ProGuitarNote.cs
+++ b/YARG.Core/Chart/Notes/ProGuitarNote.cs
@@ -11,6 +11,10 @@ namespace YARG.Core.Chart
 
         public ProGuitarNoteType Type { get; }
 
+        public bool IsStrum => Type == ProGuitarNoteType.Strum;
+        public bool IsHopo  => Type == ProGuitarNoteType.Hopo;
+        public bool IsTap   => Type == ProGuitarNoteType.Tap;
+
         public bool IsSustain { get; }
 
         public bool IsExtendedSustain => (_proFlags & ProGuitarNoteFlags.ExtendedSustain) != 0;

--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace YARG.Core.Chart
@@ -7,13 +8,16 @@ namespace YARG.Core.Chart
         private readonly List<PitchTimePair> _pitchesOverTime;
         public IReadOnlyList<PitchTimePair> PitchesOverTime => _pitchesOverTime;
 
-        public bool IsNonPitched => (_flags & NoteFlags.VocalNonPitched) != 0;
+        private readonly VocalNoteFlags _vocalFlags;
 
-        public VocalNote(List<PitchTimePair> pitchesOverTime, NoteFlags flags, double time, double timeLength, uint tick,
-            uint tickLength)
+        public bool IsNonPitched => (_vocalFlags & VocalNoteFlags.NonPitched) != 0;
+
+        public VocalNote(List<PitchTimePair> pitchesOverTime, VocalNoteFlags vocalFlags, NoteFlags flags, double time,
+            double timeLength, uint tick, uint tickLength)
             : base(flags, time, timeLength, tick, tickLength)
         {
             _pitchesOverTime = pitchesOverTime;
+            _vocalFlags = vocalFlags;
         }
 
         public float PitchAtNormalizedTime(float normalizedTime)
@@ -71,5 +75,13 @@ namespace YARG.Core.Chart
             NormalizedTime = normalizedTime;
             Pitch = pitch;
         }
+    }
+
+    [Flags]
+    public enum VocalNoteFlags
+    {
+        None = 0,
+
+        NonPitched = 1 << 0,
     }
 }

--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -6,9 +6,9 @@ namespace YARG.Core.Chart
     public class VocalNote : Note
     {
         private readonly List<PitchTimePair> _pitchesOverTime;
-        public IReadOnlyList<PitchTimePair> PitchesOverTime => _pitchesOverTime;
+        private readonly VocalNoteFlags      _vocalFlags;
 
-        private readonly VocalNoteFlags _vocalFlags;
+        public IReadOnlyList<PitchTimePair> PitchesOverTime => _pitchesOverTime;
 
         public bool IsNonPitched => (_vocalFlags & VocalNoteFlags.NonPitched) != 0;
 

--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -9,9 +9,9 @@ namespace YARG.Core.Chart
 
         public bool IsNonPitched => (_flags & NoteFlags.VocalNonPitched) != 0;
 
-        public VocalNote(Note previousNote, double time, double timeLength, uint tick,
-            uint tickLength, List<PitchTimePair> pitchesOverTime, NoteFlags flags)
-            : base(previousNote, time, timeLength, tick, tickLength, flags)
+        public VocalNote(List<PitchTimePair> pitchesOverTime, NoteFlags flags, double time, double timeLength, uint tick,
+            uint tickLength)
+            : base(flags, time, timeLength, tick, tickLength)
         {
             _pitchesOverTime = pitchesOverTime;
         }

--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -8,14 +8,18 @@ namespace YARG.Core.Chart
         private readonly List<PitchTimePair> _pitchesOverTime;
         private readonly VocalNoteFlags      _vocalFlags;
 
+        // 0-based: harmony part 1 is 0, harmony part 2 is 1, harmony part 3 is 2, etc.
+        public int HarmonyPart { get; }
+
         public IReadOnlyList<PitchTimePair> PitchesOverTime => _pitchesOverTime;
 
         public bool IsNonPitched => (_vocalFlags & VocalNoteFlags.NonPitched) != 0;
 
-        public VocalNote(List<PitchTimePair> pitchesOverTime, VocalNoteFlags vocalFlags, NoteFlags flags, double time,
-            double timeLength, uint tick, uint tickLength)
+        public VocalNote(List<PitchTimePair> pitchesOverTime, int harmonyPart, VocalNoteFlags vocalFlags, NoteFlags flags,
+            double time, double timeLength, uint tick, uint tickLength)
             : base(flags, time, timeLength, tick, tickLength)
         {
+            HarmonyPart = harmonyPart;
             _pitchesOverTime = pitchesOverTime;
             _vocalFlags = vocalFlags;
         }


### PR DESCRIPTION
Reorganized a number of things to make them a little cleaner, added new note values, types, and flags, added Pro Guitar notes, and fixed the child notes list never being initialized.

Only thing I have specific comments on is regarding the removal of the `previousNote` parameter from the note constructors, the chart loading infrastructure I'm working on doesn't use or need it and the field it assigns to is public anyways lol