### PR TITLE
Implement loading/conversion of MoonSongs to SongCharts

### DIFF
--- a/YARG.Core/Chart/Loaders/ISongLoader.cs
+++ b/YARG.Core/Chart/Loaders/ISongLoader.cs
@@ -14,6 +14,6 @@ namespace YARG.Core.Chart
         InstrumentTrack<GuitarNote> LoadGuitarTrack(Instrument instrument);
         InstrumentTrack<ProGuitarNote> LoadProGuitarTrack(Instrument instrument);
         InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument instrument);
-        InstrumentTrack<VocalNote> LoadVocalsTrack(Instrument instrument);
+        VocalsTrack LoadVocalsTrack(Instrument instrument);
     }
 }

--- a/YARG.Core/Chart/Loaders/ISongLoader.cs
+++ b/YARG.Core/Chart/Loaders/ISongLoader.cs
@@ -1,0 +1,19 @@
+using Melanchall.DryWetMidi.Core;
+
+namespace YARG.Core.Chart
+{
+    /// <summary>
+    /// Interface used for loading chart files.
+    /// </summary>
+    internal interface ISongLoader
+    {
+        void LoadSong(string filePath);
+        void LoadMidi(MidiFile midi);
+        void LoadDotChart(string chartText);
+
+        InstrumentTrack<GuitarNote> LoadGuitarTrack(Instrument instrument);
+        InstrumentTrack<ProGuitarNote> LoadProGuitarTrack(Instrument instrument);
+        InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument instrument);
+        InstrumentTrack<VocalNote> LoadVocalsTrack(Instrument instrument);
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using MoonscraperChartEditor.Song;
+
+// TODO: 5-lane <-> 4-lane conversions
+
+namespace YARG.Core.Chart
+{
+    internal partial class MoonSongLoader : ISongLoader
+    {
+        public InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument instrument)
+        {
+            return instrument.ToGameMode() switch
+            {
+                GameMode.FourLaneDrums => LoadDrumsTrack(instrument, (note, phrases) => CreateFourLaneDrumNote(instrument, note, phrases)),
+                GameMode.FiveLaneDrums => LoadDrumsTrack(instrument, CreateFiveLaneDrumNote),
+                _ => throw new ArgumentException($"Instrument {instrument} is not a drums instrument!", nameof(instrument))
+            };
+        }
+
+        private InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument instrument, CreateNoteDelegate<DrumNote> createNote)
+        {
+            var difficulties = new Dictionary<Difficulty, InstrumentDifficulty<DrumNote>>()
+            {
+                { Difficulty.Easy, LoadDifficulty(instrument, Difficulty.Easy, createNote) },
+                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote) },
+                { Difficulty.Hard, LoadDifficulty(instrument, Difficulty.Hard, createNote) },
+                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote) },
+                { Difficulty.ExpertPlus, LoadDifficulty(instrument, Difficulty.ExpertPlus, createNote) },
+            };
+            return new(instrument, difficulties);
+        }
+
+        private DrumNote CreateFourLaneDrumNote(Instrument instrument, MoonNote moonNote,
+            Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
+        {
+            var pad = GetFourLaneDrumPad(instrument, moonNote);
+            var noteType = GetDrumNoteType(moonNote);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
+
+            return new DrumNote(pad, noteType, drumFlags, generalFlags,
+                moonNote.time, moonNote.tick);
+        }
+
+        private DrumNote CreateFiveLaneDrumNote(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
+        {
+            var pad = GetFiveLaneDrumPad(moonNote);
+            var noteType = GetDrumNoteType(moonNote);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
+
+            return new DrumNote(pad, noteType, drumFlags, generalFlags,
+                moonNote.time, moonNote.tick);
+        }
+
+        private FourLaneDrumPad GetFourLaneDrumPad(Instrument instrument, MoonNote moonNote)
+        {
+            var pad = moonNote.drumPad switch
+            {
+                MoonNote.DrumPad.Kick   => FourLaneDrumPad.Kick,
+                MoonNote.DrumPad.Red    => FourLaneDrumPad.RedDrum,
+                MoonNote.DrumPad.Yellow => FourLaneDrumPad.YellowDrum,
+                MoonNote.DrumPad.Blue   => FourLaneDrumPad.BlueDrum,
+                MoonNote.DrumPad.Orange => FourLaneDrumPad.GreenDrum,
+                MoonNote.DrumPad.Green  => FourLaneDrumPad.GreenDrum,
+                _ => throw new ArgumentException($"Invalid Moonscraper drum pad {moonNote.drumPad}!", nameof(moonNote))
+            };
+
+            // Cymbal marking
+            if (instrument == Instrument.ProDrums && (moonNote.flags & MoonNote.Flags.ProDrums_Cymbal) != 0)
+            {
+                pad = pad switch
+                {
+                    FourLaneDrumPad.YellowDrum => FourLaneDrumPad.YellowCymbal,
+                    FourLaneDrumPad.BlueDrum   => FourLaneDrumPad.BlueCymbal,
+                    FourLaneDrumPad.GreenDrum  => FourLaneDrumPad.GreenCymbal,
+                    _ => throw new InvalidOperationException($"Cannot mark pad {pad} as a cymbal!")
+                };
+            }
+
+            return pad;
+        }
+
+        private FiveLaneDrumPad GetFiveLaneDrumPad(MoonNote moonNote)
+        {
+            return moonNote.drumPad switch
+            {
+                MoonNote.DrumPad.Kick   => FiveLaneDrumPad.Kick,
+                MoonNote.DrumPad.Red    => FiveLaneDrumPad.Red,
+                MoonNote.DrumPad.Yellow => FiveLaneDrumPad.Yellow,
+                MoonNote.DrumPad.Blue   => FiveLaneDrumPad.Blue,
+                MoonNote.DrumPad.Orange => FiveLaneDrumPad.Orange,
+                MoonNote.DrumPad.Green  => FiveLaneDrumPad.Green,
+                _ => throw new ArgumentException($"Invalid Moonscraper drum pad {moonNote.drumPad}!", nameof(moonNote))
+            };
+        }
+
+        private DrumNoteType GetDrumNoteType(MoonNote moonNote)
+        {
+            var noteType = DrumNoteType.Neutral;
+
+            // Accents/ghosts
+            if ((moonNote.flags & MoonNote.Flags.ProDrums_Accent) != 0)
+                noteType = DrumNoteType.Accent;
+            else if ((moonNote.flags & MoonNote.Flags.ProDrums_Ghost) != 0)
+                noteType = DrumNoteType.Ghost;
+
+            return noteType;
+        }
+
+        private DrumNoteFlags GetDrumNoteFlags(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
+        {
+            var flags = DrumNoteFlags.None;
+
+            // SP activator
+            if (currentPhrases.TryGetValue(SpecialPhrase.Type.ProDrums_Activation, out var activationPhrase) &&
+                IsNoteClosestToEndOfPhrase(moonNote, activationPhrase))
+            {
+                flags |= DrumNoteFlags.StarPowerActivator;
+            }
+
+            return flags;
+        }
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using MoonscraperChartEditor.Song;
+
+namespace YARG.Core.Chart
+{
+    internal partial class MoonSongLoader : ISongLoader
+    {
+        public InstrumentTrack<GuitarNote> LoadGuitarTrack(Instrument instrument)
+        {
+            return instrument.ToGameMode() switch
+            {
+                GameMode.FiveFretGuitar => LoadGuitarTrack(instrument, CreateFiveFretGuitarNote),
+                GameMode.SixFretGuitar  => LoadGuitarTrack(instrument, CreateSixFretGuitarNote),
+                _ => throw new ArgumentException($"Instrument {instrument} is not a guitar instrument!")
+            };
+        }
+
+        private InstrumentTrack<GuitarNote> LoadGuitarTrack(Instrument instrument, CreateNoteDelegate<GuitarNote> createNote)
+        {
+            var difficulties = new Dictionary<Difficulty, InstrumentDifficulty<GuitarNote>>()
+            {
+                { Difficulty.Easy, LoadDifficulty(instrument, Difficulty.Easy, createNote) },
+                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote) },
+                { Difficulty.Hard, LoadDifficulty(instrument, Difficulty.Hard, createNote) },
+                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote) },
+            };
+            return new(instrument, difficulties);
+        }
+
+        private GuitarNote CreateFiveFretGuitarNote(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
+        {
+            var fret = GetFiveFretGuitarFret(moonNote);
+            var noteType = GetGuitarNoteType(moonNote);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var guitarFlags = GetGuitarNoteFlags(moonNote);
+
+            return new GuitarNote(fret, noteType, guitarFlags, generalFlags,
+                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+        }
+
+        private GuitarNote CreateSixFretGuitarNote(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
+        {
+            var fret = GetSixFretGuitarFret(moonNote);
+            var noteType = GetGuitarNoteType(moonNote);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var guitarFlags = GetGuitarNoteFlags(moonNote);
+
+            return new GuitarNote(fret, noteType, guitarFlags, generalFlags,
+                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+        }
+
+        private FiveFretGuitarFret GetFiveFretGuitarFret(MoonNote moonNote)
+        {
+            return moonNote.guitarFret switch
+            {
+                MoonNote.GuitarFret.Open   => FiveFretGuitarFret.Open,
+                MoonNote.GuitarFret.Green  => FiveFretGuitarFret.Green,
+                MoonNote.GuitarFret.Red    => FiveFretGuitarFret.Red,
+                MoonNote.GuitarFret.Yellow => FiveFretGuitarFret.Yellow,
+                MoonNote.GuitarFret.Blue   => FiveFretGuitarFret.Blue,
+                MoonNote.GuitarFret.Orange => FiveFretGuitarFret.Orange,
+                _ => throw new InvalidOperationException($"Invalid Moonscraper guitar fret {moonNote.guitarFret}!")
+            };
+        }
+
+        private SixFretGuitarFret GetSixFretGuitarFret(MoonNote moonNote)
+        {
+            return moonNote.ghliveGuitarFret switch
+            {
+                MoonNote.GHLiveGuitarFret.Open   => SixFretGuitarFret.Open,
+                MoonNote.GHLiveGuitarFret.Black1 => SixFretGuitarFret.Black1,
+                MoonNote.GHLiveGuitarFret.Black2 => SixFretGuitarFret.Black2,
+                MoonNote.GHLiveGuitarFret.Black3 => SixFretGuitarFret.Black3,
+                MoonNote.GHLiveGuitarFret.White1 => SixFretGuitarFret.White1,
+                MoonNote.GHLiveGuitarFret.White2 => SixFretGuitarFret.White2,
+                MoonNote.GHLiveGuitarFret.White3 => SixFretGuitarFret.White3,
+                _ => throw new InvalidOperationException($"Invalid Moonscraper guitar fret {moonNote.ghliveGuitarFret}!")
+            };
+        }
+
+        private GuitarNoteType GetGuitarNoteType(MoonNote moonNote)
+        {
+            return moonNote.type switch
+            {
+                MoonNote.MoonNoteType.Strum => GuitarNoteType.Strum,
+                MoonNote.MoonNoteType.Hopo  => GuitarNoteType.Hopo,
+                MoonNote.MoonNoteType.Tap   => GuitarNoteType.Tap,
+                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.type}!")
+            };
+        }
+
+        private GuitarNoteFlags GetGuitarNoteFlags(MoonNote moonNote)
+        {
+            var flags = GuitarNoteFlags.None;
+
+            // Extended sustains
+            var nextNote = moonNote.NextSeperateMoonNote;
+            if (nextNote is not null && (moonNote.tick + moonNote.length) >= nextNote.tick)
+            {
+                flags |= GuitarNoteFlags.ExtendedSustain;
+            }
+
+            // Disjoint chords
+            foreach (var note in moonNote.chord)
+            {
+                if (note.length != moonNote.length)
+                {
+                    flags |= GuitarNoteFlags.Disjoint;
+                    break;
+                }
+            }
+
+            return flags;
+        }
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProGuitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProGuitar.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using MoonscraperChartEditor.Song;
+
+namespace YARG.Core.Chart
+{
+    internal partial class MoonSongLoader : ISongLoader
+    {
+        public InstrumentTrack<ProGuitarNote> LoadProGuitarTrack(Instrument instrument)
+        {
+            if (instrument.ToGameMode() != GameMode.ProGuitar)
+                throw new ArgumentException($"Instrument {instrument} is not a Pro guitar instrument!", nameof(instrument));
+
+            var difficulties = new Dictionary<Difficulty, InstrumentDifficulty<ProGuitarNote>>()
+            {
+                { Difficulty.Easy, LoadDifficulty(instrument, Difficulty.Easy, CreateProGuitarNote) },
+                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, CreateProGuitarNote) },
+                { Difficulty.Hard, LoadDifficulty(instrument, Difficulty.Hard, CreateProGuitarNote) },
+                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, CreateProGuitarNote) },
+            };
+            return new(instrument, difficulties);
+        }
+
+        private ProGuitarNote CreateProGuitarNote(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
+        {
+            var proString = GetProGuitarString(moonNote);
+            int proFret = GetProGuitarFret(moonNote);
+            var noteType = GetProGuitarNoteType(moonNote);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var proFlags = GetProGuitarNoteFlags(moonNote);
+
+            return new ProGuitarNote(proString, proFret, noteType, proFlags, generalFlags,
+                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+        }
+
+        private ProGuitarString GetProGuitarString(MoonNote moonNote)
+        {
+            return moonNote.proGuitarString switch
+            {
+                MoonNote.ProGuitarString.Red    => ProGuitarString.Red,
+                MoonNote.ProGuitarString.Green  => ProGuitarString.Green,
+                MoonNote.ProGuitarString.Orange => ProGuitarString.Orange,
+                MoonNote.ProGuitarString.Blue   => ProGuitarString.Blue,
+                MoonNote.ProGuitarString.Yellow => ProGuitarString.Yellow,
+                MoonNote.ProGuitarString.Purple => ProGuitarString.Purple,
+                _ => throw new InvalidOperationException($"Unhandled Moonscraper Pro guitar string {moonNote.proGuitarString}!")
+            };
+        }
+
+        private int GetProGuitarFret(MoonNote moonNote)
+        {
+            return moonNote.proGuitarFret;
+        }
+
+        private ProGuitarNoteType GetProGuitarNoteType(MoonNote moonNote)
+        {
+            return moonNote.type switch
+            {
+                MoonNote.MoonNoteType.Strum => ProGuitarNoteType.Strum,
+                MoonNote.MoonNoteType.Hopo  => ProGuitarNoteType.Hopo,
+                MoonNote.MoonNoteType.Tap   => ProGuitarNoteType.Tap,
+                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.type}!")
+            };
+        }
+
+        private ProGuitarNoteFlags GetProGuitarNoteFlags(MoonNote moonNote)
+        {
+            var flags = ProGuitarNoteFlags.None;
+
+            // Standard guitar flags
+            var guitarFlags = GetGuitarNoteFlags(moonNote);
+            if ((guitarFlags & GuitarNoteFlags.ExtendedSustain) != 0)
+                flags |= ProGuitarNoteFlags.ExtendedSustain;
+            if ((guitarFlags & GuitarNoteFlags.Disjoint) != 0)
+                flags |= ProGuitarNoteFlags.Disjoint;
+
+            // Muted notes
+            if ((moonNote.flags & MoonNote.Flags.ProGuitar_Muted) != 0)
+            {
+                flags |= ProGuitarNoteFlags.Muted;
+            }
+
+            return flags;
+        }
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using MoonscraperChartEditor.Song;
+using MoonscraperChartEditor.Song.IO;
+
+// TODO: Better parsing/sanitization of lyric events
+
+namespace YARG.Core.Chart
+{
+    internal partial class MoonSongLoader : ISongLoader
+    {
+        private enum LyricType
+        {
+            None = 0,
+
+            NonPitched = 1 << 0,
+            PitchSlide = 1 << 1,
+        }
+
+        private const string PITCH_SLIDE_CHARACTER = "+";
+
+        private static readonly List<char> NONPITCHED_CHARACTERS = new()
+        {
+            '#', // Standard
+            '^', // Lenient
+            '*', // Unknown, present in some charts
+        };
+
+        private static readonly Dictionary<string, string> LYRIC_REPLACE_MAP = new()
+        {
+            { "+", "" },
+            { "#", "" },
+            { "^", "" },
+            { "*", "" },
+            { "_", " " },
+        };
+
+        public VocalsTrack LoadVocalsTrack(Instrument instrument)
+        {
+            return instrument switch
+            {
+                Instrument.Vocals => LoadSoloVocals(instrument),
+                Instrument.Harmony => LoadHarmonyVocals(instrument),
+                _ => throw new ArgumentException($"Instrument {instrument} is not a drums instrument!", nameof(instrument))
+            };
+        }
+
+        private VocalsTrack LoadSoloVocals(Instrument instrument)
+        {
+            var parts = new List<VocalsPart>()
+            {
+                LoadVocalsPart(MoonSong.MoonInstrument.Vocals),
+            };
+            return new(instrument, parts);
+        }
+
+        private VocalsTrack LoadHarmonyVocals(Instrument instrument)
+        {
+            var parts = new List<VocalsPart>()
+            {
+                LoadVocalsPart(MoonSong.MoonInstrument.Harmony1),
+                LoadVocalsPart(MoonSong.MoonInstrument.Harmony2),
+                LoadVocalsPart(MoonSong.MoonInstrument.Harmony3),
+            };
+            return new(instrument, parts);
+        }
+
+        private VocalsPart LoadVocalsPart(MoonSong.MoonInstrument moonInstrument)
+        {
+            int harmonyPart = moonInstrument switch
+            {
+                MoonSong.MoonInstrument.Vocals or
+                MoonSong.MoonInstrument.Harmony1 => 0,
+                MoonSong.MoonInstrument.Harmony2 => 1,
+                MoonSong.MoonInstrument.Harmony3 => 2,
+                _ => throw new ArgumentException($"MoonInstrument {moonInstrument} is not a vocals instrument!", nameof(moonInstrument))
+            };
+            var moonChart = _moonSong.GetChart(moonInstrument, MoonSong.Difficulty.Expert);
+
+            var notePhrases = GetVocalsPhrases(moonChart, harmonyPart);
+            var otherPhrases = GetPhrases(moonChart);
+            var textEvents = GetTextEvents(moonChart);
+            return new(notePhrases, otherPhrases, textEvents);
+        }
+
+        private List<VocalsPhrase> GetVocalsPhrases(MoonChart moonChart, int harmonyPart)
+        {
+            var phrases = new List<VocalsPhrase>(moonChart.specialPhrases.Count);
+            var currentPhrases = new Dictionary<SpecialPhrase.Type, SpecialPhrase>();
+
+            int moonNoteIndex = 0;
+            int moonTextIndex = 0;
+
+            // Load relative to special phrases, not notes
+            for (int moonPhraseIndex = 0; moonPhraseIndex < moonChart.specialPhrases.Count; moonPhraseIndex++)
+            {
+                var moonPhrase = moonChart.specialPhrases[moonPhraseIndex];
+                currentPhrases[moonPhrase.type] = moonPhrase;
+                
+                if (moonPhrase.type != SpecialPhrase.Type.Vocals_LyricPhrase)
+                    continue;
+
+                // Ensure any other phrases on the same tick get tracked
+                moonPhraseIndex++;
+                while (moonPhraseIndex < moonChart.specialPhrases.Count)
+                {
+                    var moonPhrase2 = moonChart.specialPhrases[moonPhraseIndex];
+                    if (moonPhrase2.tick > moonPhrase.tick)
+                        break;
+
+                    currentPhrases[moonPhrase2.type] = moonPhrase2;
+                    moonPhraseIndex++;
+                }
+
+                // Go through each note and lyric in the phrase
+                var notes = new List<VocalNote>();
+                var lyrics = new List<TextEvent>();
+                VocalNote previousNote = null;
+                while (moonNoteIndex < moonChart.notes.Count)
+                {
+                    var moonNote = moonChart.notes[moonNoteIndex];
+                    if (moonNote.tick >= (moonPhrase.tick + moonPhrase.length))
+                        break;
+                    moonNoteIndex++;
+
+                    // Don't process notes that occur before the phrase
+                    if (moonNote.tick < moonPhrase.tick)
+                    {
+                        Debug.WriteLine($"Vocals note at {moonNote.tick} does not exist within a phrase!");
+                        continue;
+                    }
+
+                    // Handle lyric events
+                    var lyricType = LyricType.None;
+                    while (moonTextIndex < moonChart.events.Count)
+                    {
+                        var moonEvent = moonChart.events[moonTextIndex];
+                        if (moonEvent.tick > moonNote.tick)
+                            break;
+                        moonTextIndex++;
+
+                        // Ignore non-lyric events
+                        if (!moonEvent.eventName.StartsWith(ChartIOHelper.LYRIC_EVENT_PREFIX))
+                            continue;
+
+                        string lyric = moonEvent.eventName.Replace(ChartIOHelper.LYRIC_EVENT_PREFIX, "");
+
+                        // Only process note modifiers for lyrics that match the current note
+                        if (moonEvent.tick == moonNote.tick)
+                        {
+                            // Handle modifier lyrics
+                            if (lyric.EndsWith(PITCH_SLIDE_CHARACTER))
+                                lyricType = LyricType.PitchSlide;
+                            else if (NONPITCHED_CHARACTERS.Contains(lyric[^1]))
+                                lyricType = LyricType.NonPitched;
+                        }
+
+                        lyrics.Add(new(lyric, moonEvent.time, moonEvent.tick));
+                    }
+
+                    // Create new note
+                    var note = CreateVocalNote(moonNote, currentPhrases, harmonyPart, lyricType);
+                    if (lyricType is LyricType.PitchSlide && previousNote is not null)
+                    {
+                        previousNote.AddChildNote(note);
+                        continue;
+                    }
+
+                    notes.Add(note);
+                    previousNote = note;
+                }
+
+                var vocalsPhrase = CreateVocalsPhrase(moonPhrase, currentPhrases, notes, lyrics);
+                phrases.Add(vocalsPhrase);
+            }
+
+            phrases.TrimExcess();
+            return phrases;
+        }
+
+        private VocalNote CreateVocalNote(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases,
+            int harmonyPart, LyricType lyricType)
+        {
+            var vocalType = GetVocalNoteType(moonNote);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            float pitch = GetVocalNotePitch(moonNote, lyricType);
+
+            return new VocalNote(pitch, harmonyPart, vocalType, generalFlags,
+                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+        }
+
+        private float GetVocalNotePitch(MoonNote moonNote, LyricType lyricType)
+        {
+            float pitch = moonNote.vocalsPitch;
+
+            // Unpitched/percussion notes
+            if (lyricType is LyricType.NonPitched || (moonNote.flags & MoonNote.Flags.Vocals_Percussion) != 0)
+                pitch = -1f;
+
+            return pitch;
+        }
+
+        private VocalNoteType GetVocalNoteType(MoonNote moonNote)
+        {
+            var flags = VocalNoteType.Lyric;
+
+            // Percussion notes
+            if ((moonNote.flags & MoonNote.Flags.Vocals_Percussion) != 0)
+                flags |= VocalNoteType.Percussion;
+
+            return flags;
+        }
+
+        private VocalsPhrase CreateVocalsPhrase(SpecialPhrase moonPhrase,
+            Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases, List<VocalNote> notes, List<TextEvent> lyrics)
+        {
+            var type = GetVocalsPhraseType(moonPhrase, notes);
+            var bounds = GetVocalsPhraseBounds(moonPhrase);
+            var phraseFlags = GetVocalsPhraseFlags(moonPhrase, currentPhrases);
+
+            return new VocalsPhrase(type, bounds, phraseFlags, notes, lyrics);
+        }
+
+        private ChartEvent GetVocalsPhraseBounds(SpecialPhrase moonPhrase)
+        {
+            return new Phrase(PhraseType.LyricPhrase, moonPhrase.time, GetLengthInTime(moonPhrase),
+                moonPhrase.tick, moonPhrase.length);
+        }
+
+        private VocalsPhraseType GetVocalsPhraseType(SpecialPhrase moonPhrase, List<VocalNote> notes)
+        {
+            var firstNote = notes[0];
+            var phraseType = firstNote.Type switch
+            {
+                VocalNoteType.Lyric      => VocalsPhraseType.Lyric,
+                VocalNoteType.Percussion => VocalsPhraseType.Percussion,
+                _ => throw new NotImplementedException($"Unhandled vocal note type {firstNote.Type}!")
+            };
+
+            // Some debug verifications
+            Debug.Assert(notes.All((note) => note.Type == firstNote.Type), "Vocals phrase with inconsistent note types! Must be either lyric or percussion, but found both");
+
+            // Modify Moonscraper phrase to have the correct type
+            moonPhrase.type = phraseType switch
+            {
+                VocalsPhraseType.Lyric      => SpecialPhrase.Type.Vocals_LyricPhrase,
+                VocalsPhraseType.Percussion => SpecialPhrase.Type.Vocals_PercussionPhrase,
+                _ => throw new NotImplementedException($"Unhandled vocal phrase type {phraseType}!")
+            };
+
+            return phraseType;
+        }
+
+        private VocalsPhraseFlags GetVocalsPhraseFlags(SpecialPhrase moonPhrase,
+            Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
+        {
+            var phraseFlags = VocalsPhraseFlags.None;
+
+            // Star power
+            if (currentPhrases.TryGetValue(SpecialPhrase.Type.Starpower, out var starPower) && IsEventInPhrase(moonPhrase, starPower))
+                phraseFlags |= VocalsPhraseFlags.StarPower;
+
+            return phraseFlags;
+        }
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Melanchall.DryWetMidi.Core;
+using MoonscraperChartEditor.Song;
+using MoonscraperChartEditor.Song.IO;
+
+namespace YARG.Core.Chart
+{
+    using CurrentPhrases = Dictionary<SpecialPhrase.Type, SpecialPhrase>;
+
+    /// <summary>
+    /// Loads chart data from a MoonSong.
+    /// </summary>
+    internal partial class MoonSongLoader : ISongLoader
+    {
+        private delegate TNote CreateNoteDelegate<TNote>(MoonNote moonNote, CurrentPhrases currentPhrases)
+            where TNote : Note;
+
+        private MoonSong _moonSong;
+
+        public void LoadSong(string filePath)
+        {
+            _moonSong = Path.GetExtension(filePath).ToLower() switch
+            {
+                ".mid" => MidReader.ReadMidi(filePath),
+                ".chart" => ChartReader.ReadChart(filePath),
+                _ => throw new ArgumentException($"Unrecognized file extension for chart path '{filePath}'!", nameof(filePath))
+            };
+        }
+
+        public void LoadMidi(MidiFile midi)
+        {
+            _moonSong = MidReader.ReadMidi(midi);
+        }
+
+        public void LoadDotChart(string chartText)
+        {
+            _moonSong = ChartReader.ReadChart(new StringReader(chartText));
+        }
+
+        public InstrumentTrack<GuitarNote> LoadGuitarTrack(Instrument instrument)
+        {
+            // TODO
+            return new(instrument);
+        }
+
+        public InstrumentTrack<ProGuitarNote> LoadProGuitarTrack(Instrument instrument)
+        {
+            // TODO
+            return new(instrument);
+        }
+
+        public InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument instrument)
+        {
+            // TODO
+            return new(instrument);
+        }
+
+        public InstrumentTrack<VocalNote> LoadVocalsTrack(Instrument instrument)
+        {
+            // TODO
+            return new(instrument);
+        }
+
+        private InstrumentDifficulty<TNote> LoadDifficulty<TNote>(Instrument instrument, Difficulty difficulty,
+            CreateNoteDelegate<TNote> createNote)
+            where TNote : Note
+        {
+            var moonChart = GetMoonChart(instrument, difficulty);
+            var notes = GetNotes(moonChart, difficulty, createNote);
+            var phrases = GetPhrases(moonChart);
+            var textEvents = GetTextEvents(moonChart);
+            return new(instrument, difficulty, notes, phrases, textEvents);
+        }
+
+        private List<TNote> GetNotes<TNote>(MoonChart moonChart, Difficulty difficulty, CreateNoteDelegate<TNote> createNote)
+            where TNote : Note
+        {
+            var notes = new List<TNote>(moonChart.notes.Count);
+
+            int moonPhraseIndex = 0;
+            // Phrases stored here are *not* guaranteed to be active, as it's simpler that way
+            // We need to check the phrase bounds anyways, which is very simple to do
+            var currentPhrases = new CurrentPhrases();
+
+            foreach (var moonNote in moonChart.notes)
+            {
+                // Keep track of active special phrases
+                while (moonPhraseIndex < moonChart.specialPhrases.Count)
+                {
+                    var moonPhrase = moonChart.specialPhrases[moonPhraseIndex];
+                    if (moonPhrase.tick > moonNote.tick)
+                        break;
+
+                    currentPhrases[moonPhrase.type] = moonPhrase;
+                    moonPhraseIndex++;
+                }
+
+                // Skip Expert+ notes if not on Expert+
+                if (difficulty != Difficulty.ExpertPlus && (moonNote.flags & MoonNote.Flags.InstrumentPlus) != 0)
+                    continue;
+
+                var newNote = createNote(moonNote, currentPhrases);
+                AddNoteToList(notes, newNote);
+            }
+
+            notes.TrimExcess();
+            return notes;
+        }
+
+        private List<Phrase> GetPhrases(MoonChart moonChart)
+        {
+            var phrases = new List<Phrase>(moonChart.specialPhrases.Count);
+            foreach (var moonPhrase in moonChart.specialPhrases)
+            {
+                var phraseType = moonPhrase.type switch
+                {
+                    SpecialPhrase.Type.Starpower           => PhraseType.StarPower,
+                    SpecialPhrase.Type.Solo                => PhraseType.Solo,
+                    SpecialPhrase.Type.Versus_Player1      => PhraseType.VersusPlayer1,
+                    SpecialPhrase.Type.Versus_Player2      => PhraseType.VersusPlayer2,
+                    SpecialPhrase.Type.TremoloLane         => PhraseType.TremoloLane,
+                    SpecialPhrase.Type.TrillLane           => PhraseType.TrillLane,
+                    SpecialPhrase.Type.ProDrums_Activation => PhraseType.DrumFill,
+                    SpecialPhrase.Type.Vocals_LyricPhrase  => PhraseType.LyricPhrase,
+                    _ => throw new NotImplementedException($"Unhandled special phrase type {moonPhrase.type}!")
+                };
+
+                // TODO: Detect vocals percussion phrases
+
+                var newPhrase = new Phrase(phraseType, moonPhrase.time, GetLengthInTime(moonPhrase), moonPhrase.tick, moonPhrase.length);
+                phrases.Add(newPhrase);
+            }
+
+            return phrases;
+        }
+
+        private List<TextEvent> GetTextEvents(MoonChart moonChart)
+        {
+            var textEvents = new List<TextEvent>(moonChart.events.Count);
+            foreach (var moonText in moonChart.events)
+            {
+                var newText = new TextEvent(moonText.eventName, moonText.time, moonText.tick);
+                textEvents.Add(newText);
+            }
+
+            return textEvents;
+        }
+
+        private NoteFlags GetGeneralFlags(MoonNote moonNote, CurrentPhrases currentPhrases)
+        {
+            var flags = NoteFlags.None;
+
+            // Star power
+            if (currentPhrases.TryGetValue(SpecialPhrase.Type.Starpower, out var starPower) && IsNoteInPhrase(moonNote, starPower))
+            {
+                flags |= NoteFlags.StarPower;
+
+                if (!IsNoteInPhrase(moonNote.PreviousSeperateMoonNote, starPower))
+                    flags |= NoteFlags.StarPowerStart;
+
+                if (!IsNoteInPhrase(moonNote.NextSeperateMoonNote, starPower))
+                    flags |= NoteFlags.StarPowerEnd;
+            }
+
+            // Solos
+            if (currentPhrases.TryGetValue(SpecialPhrase.Type.Solo, out var solo) && IsNoteInPhrase(moonNote, solo))
+            {
+                if (!IsNoteInPhrase(moonNote.PreviousSeperateMoonNote, solo))
+                    flags |= NoteFlags.SoloStart;
+
+                if (!IsNoteInPhrase(moonNote.NextSeperateMoonNote, solo))
+                    flags |= NoteFlags.SoloEnd;
+            }
+
+            return flags;
+        }
+
+        private void AddNoteToList<TNote>(List<TNote> notes, TNote note)
+            where TNote : Note
+        {
+            // The parent of all notes on the current tick
+            var currentParent = notes.Count > 0 ? notes[^1] : null;
+            // Previous parent note (on a different tick)
+            var previousParent = notes.Count > 1 ? notes[^2] : null;
+
+            // Determine if this is part of a chord
+            if (note.Tick == currentParent?.Tick)
+            {
+                // Same chord, assign previous and add as child
+                note.previousNote = previousParent;
+                currentParent.AddChildNote(note);
+                return;
+            }
+
+            // New chord
+            previousParent = currentParent;
+            currentParent = note;
+
+            // Assign next/previous note references
+            if (previousParent is not null)
+            {
+                previousParent.nextNote = currentParent;
+                foreach (var child in previousParent.ChildNotes)
+                    child.nextNote = currentParent;
+
+                currentParent.previousNote = previousParent;
+            }
+
+            notes.Add(note);
+        }
+
+        private double GetLengthInTime(double startTime, uint tick, uint tickLength)
+        {
+            return _moonSong.TickToTime(tick + tickLength, _moonSong.resolution) - startTime;
+        }
+
+        private double GetLengthInTime(MoonNote note)
+        {
+            return GetLengthInTime(note.time, note.tick, note.length);
+        }
+
+        private double GetLengthInTime(SpecialPhrase phrase)
+        {
+            return GetLengthInTime(phrase.time, phrase.tick, phrase.length - 1);
+        }
+
+        private static bool IsNoteInPhrase(MoonNote note, SpecialPhrase phrase)
+        {
+            return note.tick >= phrase.tick && note.tick < (phrase.tick + phrase.length);
+        }
+
+        private MoonChart GetMoonChart(Instrument instrument, Difficulty difficulty)
+        {
+            var moonInstrument = YargInstrumentToMoonInstrument(instrument);
+            var moonDifficulty = YargDifficultyToMoonDifficulty(difficulty);
+            return _moonSong.GetChart(moonInstrument, moonDifficulty);
+        }
+
+        private static MoonSong.MoonInstrument YargInstrumentToMoonInstrument(Instrument instrument) => instrument switch
+        {
+            Instrument.FiveFretGuitar     => MoonSong.MoonInstrument.Guitar,
+            Instrument.FiveFretCoopGuitar => MoonSong.MoonInstrument.GuitarCoop,
+            Instrument.FiveFretBass       => MoonSong.MoonInstrument.Bass,
+            Instrument.FiveFretRhythm     => MoonSong.MoonInstrument.Rhythm,
+            Instrument.Keys               => MoonSong.MoonInstrument.Keys,
+
+            Instrument.SixFretGuitar     => MoonSong.MoonInstrument.GHLiveGuitar,
+            Instrument.SixFretCoopGuitar => MoonSong.MoonInstrument.GHLiveBass,
+            Instrument.SixFretBass       => MoonSong.MoonInstrument.GHLiveRhythm,
+            Instrument.SixFretRhythm     => MoonSong.MoonInstrument.GHLiveCoop,
+
+            Instrument.FourLaneDrums or
+            Instrument.FiveLaneDrums or
+            Instrument.ProDrums => MoonSong.MoonInstrument.Drums,
+
+            Instrument.ProGuitar_17Fret => MoonSong.MoonInstrument.ProGuitar_17Fret,
+            Instrument.ProGuitar_22Fret => MoonSong.MoonInstrument.ProGuitar_22Fret,
+            Instrument.ProBass_17Fret   => MoonSong.MoonInstrument.ProBass_17Fret,
+            Instrument.ProBass_22Fret   => MoonSong.MoonInstrument.ProBass_22Fret,
+
+            // Instrument.ProKeys => MoonSong.MoonInstrument.ProKeys,
+
+            // Vocals and harmony need to be handled specially
+            // Instrument.Vocals  => MoonSong.MoonInstrument.Vocals,
+            // Instrument.Harmony => MoonSong.MoonInstrument.Harmony1,
+
+            _ => throw new NotImplementedException($"Unhandled instrument {instrument}!")
+        };
+
+        private static MoonSong.Difficulty YargDifficultyToMoonDifficulty(Difficulty difficulty) => difficulty switch
+        {
+            Difficulty.Easy       => MoonSong.Difficulty.Easy,
+            Difficulty.Medium     => MoonSong.Difficulty.Medium,
+            Difficulty.Hard       => MoonSong.Difficulty.Hard,
+            Difficulty.Expert or
+            Difficulty.ExpertPlus => MoonSong.Difficulty.Expert,
+            _ => throw new InvalidOperationException($"Invalid difficulty {difficulty}!")
+        };
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -15,7 +15,7 @@ namespace YARG.Core.Chart
     internal partial class MoonSongLoader : ISongLoader
     {
         private delegate TNote CreateNoteDelegate<TNote>(MoonNote moonNote, CurrentPhrases currentPhrases)
-            where TNote : Note;
+            where TNote : Note<TNote>;
 
         private MoonSong _moonSong;
 
@@ -47,7 +47,7 @@ namespace YARG.Core.Chart
 
         private InstrumentDifficulty<TNote> LoadDifficulty<TNote>(Instrument instrument, Difficulty difficulty,
             CreateNoteDelegate<TNote> createNote)
-            where TNote : Note
+            where TNote : Note<TNote>
         {
             var moonChart = GetMoonChart(instrument, difficulty);
             var notes = GetNotes(moonChart, difficulty, createNote);
@@ -57,7 +57,7 @@ namespace YARG.Core.Chart
         }
 
         private List<TNote> GetNotes<TNote>(MoonChart moonChart, Difficulty difficulty, CreateNoteDelegate<TNote> createNote)
-            where TNote : Note
+            where TNote : Note<TNote>
         {
             var notes = new List<TNote>(moonChart.notes.Count);
 
@@ -160,7 +160,7 @@ namespace YARG.Core.Chart
         }
 
         private void AddNoteToList<TNote>(List<TNote> notes, TNote note)
-            where TNote : Note
+            where TNote : Note<TNote>
         {
             // The parent of all notes on the current tick
             var currentParent = notes.Count > 0 ? notes[^1] : null;

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -39,7 +39,7 @@ namespace YARG.Core.Chart
             _moonSong = ChartReader.ReadChart(new StringReader(chartText));
         }
 
-        public InstrumentTrack<VocalNote> LoadVocalsTrack(Instrument instrument)
+        public VocalsTrack LoadVocalsTrack(Instrument instrument)
         {
             // TODO
             return new(instrument);

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -39,12 +39,6 @@ namespace YARG.Core.Chart
             _moonSong = ChartReader.ReadChart(new StringReader(chartText));
         }
 
-        public InstrumentTrack<ProGuitarNote> LoadProGuitarTrack(Instrument instrument)
-        {
-            // TODO
-            return new(instrument);
-        }
-
         public InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument instrument)
         {
             // TODO

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -39,12 +39,6 @@ namespace YARG.Core.Chart
             _moonSong = ChartReader.ReadChart(new StringReader(chartText));
         }
 
-        public InstrumentTrack<GuitarNote> LoadGuitarTrack(Instrument instrument)
-        {
-            // TODO
-            return new(instrument);
-        }
-
         public InstrumentTrack<ProGuitarNote> LoadProGuitarTrack(Instrument instrument)
         {
             // TODO

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -2,7 +2,7 @@
 
 namespace YARG.Core.Chart
 {
-    public class DrumNote : Note 
+    public class DrumNote : Note<DrumNote>
     {
         private readonly DrumNoteFlags _drumFlags;
 

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -3,7 +3,7 @@ using MoonscraperChartEditor.Song;
 
 namespace YARG.Core.Chart
 {
-    public class GuitarNote : Note
+    public class GuitarNote : Note<GuitarNote>
     {
         private readonly GuitarNoteFlags _guitarFlags;
 
@@ -45,14 +45,11 @@ namespace YARG.Core.Chart
             NoteMask = 1 << fret - 1;
         }
 
-        public override void AddChildNote(Note note)
+        public override void AddChildNote(GuitarNote note)
         {
-            if (note is not GuitarNote guitarNote)
-                return;
-
             base.AddChildNote(note);
 
-            NoteMask |= 1 << guitarNote.Fret;
+            NoteMask |= 1 << note.Fret;
         }
     }
 

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -1,5 +1,4 @@
 using System;
-using MoonscraperChartEditor.Song;
 
 namespace YARG.Core.Chart
 {

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -6,7 +6,7 @@ namespace YARG.Core.Chart
     public abstract class Note<TNote> : ChartEvent
         where TNote : Note<TNote>
     {
-        private readonly List<TNote> _childNotes = new();
+        protected readonly List<TNote> _childNotes = new();
         private readonly NoteFlags  _flags;
 
         public TNote previousNote;

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -3,15 +3,16 @@ using System.Collections.Generic;
 
 namespace YARG.Core.Chart
 {
-    public abstract class Note : ChartEvent
+    public abstract class Note<TNote> : ChartEvent
+        where TNote : Note<TNote>
     {
-        private readonly List<Note> _childNotes = new();
+        private readonly List<TNote> _childNotes = new();
         private readonly NoteFlags  _flags;
 
-        public Note previousNote;
-        public Note nextNote;
+        public TNote previousNote;
+        public TNote nextNote;
 
-        public IReadOnlyList<Note> ChildNotes => _childNotes;
+        public IReadOnlyList<TNote> ChildNotes => _childNotes;
 
         public bool IsChord => _childNotes.Count > 0;
 		
@@ -31,7 +32,7 @@ namespace YARG.Core.Chart
             _flags = flags;
         }
 
-        public virtual void AddChildNote(Note note) {
+        public virtual void AddChildNote(TNote note) {
             if (note.Tick != Tick || note.ChildNotes.Count > 0) {
                 return;
             }

--- a/YARG.Core/Chart/Notes/ProGuitarNote.cs
+++ b/YARG.Core/Chart/Notes/ProGuitarNote.cs
@@ -22,16 +22,32 @@ namespace YARG.Core.Chart
 
         public bool IsMuted => (_proFlags & ProGuitarNoteFlags.Muted) != 0;
 
-        public ProGuitarNote(int stringNo, int fret, ProGuitarNoteType type, ProGuitarNoteFlags proFlags,
+        public ProGuitarNote(ProGuitarString proString, int proFret, ProGuitarNoteType type, ProGuitarNoteFlags proFlags,
+            NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
+            : this((int) proString, proFret, type, proFlags, flags, time, timeLength, tick, tickLength)
+        {
+        }
+
+        public ProGuitarNote(int proString, int proFret, ProGuitarNoteType type, ProGuitarNoteFlags proFlags,
             NoteFlags flags, double time, double timeLength, uint tick, uint tickLength)
             : base(flags, time, timeLength, tick, tickLength)
         {
-            String = stringNo;
-            Fret = fret;
+            String = proString;
+            Fret = proFret;
             Type = type;
 
             _proFlags = proFlags;
         }
+    }
+
+    public enum ProGuitarString
+    {
+        Red,
+        Green,
+        Orange,
+        Blue,
+        Yellow,
+        Purple,
     }
 
     public enum ProGuitarNoteType
@@ -49,6 +65,6 @@ namespace YARG.Core.Chart
         ExtendedSustain = 1 << 0,
         Disjoint        = 1 << 1,
 
-        Muted = 1 << 2,
+        Muted = 1 << 2, // TODO: would this make more sense as its own note type? physically, only strums can be muted
     }
 }

--- a/YARG.Core/Chart/Notes/ProGuitarNote.cs
+++ b/YARG.Core/Chart/Notes/ProGuitarNote.cs
@@ -2,7 +2,7 @@
 
 namespace YARG.Core.Chart
 {
-    public class ProGuitarNote : Note
+    public class ProGuitarNote : Note<ProGuitarNote>
     {
         private readonly ProGuitarNoteFlags _proFlags;
 

--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -87,5 +87,6 @@ namespace YARG.Core.Chart
         None = 0,
 
         NonPitched = 1 << 0,
+        Percussion = 1 << 1,
     }
 }

--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace YARG.Core.Chart
 {
-    public class VocalNote : Note
+    public class VocalNote : Note<VocalNote>
     {
         private readonly List<PitchTimePair> _pitchesOverTime;
         private readonly VocalNoteFlags      _vocalFlags;

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -18,10 +18,10 @@ namespace YARG.Core.Chart
         public InstrumentTrack<GuitarNote> Keys { get; set; } = new(Instrument.Keys);
 
         // Not supported yet
-        // public InstrumentTrack<GuitarNote> SixFretGuitar { get; set; } = new(Instrument.SixFretGuitar);
-        // public InstrumentTrack<GuitarNote> SixFretCoop { get; set; } = new(Instrument.SixFretCoopGuitar);
-        // public InstrumentTrack<GuitarNote> SixFretRhythm { get; set; } = new(Instrument.SixFretRhythm);
-        // public InstrumentTrack<GuitarNote> SixFretBass { get; set; } = new(Instrument.SixFretBass);
+        public InstrumentTrack<GuitarNote> SixFretGuitar { get; set; } = new(Instrument.SixFretGuitar);
+        public InstrumentTrack<GuitarNote> SixFretCoop { get; set; } = new(Instrument.SixFretCoopGuitar);
+        public InstrumentTrack<GuitarNote> SixFretRhythm { get; set; } = new(Instrument.SixFretRhythm);
+        public InstrumentTrack<GuitarNote> SixFretBass { get; set; } = new(Instrument.SixFretBass);
 
         public InstrumentTrack<DrumNote> FourLaneDrums { get; set; } = new(Instrument.FourLaneDrums);
         public InstrumentTrack<DrumNote> ProDrums { get; set; } = new(Instrument.ProDrums);
@@ -53,10 +53,10 @@ namespace YARG.Core.Chart
             FiveFretBass = loader.LoadGuitarTrack(Instrument.FiveFretBass);
             Keys = loader.LoadGuitarTrack(Instrument.Keys);
 
-            // SixFretGuitar = loader.LoadGuitarTrack(Instrument.SixFretGuitar);
-            // SixFretCoop = loader.LoadGuitarTrack(Instrument.SixFretCoopGuitar);
-            // SixFretRhythm = loader.LoadGuitarTrack(Instrument.SixFretRhythm);
-            // SixFretBass = loader.LoadGuitarTrack(Instrument.SixFretBass);
+            SixFretGuitar = loader.LoadGuitarTrack(Instrument.SixFretGuitar);
+            SixFretCoop = loader.LoadGuitarTrack(Instrument.SixFretCoopGuitar);
+            SixFretRhythm = loader.LoadGuitarTrack(Instrument.SixFretRhythm);
+            SixFretBass = loader.LoadGuitarTrack(Instrument.SixFretBass);
 
             FourLaneDrums = loader.LoadDrumsTrack(Instrument.FourLaneDrums);
             ProDrums = loader.LoadDrumsTrack(Instrument.ProDrums);

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -1,8 +1,4 @@
-using System;
-using System.IO;
 using Melanchall.DryWetMidi.Core;
-using MoonscraperChartEditor.Song;
-using MoonscraperChartEditor.Song.IO;
 
 namespace YARG.Core.Chart
 {
@@ -79,20 +75,23 @@ namespace YARG.Core.Chart
 
         public static SongChart FromFile(string filePath)
         {
-            // TODO
-            return new SongChart();
+            ISongLoader loader = new MoonSongLoader();
+            loader.LoadSong(filePath);
+            return new SongChart(loader);
         }
 
         public static SongChart FromMidi(MidiFile midi)
         {
-            // TODO
-            return new SongChart();
+            ISongLoader loader = new MoonSongLoader();
+            loader.LoadMidi(midi);
+            return new SongChart(loader);
         }
 
         public static SongChart FromDotChart(string chartText)
         {
-            // TODO
-            return new SongChart();
+            ISongLoader loader = new MoonSongLoader();
+            loader.LoadDotChart(chartText);
+            return new SongChart(loader);
         }
     }
 }

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -12,36 +12,36 @@ namespace YARG.Core.Chart
     /// </summary>
     public class SongChart 
     {
-        public InstrumentTrack<GuitarNote> FiveFretGuitar { get; }
-        public InstrumentTrack<GuitarNote> FiveFretCoop { get; }
-        public InstrumentTrack<GuitarNote> FiveFretRhythm { get; }
-        public InstrumentTrack<GuitarNote> FiveFretBass { get; }
-        public InstrumentTrack<GuitarNote> Keys { get; }
+        public InstrumentTrack<GuitarNote> FiveFretGuitar { get; set; } = new(Instrument.FiveFretGuitar);
+        public InstrumentTrack<GuitarNote> FiveFretCoop { get; set; } = new(Instrument.FiveFretCoopGuitar);
+        public InstrumentTrack<GuitarNote> FiveFretRhythm { get; set; } = new(Instrument.FiveFretRhythm);
+        public InstrumentTrack<GuitarNote> FiveFretBass { get; set; } = new(Instrument.FiveFretBass);
+        public InstrumentTrack<GuitarNote> Keys { get; set; } = new(Instrument.Keys);
 
         // Not supported yet
-        // public InstrumentTrack<GuitarNote> SixFretGuitar { get; }
-        // public InstrumentTrack<GuitarNote> SixFretCoop { get; }
-        // public InstrumentTrack<GuitarNote> SixFretRhythm { get; }
-        // public InstrumentTrack<GuitarNote> SixFretBass { get; }
+        // public InstrumentTrack<GuitarNote> SixFretGuitar { get; set; } = new(Instrument.SixFretGuitar);
+        // public InstrumentTrack<GuitarNote> SixFretCoop { get; set; } = new(Instrument.SixFretCoopGuitar);
+        // public InstrumentTrack<GuitarNote> SixFretRhythm { get; set; } = new(Instrument.SixFretRhythm);
+        // public InstrumentTrack<GuitarNote> SixFretBass { get; set; } = new(Instrument.SixFretBass);
 
-        public InstrumentTrack<DrumNote> FourLaneDrums { get; }
-        public InstrumentTrack<DrumNote> ProDrums { get; }
+        public InstrumentTrack<DrumNote> FourLaneDrums { get; set; } = new(Instrument.FourLaneDrums);
+        public InstrumentTrack<DrumNote> ProDrums { get; set; } = new(Instrument.ProDrums);
 
-        public InstrumentTrack<DrumNote> FiveLaneDrums { get; }
+        public InstrumentTrack<DrumNote> FiveLaneDrums { get; set; } = new(Instrument.FiveLaneDrums);
 
-        // public InstrumentTrack<DrumNote> TrueDrums { get; }
+        // public InstrumentTrack<DrumNote> TrueDrums { get; set; } = new(Instrument.TrueDrums);
 
-        // public InstrumentTrack<ProGuitarNote> ProGuitar_17Fret { get; }
-        // public InstrumentTrack<ProGuitarNote> ProGuitar_22Fret { get; }
-        // public InstrumentTrack<ProGuitarNote> ProBass_17Fret { get; }
-        // public InstrumentTrack<ProGuitarNote> ProBass_22Fret { get; }
+        // public InstrumentTrack<ProGuitarNote> ProGuitar_17Fret { get; set; } = new(Instrument.ProGuitar_17Fret);
+        // public InstrumentTrack<ProGuitarNote> ProGuitar_22Fret { get; set; } = new(Instrument.ProGuitar_22Fret);
+        // public InstrumentTrack<ProGuitarNote> ProBass_17Fret { get; set; } = new(Instrument.ProBass_17Fret);
+        // public InstrumentTrack<ProGuitarNote> ProBass_22Fret { get; set; } = new(Instrument.ProBass_22Fret);
 
-        // public InstrumentTrack<ProKeysNote> ProKeys { get; }
+        // public InstrumentTrack<ProKeysNote> ProKeys { get; set; } = new(Instrument.ProKeys);
 
-        public InstrumentTrack<VocalNote> Vocals { get; }
-        public List<InstrumentTrack<VocalNote>> Harmonies { get; }
+        public InstrumentTrack<VocalNote> Vocals { get; set; } = new(Instrument.Vocals);
+        public List<InstrumentTrack<VocalNote>> Harmonies { get; set; } = new();
 
-        // public InstrumentTrack<DjNote> Dj { get; }
+        // public InstrumentTrack<DjNote> Dj { get; set; } = new(Instrument.Dj);
 
         public static SongChart FromFile(string filePath)
         {

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -33,8 +33,8 @@ namespace YARG.Core.Chart
 
         // public InstrumentTrack<ProKeysNote> ProKeys { get; set; } = new(Instrument.ProKeys);
 
-        public InstrumentTrack<VocalNote> Vocals { get; set; } = new(Instrument.Vocals);
-        public InstrumentTrack<VocalNote> Harmony { get; set; } = new(Instrument.Harmony);
+        public VocalsTrack Vocals { get; set; } = new(Instrument.Vocals);
+        public VocalsTrack Harmony { get; set; } = new(Instrument.Harmony);
 
         // public InstrumentTrack<DjNote> Dj { get; set; } = new(Instrument.Dj);
 

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -42,41 +42,54 @@ namespace YARG.Core.Chart
 
         // public InstrumentTrack<DjNote> Dj { get; set; } = new(Instrument.Dj);
 
-        public static SongChart FromFile(string filePath)
+        // To explicitly allow creation without going through a file
+        public SongChart() { }
+
+        internal SongChart(ISongLoader loader)
         {
-            return Path.GetExtension(filePath).ToLower() switch
-            {
-                ".mid" => FromMidiPath(filePath),
-                ".chart" => FromDotChartPath(filePath),
-                _ => throw new ArgumentException($"Unrecognized file extension for chart path '{filePath}'!", nameof(filePath))
-            };
+            FiveFretGuitar = loader.LoadGuitarTrack(Instrument.FiveFretGuitar);
+            FiveFretCoop = loader.LoadGuitarTrack(Instrument.FiveFretCoopGuitar);
+            FiveFretRhythm = loader.LoadGuitarTrack(Instrument.FiveFretRhythm);
+            FiveFretBass = loader.LoadGuitarTrack(Instrument.FiveFretBass);
+            Keys = loader.LoadGuitarTrack(Instrument.Keys);
+
+            // SixFretGuitar = loader.LoadGuitarTrack(Instrument.SixFretGuitar);
+            // SixFretCoop = loader.LoadGuitarTrack(Instrument.SixFretCoopGuitar);
+            // SixFretRhythm = loader.LoadGuitarTrack(Instrument.SixFretRhythm);
+            // SixFretBass = loader.LoadGuitarTrack(Instrument.SixFretBass);
+
+            FourLaneDrums = loader.LoadDrumsTrack(Instrument.FourLaneDrums);
+            ProDrums = loader.LoadDrumsTrack(Instrument.ProDrums);
+            FiveLaneDrums = loader.LoadDrumsTrack(Instrument.FiveLaneDrums);
+
+            // TrueDrums = loader.LoadDrumsTrack(Instrument.TrueDrums);
+
+            ProGuitar_17Fret = loader.LoadProGuitarTrack(Instrument.ProGuitar_17Fret);
+            ProGuitar_22Fret = loader.LoadProGuitarTrack(Instrument.ProGuitar_22Fret);
+            ProBass_17Fret = loader.LoadProGuitarTrack(Instrument.ProBass_17Fret);
+            ProBass_22Fret = loader.LoadProGuitarTrack(Instrument.ProBass_22Fret);
+
+            // ProKeys = loader.LoadProKeysTrack(Instrument.ProKeys);
+
+            Vocals = loader.LoadVocalsTrack(Instrument.Vocals);
+            Harmony = loader.LoadVocalsTrack(Instrument.Harmony);
+
+            // Dj = loader.LoadDjTrack(Instrument.Dj);
         }
 
-        public static SongChart FromMidiPath(string filePath)
+        public static SongChart FromFile(string filePath)
         {
-            var moonSong = MidReader.ReadMidi(filePath);
-            return FromMoonSong(moonSong);
+            // TODO
+            return new SongChart();
         }
 
         public static SongChart FromMidi(MidiFile midi)
         {
-            var moonSong = MidReader.ReadMidi(midi);
-            return FromMoonSong(moonSong);
+            // TODO
+            return new SongChart();
         }
 
-        public static SongChart FromDotChartPath(string filePath)
-        {
-            var moonSong = ChartReader.ReadChart(filePath);
-            return FromMoonSong(moonSong);
-        }
-
-        public static SongChart FromDotChartText(string fileText)
-        {
-            var moonSong = ChartReader.ReadChart(new StringReader(fileText));
-            return FromMoonSong(moonSong);
-        }
-
-        public static SongChart FromMoonSong(MoonSong moonSong)
+        public static SongChart FromDotChart(string chartText)
         {
             // TODO
             return new SongChart();

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using Melanchall.DryWetMidi.Core;
 using MoonscraperChartEditor.Song;
@@ -31,15 +30,15 @@ namespace YARG.Core.Chart
 
         // public InstrumentTrack<DrumNote> TrueDrums { get; set; } = new(Instrument.TrueDrums);
 
-        // public InstrumentTrack<ProGuitarNote> ProGuitar_17Fret { get; set; } = new(Instrument.ProGuitar_17Fret);
-        // public InstrumentTrack<ProGuitarNote> ProGuitar_22Fret { get; set; } = new(Instrument.ProGuitar_22Fret);
-        // public InstrumentTrack<ProGuitarNote> ProBass_17Fret { get; set; } = new(Instrument.ProBass_17Fret);
-        // public InstrumentTrack<ProGuitarNote> ProBass_22Fret { get; set; } = new(Instrument.ProBass_22Fret);
+        public InstrumentTrack<ProGuitarNote> ProGuitar_17Fret { get; set; } = new(Instrument.ProGuitar_17Fret);
+        public InstrumentTrack<ProGuitarNote> ProGuitar_22Fret { get; set; } = new(Instrument.ProGuitar_22Fret);
+        public InstrumentTrack<ProGuitarNote> ProBass_17Fret { get; set; } = new(Instrument.ProBass_17Fret);
+        public InstrumentTrack<ProGuitarNote> ProBass_22Fret { get; set; } = new(Instrument.ProBass_22Fret);
 
         // public InstrumentTrack<ProKeysNote> ProKeys { get; set; } = new(Instrument.ProKeys);
 
         public InstrumentTrack<VocalNote> Vocals { get; set; } = new(Instrument.Vocals);
-        public List<InstrumentTrack<VocalNote>> Harmonies { get; set; } = new();
+        public InstrumentTrack<VocalNote> Harmony { get; set; } = new(Instrument.Harmony);
 
         // public InstrumentTrack<DjNote> Dj { get; set; } = new(Instrument.Dj);
 

--- a/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
+++ b/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
@@ -7,7 +7,7 @@ namespace YARG.Core.Chart
     /// A single difficulty of an instrument track.
     /// </summary>
     public class InstrumentDifficulty<TNote>
-        where TNote : Note
+        where TNote : Note<TNote>
     {
         public Instrument Instrument { get; }
         public Difficulty Difficulty { get; }

--- a/YARG.Core/Chart/Tracks/InstrumentTrack.cs
+++ b/YARG.Core/Chart/Tracks/InstrumentTrack.cs
@@ -9,19 +9,16 @@ namespace YARG.Core.Chart
         where TNote : Note
     {
         public Instrument Instrument { get; }
-        public Difficulty MaxDifficulty { get; }
 
         public Dictionary<Difficulty, InstrumentDifficulty<TNote>> Difficulties { get; } = new();
 
-        public InstrumentTrack(Instrument instrument, Difficulty maxDifficulty)
+        public InstrumentTrack(Instrument instrument)
         {
             Instrument = instrument;
-            MaxDifficulty = maxDifficulty;
         }
 
-        public InstrumentTrack(Instrument instrument, Difficulty maxDifficulty,
-            Dictionary<Difficulty, InstrumentDifficulty<TNote>> difficulties)
-            : this(instrument, maxDifficulty)
+        public InstrumentTrack(Instrument instrument, Dictionary<Difficulty, InstrumentDifficulty<TNote>> difficulties)
+            : this(instrument)
         {
             Difficulties = difficulties;
         }

--- a/YARG.Core/Chart/Tracks/InstrumentTrack.cs
+++ b/YARG.Core/Chart/Tracks/InstrumentTrack.cs
@@ -6,7 +6,7 @@ namespace YARG.Core.Chart
     /// An instrument track and all of its difficulties.
     /// </summary>
     public class InstrumentTrack<TNote>
-        where TNote : Note
+        where TNote : Note<TNote>
     {
         public Instrument Instrument { get; }
 

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace YARG.Core.Chart
+{
+    /// <summary>
+    /// A single part on a vocals track.
+    /// </summary>
+    public class VocalsPart
+    {
+        public List<VocalsPhrase> NotePhrases { get; } = new();
+        public List<Phrase> OtherPhrases { get; } = new();
+        public List<TextEvent> TextEvents { get; } = new();
+
+        public VocalsPart(List<VocalsPhrase> notePhrases, List<Phrase> otherPhrases, List<TextEvent> text)
+        {
+            NotePhrases = notePhrases;
+            OtherPhrases = otherPhrases;
+            TextEvents = text;
+        }
+    }
+}

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPhrase.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPhrase.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+
+namespace YARG.Core.Chart
+{
+    /// <summary>
+    /// A lyric/percussion phrase on a vocals track.
+    /// </summary>
+    public class VocalsPhrase
+    {
+        private readonly VocalsPhraseFlags _flags;
+
+        public VocalsPhraseType Type { get; }
+
+        public ChartEvent Bounds { get; }
+
+        public List<VocalNote> Notes  { get; } = new();
+        public List<TextEvent> Lyrics { get; } = new();
+
+        public bool IsLyric      => Type == VocalsPhraseType.Lyric;
+        public bool IsPercussion => Type == VocalsPhraseType.Percussion;
+
+        public bool IsStarPower => (_flags & VocalsPhraseFlags.StarPower) != 0;
+
+        public VocalsPhrase(VocalsPhraseType type, ChartEvent bounds, VocalsPhraseFlags flags)
+        {
+            _flags = flags;
+
+            Type = type;
+            Bounds = bounds;
+        }
+
+        public VocalsPhrase(VocalsPhraseType type, ChartEvent bounds, VocalsPhraseFlags flags, List<VocalNote> notes,
+            List<TextEvent> lyrics)
+            : this(type, bounds, flags)
+        {
+            Notes = notes;
+            Lyrics = lyrics;
+        }
+    }
+
+    public enum VocalsPhraseType
+    {
+        Lyric,
+        Percussion,
+    }
+
+    public enum VocalsPhraseFlags
+    {
+        None = 0,
+
+        StarPower = 1 << 0,
+    }
+}

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsTrack.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsTrack.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace YARG.Core.Chart
+{
+    /// <summary>
+    /// A vocals track.
+    /// </summary>
+    public class VocalsTrack
+    {
+        public Instrument Instrument { get; }
+
+        public List<VocalsPart> Parts { get; } = new();
+
+        public VocalsTrack(Instrument instrument)
+        {
+            Instrument = instrument;
+        }
+
+        public VocalsTrack(Instrument instrument, List<VocalsPart> parts)
+            : this(instrument)
+        {
+            Parts = parts;
+        }
+
+        // TODO: Helper methods for getting info across all parts
+    }
+}

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -6,7 +6,7 @@ using YARG.Core.Input;
 namespace YARG.Core.Engine
 {
     public abstract class BaseEngine<TNoteType, TInputType, TActionType, TEngineParams, TEngineStats, TEngineState> 
-        where TNoteType : Note
+        where TNoteType : Note<TNoteType>
         where TInputType : AbstractGameInput<TActionType>
         where TActionType : Enum
         where TEngineParams : BaseEngineParameters

--- a/YARG.Core/InstrumentEnums.cs
+++ b/YARG.Core/InstrumentEnums.cs
@@ -8,7 +8,7 @@ namespace YARG.Core
     public enum GameMode
     {
         FiveFretGuitar,
-        // SixFretGuitar,
+        SixFretGuitar,
 
         FourLaneDrums,
         FiveLaneDrums,
@@ -33,10 +33,10 @@ namespace YARG.Core
         FiveFretCoopGuitar,
         Keys,
 
-        // SixFretGuitar,
-        // SixFretBass,
-        // SixFretRhythm,
-        // SixFretCoopGuitar,
+        SixFretGuitar,
+        SixFretBass,
+        SixFretRhythm,
+        SixFretCoopGuitar,
 
         FourLaneDrums,
         ProDrums,
@@ -82,10 +82,10 @@ namespace YARG.Core
                 Instrument.FiveFretCoopGuitar or
                 Instrument.Keys => GameMode.FiveFretGuitar,
 
-                // Instrument.SixFretGuitar or
-                // Instrument.SixFretBass or
-                // Instrument.SixFretRhythm or
-                // Instrument.SixFretCoopGuitar => GameMode.SixFretGuitar,
+                Instrument.SixFretGuitar or
+                Instrument.SixFretBass or
+                Instrument.SixFretRhythm or
+                Instrument.SixFretCoopGuitar => GameMode.SixFretGuitar,
 
                 Instrument.FourLaneDrums or
                 Instrument.ProDrums => GameMode.FourLaneDrums,

--- a/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
@@ -24,6 +24,7 @@ namespace MoonscraperChartEditor.Song
 
             // Vocals
             Vocals_LyricPhrase,
+            Vocals_PercussionPhrase,
         }
 
         private readonly ID _classID = ID.Special;

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -523,7 +523,7 @@ namespace MoonscraperChartEditor.Song.IO
 
             var chart = song.GetChart(instrument, difficulty);
 
-            SongObjectHelper.GetRange(chart.notes, startTick, endTick, out int index, out int length);
+            SongObjectHelper.GetRange(chart.notes, startTick, --endTick, out int index, out int length);
 
             for (int i = index; i < index + length; ++i)
             {


### PR DESCRIPTION
Big monumental step towards the new engine!

The song loading has been abstracted in a way that should make it easier to switch to another parser or support multiple parsers at the same time. The only references to any Moonscraper types now, outside of within Moonscraper itself, are in the MoonSong loader and in the parser unit tests.

A good number of changes to the chart storage types have been made along the way:

- `InstrumentTrack` no longer contains a `MaxDifficulty` field, though this could be re-added later if it would be convenient enough. Removed it because it seems less convenient/necessary than it did when I first added it.
- `SongChart` is now fully default-initialized and can be created without going through a chart file.
- Vocal tracks now have their own dedicated storage types, since they work very differently from the other tracks lol
- The 6-fret instrument/game mode definitions were uncommented, not much additional work was needed to load them in.
- `Note` has been turned into a recursive generic type (`Note<TNote> where TNote : Note<TNote>`), to remove the need to type-test on the previous/next notes or child note list to get the true type. Any methods that need to work with just `Note`s can be written as generic methods in the same fashion.
- `VocalNote`'s pitch-over-time storage has been reworked to use the child note list, as this greatly simplifies vocals parsing (which is already complex enough lol).
- Some various other things were reworked in `VocalNote`, and doc comments were added since some things may not be clear at a first glance.

And to top things off, I fixed a Moonscraper parsing bug I found when testing vocals loading.