### PR TITLE
Use binarysearch over IndexOf for category writing

### DIFF
--- a/YARG.Core/Song/Cache/SongCategories.cs
+++ b/YARG.Core/Song/Cache/SongCategories.cs
@@ -61,8 +61,8 @@ namespace YARG.Core.Song.Cache
                 foreach (var entry in element.Value)
                 {
                     string str = entry.GetStringAttribute(attribute);
-                    int index  = strings.IndexOf(str);
-                    if (index == -1)
+                    int index  = strings.BinarySearch(str);
+                    if (index < 0)
                     {
                         index = strings.Count;
                         strings.Add(str);


### PR DESCRIPTION
Heavily benefits larger libraries with lots of strings to go through