### PR TITLE
Hold both second & millisecond versions of metadata time values

### DIFF
--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -50,7 +50,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 23_08_27_01;
+        public const int CACHE_VERSION = 23_08_31_01;
 
         public readonly List<object> errorList = new();
         public ScanProgress Progress { get; private set; }

--- a/YARG.Core/Song/Cache/SongCategories.cs
+++ b/YARG.Core/Song/Cache/SongCategories.cs
@@ -159,17 +159,17 @@ namespace YARG.Core.Song.Cache
 
     public class SongLengthCategory : SongCategory<string>
     {
+        private const int MILLISECONDS_PER_MINUTE = 60 * 1000;
         private static readonly EntryComparer comparer = new(SongAttribute.SongLength);
         public override void Add(SongMetadata entry)
         {
-            string key = TimeSpan.FromSeconds(entry.SongLength).TotalMinutes switch
+            string key = (entry.SongLength / MILLISECONDS_PER_MINUTE) switch
             {
-                <= 0.00 => "-",
-                <= 2.00 => "00:00 - 02:00",
-                <= 5.00 => "02:00 - 05:00",
-                <= 10.00 => "05:00 - 10:00",
-                <= 15.00 => "10:00 - 15:00",
-                <= 20.00 => "15:00 - 20:00",
+                < 2 => "00:00 - 02:00",
+                < 5 => "02:00 - 05:00",
+                < 10 => "05:00 - 10:00",
+                < 15 => "10:00 - 15:00",
+                < 20 => "15:00 - 20:00",
                 _ => "20:00+",
             };
 

--- a/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
@@ -23,14 +23,14 @@ namespace YARG.Core.Song
             _albumTrack = reader.ReadInt32();
             _playlistTrack = reader.ReadInt32();
 
-            _songLength = reader.ReadDouble();
-            _songOffset = reader.ReadDouble();
+            SongLength = reader.ReadUInt64();
+            SongOffset = reader.ReadInt64();
 
-            _previewStart = reader.ReadDouble();
-            _previewEnd = reader.ReadDouble();
+            PreviewStart = reader.ReadUInt64();
+            PreviewEnd = reader.ReadUInt64();
 
-            _videoStartTime = reader.ReadDouble();
-            _videoEndTime = reader.ReadDouble();
+            _videoStartTimeInSeconds = reader.ReadDouble();
+            _videoEndTimeInSeconds = reader.ReadDouble();
 
             _loadingPhrase = reader.ReadLEBString();
 
@@ -67,8 +67,8 @@ namespace YARG.Core.Song
             writer.Write(_previewStart);
             writer.Write(_previewEnd);
 
-            writer.Write(_videoStartTime);
-            writer.Write(_videoEndTime);
+            writer.Write(_videoStartTimeInSeconds);
+            writer.Write(_videoEndTimeInSeconds);
 
             writer.Write(_loadingPhrase);
 

--- a/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
@@ -157,39 +157,38 @@ namespace YARG.Core.Song
             if (!section.TryGet("album_track", out _albumTrack))
                 _albumTrack = -1;
 
-            section.TryGet("song_length", out ulong songLength);
-            _songLength = songLength / MILLISECOND_FACTOR;
+            if (section.TryGet("song_length", out _songLength))
+                SongLength = _songLength;
 
-            if (section.TryGet("preview", out ulong previewStart, out ulong previewEnd))
+            if (section.TryGet("preview", out _previewStart, out _previewEnd))
             {
-                _previewStart = previewStart / MILLISECOND_FACTOR;
-                _previewEnd = previewEnd / MILLISECOND_FACTOR;
+                PreviewStart = _previewStart;
+                PreviewEnd = _previewEnd;
             }
             else
             {
-                if (section.TryGet("preview_start_time", out previewStart))
-                    _previewStart = previewStart / MILLISECOND_FACTOR;
-                else
-                    section.TryGet("previewStart", out _previewStart);
+                if (section.TryGet("preview_start_time", out _previewStart))
+                    PreviewStart = _previewStart;
+                else if (section.TryGet("previewStart", out _previewStartInSeconds))
+                    PreviewStartInSeconds = _previewStartInSeconds;
 
-                if (section.TryGet("preview_end_time", out previewEnd))
-                    _previewEnd = previewEnd / MILLISECOND_FACTOR;
-                else
-                    section.TryGet("previewEnd", out _previewEnd);
+                if (section.TryGet("preview_end_time", out _previewEnd))
+                    PreviewEnd = _previewEnd;
+                else if (section.TryGet("previewEnd", out _previewEndInSeconds))
+                    PreviewEndInSeconds = _previewEndInSeconds;
             }
+            
 
-            if (section.TryGet("delay", out long songOffset))
-                _songOffset = songOffset / MILLISECOND_FACTOR;
-            else
-                section.TryGet("offset", out _songOffset);
+            if (section.TryGet("delay", out _songOffset))
+                SongOffset = _songOffset;
+            else if (section.TryGet("offset", out _songOffsetInSeconds))
+                SongOffsetInSeconds = _songOffsetInSeconds;
+                
 
-            section.TryGet("video_start_time", out long videoStartTime);
-            _videoStartTime = videoStartTime / MILLISECOND_FACTOR;
+            if (section.TryGet("video_start_time", out long videoStartTime))
+                _videoStartTimeInSeconds = videoStartTime / MILLISECOND_FACTOR;
 
-            if (section.TryGet("video_end_time", out long videoEndTime))
-                _videoEndTime = videoEndTime / MILLISECOND_FACTOR;
-            else
-                _videoEndTime = -1;
+            _videoEndTimeInSeconds = section.TryGet("video_end_time", out long videoEndTime) ? videoEndTime / MILLISECOND_FACTOR : -1;
 
             if (_parseSettings.DrumsType == DrumsType.ProDrums)
                 _parseSettings.DrumsType = DrumsType.FourLane;

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -406,8 +406,8 @@ namespace YARG.Core.Song
                             break;
                         }
                     case "preview":
-                        _previewStart = reader.ReadUInt32() / MILLISECOND_FACTOR;
-                        _previewEnd = reader.ReadUInt32() / MILLISECOND_FACTOR;
+                        PreviewStart = reader.ReadUInt64();
+                        PreviewEnd = reader.ReadUInt64();
                         break;
                     case "rank": _parts.SetIntensities(rbConMetadata.RBDifficulties, reader); break;
                     case "solo": rbConMetadata.Soloes = reader.ExtractList_String().ToArray(); break;
@@ -452,7 +452,7 @@ namespace YARG.Core.Song
                     case "base_points": /*BasePoints = reader.ReadUInt32();*/ break;
                     case "band_fail_cue": /*BandFailCue = reader.ExtractText();*/ break;
                     case "drum_bank": rbConMetadata.DrumBank = reader.ExtractText(); break;
-                    case "song_length": _songLength = reader.ReadUInt32() / MILLISECOND_FACTOR; break;
+                    case "song_length": SongLength = reader.ReadUInt64(); break;
                     case "sub_genre": /*Subgenre = reader.ExtractText();*/ break;
                     case "author": _charter = reader.ExtractText(); break;
                     case "guide_pitch_volume": /*GuidePitchVolume = reader.ReadFloat();*/ break;

--- a/YARG.Core/Song/Metadata/SongMetadata.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.cs
@@ -77,14 +77,20 @@ namespace YARG.Core.Song
 
         private string _loadingPhrase = string.Empty;
 
-        private double _songLength = 0;
-        private double _songOffset = 0;
+        private ulong _songLength = 0;
+        private long _songOffset = 0;
 
-        private double _previewStart = 0;
-        private double _previewEnd = 0;
+        private double _songLengthInSeconds = 0;
+        private double _songOffsetInSeconds = 0;
 
-        private double _videoStartTime = 0;
-        private double _videoEndTime = -1;
+        private ulong _previewStart = 0;
+        private ulong _previewEnd = 0;
+
+        private double _previewStartInSeconds = 0;
+        private double _previewEndInSeconds = 0;
+
+        private double _videoStartTimeInSeconds = 0;
+        private double _videoEndTimeInSeconds = -1;
 
         private HashWrapper _hash = default;
 
@@ -141,23 +147,89 @@ namespace YARG.Core.Song
 
         public string LoadingPhrase => _loadingPhrase;
 
-        public double SongLength => _songLength;
-        public double SongOffset => _songOffset;
+        public ulong SongLength
+        {
+            get => _songLength;
+            private set
+            {
+                _songLength = value;
+                _songLengthInSeconds = value / MILLISECOND_FACTOR;
+            }
+        }
 
-        public ulong SongLengthMilliseconds => (ulong) (SongLength * MILLISECOND_FACTOR);
-        public long SongOffsetMilliseconds => (long) (SongOffset * MILLISECOND_FACTOR);
+        public long SongOffset
+        {
+            get => _songOffset;
+            private set
+            {
+                _songOffset = value;
+                _songOffsetInSeconds = value / MILLISECOND_FACTOR;
+            }
+        }
 
-        public double PreviewStart => _previewStart;
-        public double PreviewEnd => _previewEnd;
+        public double SongLengthInSeconds
+        {
+            get => _songLengthInSeconds;
+            private set
+            {
+                _songLengthInSeconds = value;
+                _songLength = (ulong)(value * MILLISECOND_FACTOR);
+            }
+        }
 
-        public ulong PreviewStartMilliseconds => (ulong) (PreviewStart * MILLISECOND_FACTOR);
-        public ulong PreviewEndMilliseconds => (ulong) (PreviewEnd * MILLISECOND_FACTOR);
+        public double SongOffsetInSeconds
+        {
+            get => _songOffsetInSeconds;
+            private set
+            {
+                _songOffsetInSeconds = value;
+                _songOffset = (long) (value * MILLISECOND_FACTOR);
+            }
+        }
 
-        public double VideoStartTime => _videoStartTime;
-        public double VideoEndTime => _videoEndTime;
+        public ulong PreviewStart
+        {
+            get => _previewStart;
+            private set
+            {
+                _previewStart = value;
+                _previewStartInSeconds = value / MILLISECOND_FACTOR;
+            }
+        }
 
-        public long VideoStartTimeMilliseconds => (long) (VideoStartTime * MILLISECOND_FACTOR);
-        public long VideoEndTimeMilliseconds => (long) (VideoEndTime * MILLISECOND_FACTOR);
+        public ulong PreviewEnd
+        {
+            get => _previewEnd;
+            private set
+            {
+                _previewEnd = value;
+                _previewEndInSeconds = value / MILLISECOND_FACTOR;
+            }
+        }
+
+        public double PreviewStartInSeconds
+        {
+            get => _previewStartInSeconds;
+            private set
+            {
+                _previewStartInSeconds = value;
+                _previewStart = (ulong) (value * MILLISECOND_FACTOR);
+            }
+        }
+
+        public double PreviewEndInSeconds
+        {
+            get => _previewEndInSeconds;
+            private set
+            {
+                _previewEndInSeconds = value;
+                _previewEnd = (ulong) (value * MILLISECOND_FACTOR);
+            }
+        }
+
+        public double VideoStartTimeInSeconds => _videoStartTimeInSeconds;
+
+        public double VideoEndTimeInSeconds => _videoEndTimeInSeconds;
 
         public HashWrapper Hash => _hash;
 


### PR DESCRIPTION
This allows us to keep accurate values while also removing unnecessary conversion to and from seconds & milliseconds on queries.

The usual integer value representations are the only ones sent to cache, however (Video time metadatas being the exception)