### PR TITLE
Refactor TxtReader_Base to a generic class

### DIFF
--- a/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader.cs
+++ b/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader.cs
@@ -185,7 +185,7 @@ namespace YARG.Core.Song.Deserialization
             start = end;
             while (true)
             {
-                byte curr = (byte) (data[end] & LOWER_CASE_MASK);
+                char curr = (char) (data[end] & LOWER_CASE_MASK);
                 if (curr < 'A' || 'Z' < curr)
                     break;
                 ++end;
@@ -226,10 +226,15 @@ namespace YARG.Core.Song.Deserialization
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_Base<byte>.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position)
+                {
+                    char character = (char)data[point];
+                    if (!ITXTReader.IsWhitespace(character) || character == '\n')
+                        break;
                     --point;
+                }
 
-                if (data[point] == '\n')
+                if (data[point] == (byte)'\n')
                 {
                     reader.Position = position + next;
                     reader.SetNextPointer();
@@ -250,7 +255,7 @@ namespace YARG.Core.Song.Deserialization
             i = 0;
             while (i < distanceToEnd)
             {
-                if (data[position + i] == '}')
+                if (data[position + i] == (byte) '}')
                     return true;
                 ++i;
             }

--- a/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader.cs
+++ b/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader.cs
@@ -226,7 +226,7 @@ namespace YARG.Core.Song.Deserialization
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_Base.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position && YARGTXTReader_Base<byte>.IsWhitespace(data[point]) && data[point] != '\n')
                     --point;
 
                 if (data[point] == '\n')

--- a/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader_Char.cs
+++ b/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader_Char.cs
@@ -229,7 +229,7 @@ namespace YARG.Core.Song.Deserialization
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_BaseChar.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position && YARGTXTReader_Base<char>.IsWhitespace(data[point]) && data[point] != '\n')
                     --point;
 
                 if (data[point] == '\n')

--- a/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader_Char.cs
+++ b/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader_Char.cs
@@ -229,7 +229,7 @@ namespace YARG.Core.Song.Deserialization
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_Base<char>.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position && ITXTReader.IsWhitespace(data[point]) && data[point] != '\n')
                     --point;
 
                 if (data[point] == '\n')

--- a/YARG.Core/Song/Deserialization/Ini/YARGIniReader.cs
+++ b/YARG.Core/Song/Deserialization/Ini/YARGIniReader.cs
@@ -43,8 +43,13 @@ namespace YARG.Core.Song.Deserialization.Ini
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_Base<byte>.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position)
+                {
+                    char character = (char) data[point];
+                    if (!ITXTReader.IsWhitespace(character) || character == '\n')
+                        break;
                     --point;
+                }
 
                 if (data[point] == '\n')
                 {

--- a/YARG.Core/Song/Deserialization/Ini/YARGIniReader.cs
+++ b/YARG.Core/Song/Deserialization/Ini/YARGIniReader.cs
@@ -43,7 +43,7 @@ namespace YARG.Core.Song.Deserialization.Ini
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_Base.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position && YARGTXTReader_Base<byte>.IsWhitespace(data[point]) && data[point] != '\n')
                     --point;
 
                 if (data[point] == '\n')

--- a/YARG.Core/Song/Deserialization/Ini/YARGIniReader_Char.cs
+++ b/YARG.Core/Song/Deserialization/Ini/YARGIniReader_Char.cs
@@ -48,7 +48,7 @@ namespace YARG.Core.Song.Deserialization.Ini
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_BaseChar.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position && YARGTXTReader_Base<char>.IsWhitespace(data[point]) && data[point] != '\n')
                     --point;
 
                 if (data[point] == '\n')

--- a/YARG.Core/Song/Deserialization/Ini/YARGIniReader_Char.cs
+++ b/YARG.Core/Song/Deserialization/Ini/YARGIniReader_Char.cs
@@ -48,7 +48,7 @@ namespace YARG.Core.Song.Deserialization.Ini
             while (GetDistanceToTrackCharacter(position, out int next))
             {
                 int point = position + next - 1;
-                while (point > position && YARGTXTReader_Base<char>.IsWhitespace(data[point]) && data[point] != '\n')
+                while (point > position && ITXTReader.IsWhitespace(data[point]) && data[point] != '\n')
                     --point;
 
                 if (data[point] == '\n')

--- a/YARG.Core/Song/Deserialization/TXTReader/ITXTReader.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/ITXTReader.cs
@@ -44,5 +44,11 @@ namespace YARG.Core.Song.Deserialization
         public double ReadDouble();
 
         public string ExtractText(bool checkForQuotes = true);
+
+        public const char SPACE_ASCII = (char) 32;
+        public static bool IsWhitespace(char character)
+        {
+            return character <= SPACE_ASCII;
+        }
     }
 }

--- a/YARG.Core/Song/Deserialization/TXTReader/ITXTReader.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/ITXTReader.cs
@@ -6,6 +6,7 @@ namespace YARG.Core.Song.Deserialization
 {
     public interface ITXTReader
     {
+        public static readonly Encoding Latin1 = Encoding.GetEncoding(28591);
         public bool ReadBoolean(ref bool value);
 
         public bool ReadInt16(ref short value);

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader.cs
@@ -53,12 +53,12 @@ namespace YARG.Core.Song.Deserialization
                 GotoNextLine();
         }
 
-        public override byte SkipWhiteSpace()
+        public override char SkipWhiteSpace()
         {
             while (_position < length)
             {
-                byte ch = data[_position];
-                if (IsWhitespace(ch))
+                char ch = (char)data[_position];
+                if (ITXTReader.IsWhitespace(ch))
                 {
                     if (ch == '\n')
                         return ch;
@@ -68,12 +68,12 @@ namespace YARG.Core.Song.Deserialization
                 ++_position;
             }
 
-            return 0;
+            return (char)0;
         }
 
         public void GotoNextLine()
         {
-            byte curr;
+            char curr;
             do
             {
                 _position = _next;
@@ -112,7 +112,7 @@ namespace YARG.Core.Song.Deserialization
             if (checkForQuotes && data[_position] == '\"')
             {
                 int end = boundaries.Item2 - 1;
-                while (_position + 1 < end && IsWhitespace(data[end]))
+                while (_position + 1 < end && ITXTReader.IsWhitespace((char)data[end]))
                     --end;
 
                 if (_position < end && data[end] == '\"' && data[end - 1] != '\\')
@@ -125,7 +125,7 @@ namespace YARG.Core.Song.Deserialization
             if (boundaries.Item2 < boundaries.Item1)
                 return new();
 
-            while (boundaries.Item2 > boundaries.Item1 && IsWhitespace(data[boundaries.Item2 - 1]))
+            while (boundaries.Item2 > boundaries.Item1 && ITXTReader.IsWhitespace((char)data[boundaries.Item2 - 1]))
                 --boundaries.Item2;
 
             _position = _next;
@@ -151,8 +151,8 @@ namespace YARG.Core.Song.Deserialization
             int curr = _position;
             while (curr < length)
             {
-                byte b = data[curr];
-                if (IsWhitespace(b) || b == '=')
+                char b = (char)data[curr];
+                if (ITXTReader.IsWhitespace(b) || b == '=')
                     break;
                 ++curr;
             }

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader.cs
@@ -6,7 +6,7 @@ using System.Text;
 namespace YARG.Core.Song.Deserialization
 {
 #nullable enable
-    public class YARGTXTReader : YARGTXTReader_Base, ITXTReader
+    public class YARGTXTReader : YARGTXTReader_Base<byte>, ITXTReader
     {
         private static readonly byte[] BOM_UTF8 = { 0xEF, 0xBB, 0xBF };
         private static readonly byte[] BOM_OTHER = { 0xFF, 0xFE };
@@ -141,7 +141,7 @@ namespace YARG.Core.Song.Deserialization
             }
             catch
             {
-                encoding = Latin1;
+                encoding = ITXTReader.Latin1;
                 return encoding.GetString(span);
             }
         }

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Base.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Base.cs
@@ -3,14 +3,14 @@ using System.Text;
 
 namespace YARG.Core.Song.Deserialization
 {
-    public abstract class YARGTXTReader_Base
+    public abstract class YARGTXTReader_Base<T>
+        where T : IConvertible
     {
-        public static readonly Encoding Latin1 = Encoding.GetEncoding(28591);
-        protected readonly byte[] data;
+        protected readonly T[] data;
         protected readonly int length;
         protected int _position;
 
-        public byte[] Data => data;
+        public T[] Data => data;
         public int Length => length;
 
         public int Position
@@ -27,24 +27,24 @@ namespace YARG.Core.Song.Deserialization
         protected int _next;
         public int Next { get { return _next; } }
 
-        public byte Peek()
+        public T Peek()
         {
             return data[_position];
         }
 
-        protected YARGTXTReader_Base(byte[] data)
+        protected YARGTXTReader_Base(T[] data)
         {
             this.data = data;
             this.length = data.Length;
         }
 
-        public abstract byte SkipWhiteSpace();
+        public abstract T SkipWhiteSpace();
 
         private void SkipDigitsAndWhiteSpace()
         {
             while (_position < _next)
             {
-                byte b = data[_position];
+                char b = data[_position].ToChar(null);
                 if (b < '0' || '9' < b)
                     break;
                 ++_position;
@@ -53,9 +53,9 @@ namespace YARG.Core.Song.Deserialization
         }
 
         private const int SPACE_ASCII = 32;
-        public static bool IsWhitespace(byte b)
+        public static bool IsWhitespace(T b)
         {
-            return b <= SPACE_ASCII;
+            return b.ToInt32(null) <= SPACE_ASCII;
         }
 
         public bool IsEndOfFile()
@@ -65,15 +65,15 @@ namespace YARG.Core.Song.Deserialization
 
         public bool ReadBoolean(ref bool value)
         {
-            value = data[_position] switch
+            value = data[_position].ToChar(null) switch
             {
-                (byte) '0' => false,
-                (byte) '1' => true,
+                '0' => false,
+                '1' => true,
                 _ => _position + 4 <= _next &&
-                                    (data[_position] == 't' || data[_position] == 'T') &&
-                                    (data[_position + 1] == 'r' || data[_position + 1] == 'R') &&
-                                    (data[_position + 2] == 'u' || data[_position + 2] == 'U') &&
-                                    (data[_position + 3] == 'e' || data[_position + 3] == 'E'),
+                    (data[_position    ].ToChar(null) == 't' || data[_position    ].ToChar(null) == 'T') &&
+                    (data[_position + 1].ToChar(null) == 'r' || data[_position + 1].ToChar(null) == 'R') &&
+                    (data[_position + 2].ToChar(null) == 'u' || data[_position + 2].ToChar(null) == 'U') &&
+                    (data[_position + 3].ToChar(null) == 'e' || data[_position + 3].ToChar(null) == 'E'),
             };
             return true;
         }
@@ -87,14 +87,15 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
+            char b = data[_position].ToChar(null);
             short sign = b == '-' ? (short) -1 : (short)1;
+
             if (b == '-' || b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position];
+                b = data[_position].ToChar(null);
             }
 
             if (b < '0' || '9' < b)
@@ -116,7 +117,7 @@ namespace YARG.Core.Song.Deserialization
                 if (_position == _next)
                     break;
 
-                b = data[_position];
+                b = data[_position].ToChar(null);
                 if (b < '0' || '9' < b)
                     break;
 
@@ -134,13 +135,14 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
+            char b = data[_position].ToChar(null);
+
             if (b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position];
+                b = data[_position].ToChar(null);
             }
 
             if (b < '0' || '9' < b)
@@ -162,7 +164,7 @@ namespace YARG.Core.Song.Deserialization
                 if (_position == _next)
                     break;
 
-                b = data[_position];
+                b = data[_position].ToChar(null);
                 if (b < '0' || '9' < b)
                     break;
                 value *= 10;
@@ -178,14 +180,15 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
+            char b = data[_position].ToChar(null);
             int sign = b == '-' ? -1 : 1;
+
             if (b == '-' || b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position];
+                b = data[_position].ToChar(null);
             }
 
             if (b < '0' || '9' < b)
@@ -207,7 +210,7 @@ namespace YARG.Core.Song.Deserialization
                 if (_position == _next)
                     break;
 
-                b = data[_position];
+                b = data[_position].ToChar(null);
                 if (b < '0' || '9' < b)
                     break;
                 value *= 10;
@@ -224,13 +227,14 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
+            char b = data[_position].ToChar(null);
+
             if (b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position];
+                b = data[_position].ToChar(null);
             }
 
             if (b < '0' || '9' < b)
@@ -252,7 +256,7 @@ namespace YARG.Core.Song.Deserialization
                 if (_position == _next)
                     break;
 
-                b = data[_position];
+                b = data[_position].ToChar(null);
                 if (b < '0' || '9' < b)
                     break;
                 value *= 10;
@@ -268,14 +272,15 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
+            char b = data[_position].ToChar(null);
             long sign = b == '-' ? -1 : 1;
+
             if (b == '-' || b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position];
+                b = data[_position].ToChar(null);
             }
 
             if (b < '0' || '9' < b)
@@ -297,7 +302,7 @@ namespace YARG.Core.Song.Deserialization
                 if (_position == _next)
                     break;
 
-                b = data[_position];
+                b = data[_position].ToChar(null);
                 if (b < '0' || '9' < b)
                     break;
                 value *= 10;
@@ -314,13 +319,13 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
+            char b = data[_position].ToChar(null);
             if (b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position];
+                b = data[_position].ToChar(null);
             }
 
             if (b < '0' || '9' < b)
@@ -342,7 +347,7 @@ namespace YARG.Core.Song.Deserialization
                 if (_position == _next)
                     break;
 
-                b = data[_position];
+                b = data[_position].ToChar(null);
                 if (b < '0' || '9' < b)
                     break;
                 value *= 10;
@@ -357,23 +362,15 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
-            bool isNegative = false;
+            char b = data[_position].ToChar(null);
+            float sign = b == '-' ? -1 : 1;
 
-            if (b == '+')
+            if (b == '-' || b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position];
-            }
-            else if (b == '-')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                b = data[_position];
-                isNegative = true;
+                b = data[_position].ToChar(null);
             }
 
             if (b > '9' || (b < '0' && b != '.'))
@@ -389,7 +386,7 @@ namespace YARG.Core.Song.Deserialization
                     if (_position == _next)
                         break;
 
-                    b = data[_position];
+                    b = data[_position].ToChar(null);
                     if (b < '0' || b > '9')
                         break;
 
@@ -405,7 +402,7 @@ namespace YARG.Core.Song.Deserialization
                 int count = 0;
                 if (_position < _next)
                 {
-                    b = data[_position];
+                    b = data[_position].ToChar(null);
                     if ('0' <= b && b <= '9')
                     {
                         ++count;
@@ -416,7 +413,7 @@ namespace YARG.Core.Song.Deserialization
                             if (_position == _next)
                                 break;
 
-                            b = data[_position];
+                            b = data[_position].ToChar(null);
                             if (b < '0' || b > '9')
                                 break;
                             dec *= 10;
@@ -431,8 +428,7 @@ namespace YARG.Core.Song.Deserialization
                 value += dec;
             }
 
-            if (isNegative)
-                value = -value;
+            value *= sign;
 
             SkipWhiteSpace();
             return true;
@@ -443,27 +439,18 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            byte b = data[_position];
-            bool isNegative = false;
+            char b = data[_position].ToChar(null);
+            double sign = b == '-' ? -1 : 1;
 
-            if (b == '+')
+            if (b == '-' || b == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-            }
-            else if (b == '-')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                isNegative = true;
+                b = data[_position].ToChar(null);
             }
 
-            if (b > '9')
-                return false;
-
-            if (b < '0' && b != '.')
+            if (b > '9' || (b < '0' && b != '.'))
                 return false;
 
             value = 0;
@@ -476,7 +463,7 @@ namespace YARG.Core.Song.Deserialization
                     if (_position == _next)
                         break;
 
-                    b = data[_position];
+                    b = data[_position].ToChar(null);
                     if (b < '0' || b > '9')
                         break;
 
@@ -492,7 +479,7 @@ namespace YARG.Core.Song.Deserialization
                 int count = 0;
                 if (_position < _next)
                 {
-                    b = data[_position];
+                    b = data[_position].ToChar(null);
                     if ('0' <= b && b <= '9')
                     {
                         ++count;
@@ -503,7 +490,7 @@ namespace YARG.Core.Song.Deserialization
                             if (_position == _next)
                                 break;
 
-                            b = data[_position];
+                            b = data[_position].ToChar(null);
                             if (b < '0' || b > '9')
                                 break;
                             dec *= 10;
@@ -518,8 +505,7 @@ namespace YARG.Core.Song.Deserialization
                 value += dec;
             }
 
-            if (isNegative)
-                value = -value;
+            value *= sign;
 
             SkipWhiteSpace();
             return true;
@@ -597,710 +583,9 @@ namespace YARG.Core.Song.Deserialization
             return value;
         }
 
-        public ReadOnlySpan<byte> ExtractBasicSpan(int length)
+        public ReadOnlySpan<T> ExtractBasicSpan(int length)
         {
-            return new ReadOnlySpan<byte>(data, _position, length);
-        }
-    }
-
-    public abstract class YARGTXTReader_BaseChar
-    {
-        protected readonly char[] data;
-        protected readonly int length;
-        protected int _position;
-
-        public char[] Data => data;
-        public int Length => length;
-
-        public int Position
-        {
-            get { return _position; }
-            set
-            {
-                if (value < _position && _position <= length)
-                    throw new ArgumentOutOfRangeException("Position");
-                _position = value;
-            }
-        }
-
-        protected int _next;
-        public int Next { get { return _next; } }
-
-        public char Peek()
-        {
-            return data[_position];
-        }
-
-        protected YARGTXTReader_BaseChar(char[] data)
-        {
-            this.data = data;
-            this.length = data.Length;
-        }
-
-        public abstract char SkipWhiteSpace();
-
-        private const int SPACE_ASCII = 32;
-        public static bool IsWhitespace(char b)
-        {
-            return b <= SPACE_ASCII;
-        }
-
-        public bool IsEndOfFile()
-        {
-            return _position >= length;
-        }
-
-        public bool ReadBoolean(ref bool value)
-        {
-            value = data[_position] switch
-            {
-                '0' => false,
-                '1' => true,
-                _ => _position + 4 <= _next &&
-                                    (data[_position] == 't' || data[_position] == 'T') &&
-                                    (data[_position + 1] == 'r' || data[_position + 1] == 'R') &&
-                                    (data[_position + 2] == 'u' || data[_position + 2] == 'U') &&
-                                    (data[_position + 3] == 'e' || data[_position + 3] == 'E'),
-            };
-            return true;
-        }
-
-        public bool ReadInt16(ref short value)
-        {
-            if (_position >= _next)
-                return false;
-
-            short b = (short) data[_position];
-            if (b != '-')
-            {
-                if (b == '+')
-                {
-                    ++_position;
-                    if (_position == _next)
-                        return false;
-                    b = (short) data[_position];
-                }
-
-                if (b < '0' || b > '9')
-                    return false;
-
-                value = 0;
-                while (true)
-                {
-                    _position++;
-                    short val = (short) (value + b - '0');
-                    if (val >= value)
-                    {
-                        value = val;
-                        if (_position == _next)
-                            break;
-
-                        b = (short) data[_position];
-                        if (b < '0' || b > '9')
-                            break;
-
-                        val *= 10;
-                        if (val >= value)
-                            value = val;
-                        else
-                            value = short.MaxValue;
-                    }
-                    else
-                        value = short.MaxValue;
-                }
-            }
-            else
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-
-                b = (short) data[_position];
-                if (b < '0' || b > '9')
-                    return false;
-
-                value = 0;
-                while (true)
-                {
-                    _position++;
-                    short val = (short) (value - (b - '0'));
-                    if (val <= value)
-                    {
-                        value = val;
-                        if (_position == _next)
-                            break;
-
-                        b = (short) data[_position];
-                        if (b < '0' || b > '9')
-                            break;
-
-                        val *= 10;
-                        if (val <= value)
-                            value = val;
-                        else
-                            value = short.MinValue;
-                    }
-                    else
-                        value = short.MinValue;
-                }
-            }
-
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadUInt16(ref ushort value)
-        {
-            if (_position >= _next)
-                return false;
-
-            ushort b = data[_position];
-            if (b == '+')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                b = data[_position];
-            }
-
-            if (b < '0' || b > '9')
-                return false;
-
-            value = 0;
-            while (true)
-            {
-                _position++;
-                ushort val = (ushort) (value + b - '0');
-                if (val >= value)
-                {
-                    value = val;
-                    if (_position == _next)
-                        break;
-
-                    b = data[_position];
-                    if (b < '0' || b > '9')
-                        break;
-
-                    val *= 10;
-                    if (val >= value)
-                        value = val;
-                    else
-                        value = ushort.MaxValue;
-                }
-                else
-                    value = ushort.MaxValue;
-            }
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadInt32(ref int value)
-        {
-            if (_position >= _next)
-                return false;
-
-            int b = data[_position];
-            if (b != '-')
-            {
-                if (b == '+')
-                {
-                    ++_position;
-                    if (_position == _next)
-                        return false;
-                    b = data[_position];
-                }
-
-                if (b < '0' || b > '9')
-                    return false;
-
-                value = 0;
-                while (true)
-                {
-                    _position++;
-                    int val = value + b - '0';
-                    if (val >= value)
-                    {
-                        value = val;
-                        if (_position == _next)
-                            break;
-
-                        b = data[_position];
-                        if (b < '0' || b > '9')
-                            break;
-
-                        val *= 10;
-                        if (val >= value)
-                            value = val;
-                        else
-                            value = int.MaxValue;
-                    }
-                    else
-                        value = int.MaxValue;
-                }
-            }
-            else
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-
-                b = data[_position];
-                if (b < '0' || b > '9')
-                    return false;
-
-                value = 0;
-                while (true)
-                {
-                    _position++;
-                    int val = value - (b - '0');
-                    if (val <= value)
-                    {
-                        value = val;
-                        if (_position == _next)
-                            break;
-
-                        b = data[_position];
-                        if (b < '0' || b > '9')
-                            break;
-
-                        val *= 10;
-                        if (val <= value)
-                            value = val;
-                        else
-                            value = int.MinValue;
-                    }
-                    else
-                        value = int.MinValue;
-                }
-            }
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadUInt32(ref uint value)
-        {
-            if (_position >= _next)
-                return false;
-
-            uint b = data[_position];
-            if (b == '+')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                b = data[_position];
-            }
-
-            if (b < '0' || b > '9')
-                return false;
-
-            value = 0;
-            while (true)
-            {
-                _position++;
-                uint val = value + b - '0';
-                if (val >= value)
-                {
-                    value = val;
-                    if (_position == _next)
-                        break;
-
-                    b = data[_position];
-                    if (b < '0' || b > '9')
-                        break;
-
-                    val *= 10;
-                    if (val >= value)
-                        value = val;
-                    else
-                        value = uint.MaxValue;
-                }
-                else
-                    value = uint.MaxValue;
-            }
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadInt64(ref long value)
-        {
-            if (_position >= _next)
-                return false;
-
-            long b = data[_position];
-            if (b != '-')
-            {
-                if (b == '+')
-                {
-                    ++_position;
-                    if (_position == _next)
-                        return false;
-                    b = data[_position];
-                }
-
-                if (b < '0' || b > '9')
-                    return false;
-
-                value = 0;
-                while (true)
-                {
-                    _position++;
-                    long val = value + b - '0';
-                    if (val >= value)
-                    {
-                        value = val;
-                        if (_position == _next)
-                            break;
-
-                        b = data[_position];
-                        if (b < '0' || b > '9')
-                            break;
-
-                        val *= 10;
-                        if (val >= value)
-                            value = val;
-                        else
-                            value = long.MaxValue;
-                    }
-                    else
-                        value = long.MaxValue;
-                }
-            }
-            else
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-
-                b = data[_position];
-                if (b < '0' || b > '9')
-                    return false;
-
-                value = 0;
-                while (true)
-                {
-                    _position++;
-                    long val = value - (b - '0');
-                    if (val <= value)
-                    {
-                        value = val;
-                        if (_position == _next)
-                            break;
-
-                        b = data[_position];
-                        if (b < '0' || b > '9')
-                            break;
-
-                        val *= 10;
-                        if (val <= value)
-                            value = val;
-                        else
-                            value = long.MinValue;
-                    }
-                    else
-                        value = long.MinValue;
-                }
-            }
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadUInt64(ref ulong value)
-        {
-            if (_position >= _next)
-                return false;
-
-            ulong b = data[_position];
-            if (b == '+')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                b = data[_position];
-            }
-
-            if (b < '0' || b > '9')
-                return false;
-
-            value = 0;
-            while (true)
-            {
-                _position++;
-                ulong val = value + b - '0';
-                if (val >= value)
-                {
-                    value = val;
-                    if (_position == _next)
-                        break;
-
-                    b = data[_position];
-                    if (b < '0' || b > '9')
-                        break;
-
-                    val *= 10;
-                    if (val >= value)
-                        value = val;
-                    else
-                        value = ulong.MaxValue;
-                }
-                else
-                    value = ulong.MaxValue;
-            }
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadFloat(ref float value)
-        {
-            if (_position >= _next)
-                return false;
-
-            char b = data[_position];
-            bool isNegative = false;
-
-            if (b == '+')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                b = data[_position];
-            }
-            else if (b == '-')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                b = data[_position];
-                isNegative = true;
-            }
-
-            if (b > '9')
-                return false;
-
-            if (b < '0' && b != '.')
-                return false;
-
-            value = 0;
-            if (b != '.')
-            {
-                while (true)
-                {
-                    value += b - '0';
-                    ++_position;
-                    if (_position == _next)
-                        break;
-
-                    b = data[_position];
-                    if (b < '0' || b > '9')
-                        break;
-
-                    value *= 10;
-                }
-            }
-
-            if (b == '.')
-            {
-                ++_position;
-
-                float dec = 0;
-                int count = 0;
-                if (_position < _next)
-                {
-                    b = data[_position];
-                    if ('0' <= b && b <= '9')
-                    {
-                        ++count;
-                        while (true)
-                        {
-                            dec += b - '0';
-                            ++_position;
-                            if (_position == _next)
-                                break;
-
-                            b = data[_position];
-                            if (b < '0' || b > '9')
-                                break;
-                            dec *= 10;
-                            ++count;
-                        }
-                    }
-                }
-
-                for (int i = 0; i < count; ++i)
-                    dec /= 10;
-
-                value += dec;
-            }
-
-            if (isNegative)
-                value = -value;
-
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadDouble(ref double value)
-        {
-            if (_position >= _next)
-                return false;
-
-            char b = data[_position];
-            bool isNegative = false;
-
-            if (b == '+')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-            }
-            else if (b == '-')
-            {
-                ++_position;
-                if (_position == _next)
-                    return false;
-                isNegative = true;
-            }
-
-            if (b > '9')
-                return false;
-
-            if (b < '0' && b != '.')
-                return false;
-
-            value = 0;
-            if (b != '.')
-            {
-                while (true)
-                {
-                    ++_position;
-                    value += b - '0';
-                    if (_position == _next)
-                        break;
-
-                    b = data[_position];
-                    if (b < '0' || b > '9')
-                        break;
-
-                    value *= 10;
-                }
-            }
-
-            if (b == '.')
-            {
-                ++_position;
-
-                double dec = 0;
-                int count = 0;
-                if (_position < _next)
-                {
-                    b = data[_position];
-                    if ('0' <= b && b <= '9')
-                    {
-                        ++count;
-                        while (true)
-                        {
-                            dec += b - '0';
-                            ++_position;
-                            if (_position == _next)
-                                break;
-
-                            b = data[_position];
-                            if (b < '0' || b > '9')
-                                break;
-                            dec *= 10;
-                            ++count;
-                        }
-                    }
-                }
-
-                for (int i = 0; i < count; ++i)
-                    dec /= 10;
-
-                value += dec;
-            }
-
-            if (isNegative)
-                value = -value;
-
-            SkipWhiteSpace();
-            return true;
-        }
-
-        public bool ReadBoolean()
-        {
-            bool value = default;
-            if (!ReadBoolean(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public short ReadInt16()
-        {
-            short value = default;
-            if (!ReadInt16(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public ushort ReadUInt16()
-        {
-            ushort value = default;
-            if (!ReadUInt16(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public int ReadInt32()
-        {
-            int value = default;
-            if (!ReadInt32(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public uint ReadUInt32()
-        {
-            uint value = default;
-            if (!ReadUInt32(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public long ReadInt64()
-        {
-            long value = default;
-            if (!ReadInt64(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public ulong ReadUInt64()
-        {
-            ulong value = default;
-            if (!ReadUInt64(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public float ReadFloat()
-        {
-            float value = default;
-            if (!ReadFloat(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public double ReadDouble()
-        {
-            double value = default;
-            if (!ReadDouble(ref value))
-                throw new Exception("Failed to parse data");
-            return value;
-        }
-
-        public ReadOnlySpan<char> ExtractBasicSpan(int length)
-        {
-            return new ReadOnlySpan<char>(data, _position, length);
+            return new ReadOnlySpan<T>(data, _position, length);
         }
     }
 }

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Base.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Base.cs
@@ -38,7 +38,7 @@ namespace YARG.Core.Song.Deserialization
             this.length = data.Length;
         }
 
-        public abstract T SkipWhiteSpace();
+        public abstract char SkipWhiteSpace();
 
         private void SkipDigitsAndWhiteSpace()
         {
@@ -50,12 +50,6 @@ namespace YARG.Core.Song.Deserialization
                 ++_position;
             }
             SkipWhiteSpace();
-        }
-
-        private const int SPACE_ASCII = 32;
-        public static bool IsWhitespace(T b)
-        {
-            return b.ToInt32(null) <= SPACE_ASCII;
         }
 
         public bool IsEndOfFile()

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Base.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Base.cs
@@ -44,8 +44,8 @@ namespace YARG.Core.Song.Deserialization
         {
             while (_position < _next)
             {
-                char b = data[_position].ToChar(null);
-                if (b < '0' || '9' < b)
+                char ch = data[_position].ToChar(null);
+                if (ch < '0' || '9' < ch)
                     break;
                 ++_position;
             }
@@ -81,38 +81,38 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
-            short sign = b == '-' ? (short) -1 : (short)1;
+            char ch = data[_position].ToChar(null);
+            short sign = ch == '-' ? (short) -1 : (short)1;
 
-            if (b == '-' || b == '+')
+            if (ch == '-' || ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b < '0' || '9' < b)
+            if (ch < '0' || '9' < ch)
                 return false;
 
             value = 0;
             while (true)
             {
-                if (value > SHORT_MAX || (value == SHORT_MAX && b > LAST_DIGIT_SIGNED))
+                if (value > SHORT_MAX || (value == SHORT_MAX && ch > LAST_DIGIT_SIGNED))
                 {
                     value = sign == -1 ? short.MinValue : short.MaxValue;
                     SkipDigitsAndWhiteSpace();
                     return true;
                 }
 
-                value += (short) (b - '0');
+                value += (short) (ch - '0');
 
                 ++_position;
                 if (_position == _next)
                     break;
 
-                b = data[_position].ToChar(null);
-                if (b < '0' || '9' < b)
+                ch = data[_position].ToChar(null);
+                if (ch < '0' || '9' < ch)
                     break;
 
                 value *= 10;
@@ -129,37 +129,37 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
+            char ch = data[_position].ToChar(null);
 
-            if (b == '+')
+            if (ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b < '0' || '9' < b)
+            if (ch < '0' || '9' < ch)
                 return false;
 
             value = 0;
             while (true)
             {
-                if (value > USHORT_MAX || (value == USHORT_MAX && b > LAST_DIGIT_UNSIGNED))
+                if (value > USHORT_MAX || (value == USHORT_MAX && ch > LAST_DIGIT_UNSIGNED))
                 {
                     value = ushort.MaxValue;
                     SkipDigitsAndWhiteSpace();
                     return true;
                 }
 
-                value += (ushort) (b - '0');
+                value += (ushort) (ch - '0');
 
                 ++_position;
                 if (_position == _next)
                     break;
 
-                b = data[_position].ToChar(null);
-                if (b < '0' || '9' < b)
+                ch = data[_position].ToChar(null);
+                if (ch < '0' || '9' < ch)
                     break;
                 value *= 10;
             }
@@ -174,38 +174,38 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
-            int sign = b == '-' ? -1 : 1;
+            char ch = data[_position].ToChar(null);
+            int sign = ch == '-' ? -1 : 1;
 
-            if (b == '-' || b == '+')
+            if (ch == '-' || ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b < '0' || '9' < b)
+            if (ch < '0' || '9' < ch)
                 return false;
 
             value = 0;
             while (true)
             {
-                if (value > INT_MAX || (value == INT_MAX && b > LAST_DIGIT_SIGNED))
+                if (value > INT_MAX || (value == INT_MAX && ch > LAST_DIGIT_SIGNED))
                 {
                     value = sign == -1 ? int.MinValue : int.MaxValue;
                     SkipDigitsAndWhiteSpace();
                     return true;
                 }
 
-                value +=  b - '0';
+                value +=  ch - '0';
 
                 ++_position;
                 if (_position == _next)
                     break;
 
-                b = data[_position].ToChar(null);
-                if (b < '0' || '9' < b)
+                ch = data[_position].ToChar(null);
+                if (ch < '0' || '9' < ch)
                     break;
                 value *= 10;
             }
@@ -221,37 +221,37 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
+            char ch = data[_position].ToChar(null);
 
-            if (b == '+')
+            if (ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b < '0' || '9' < b)
+            if (ch < '0' || '9' < ch)
                 return false;
 
             value = 0;
             while (true)
             {
-                if (value > UINT_MAX || (value == UINT_MAX && b > LAST_DIGIT_UNSIGNED))
+                if (value > UINT_MAX || (value == UINT_MAX && ch > LAST_DIGIT_UNSIGNED))
                 {
                     value = uint.MaxValue;
                     SkipDigitsAndWhiteSpace();
                     return true;
                 }
 
-                value += (uint) (b - '0');
+                value += (uint) (ch - '0');
 
                 ++_position;
                 if (_position == _next)
                     break;
 
-                b = data[_position].ToChar(null);
-                if (b < '0' || '9' < b)
+                ch = data[_position].ToChar(null);
+                if (ch < '0' || '9' < ch)
                     break;
                 value *= 10;
             }
@@ -266,38 +266,38 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
-            long sign = b == '-' ? -1 : 1;
+            char ch = data[_position].ToChar(null);
+            long sign = ch == '-' ? -1 : 1;
 
-            if (b == '-' || b == '+')
+            if (ch == '-' || ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b < '0' || '9' < b)
+            if (ch < '0' || '9' < ch)
                 return false;
 
             value = 0;
             while (true)
             {
-                if (value > LONG_MAX || (value == LONG_MAX && b > LAST_DIGIT_SIGNED))
+                if (value > LONG_MAX || (value == LONG_MAX && ch > LAST_DIGIT_SIGNED))
                 {
                     value = sign == -1 ? long.MinValue : long.MaxValue;
                     SkipDigitsAndWhiteSpace();
                     return true;
                 }
 
-                value += b - '0';
+                value += ch - '0';
 
                 ++_position;
                 if (_position == _next)
                     break;
 
-                b = data[_position].ToChar(null);
-                if (b < '0' || '9' < b)
+                ch = data[_position].ToChar(null);
+                if (ch < '0' || '9' < ch)
                     break;
                 value *= 10;
             }
@@ -313,36 +313,36 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
-            if (b == '+')
+            char ch = data[_position].ToChar(null);
+            if (ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b < '0' || '9' < b)
+            if (ch < '0' || '9' < ch)
                 return false;
 
             value = 0;
             while (true)
             {
-                if (value > ULONG_MAX || (value == ULONG_MAX && b > LAST_DIGIT_UNSIGNED))
+                if (value > ULONG_MAX || (value == ULONG_MAX && ch > LAST_DIGIT_UNSIGNED))
                 {
                     value = ulong.MaxValue;
                     SkipDigitsAndWhiteSpace();
                     return true;
                 }
 
-                value += (ulong) (b - '0');
+                value += (ulong) (ch - '0');
 
                 ++_position;
                 if (_position == _next)
                     break;
 
-                b = data[_position].ToChar(null);
-                if (b < '0' || '9' < b)
+                ch = data[_position].ToChar(null);
+                if (ch < '0' || '9' < ch)
                     break;
                 value *= 10;
             }
@@ -356,39 +356,39 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
-            float sign = b == '-' ? -1 : 1;
+            char ch = data[_position].ToChar(null);
+            float sign = ch == '-' ? -1 : 1;
 
-            if (b == '-' || b == '+')
+            if (ch == '-' || ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b > '9' || (b < '0' && b != '.'))
+            if (ch > '9' || (ch < '0' && ch != '.'))
                 return false;
 
             value = 0;
-            if (b != '.')
+            if (ch != '.')
             {
                 while (true)
                 {
-                    value += b - '0';
+                    value += ch - '0';
                     ++_position;
                     if (_position == _next)
                         break;
 
-                    b = data[_position].ToChar(null);
-                    if (b < '0' || b > '9')
+                    ch = data[_position].ToChar(null);
+                    if (ch < '0' || ch > '9')
                         break;
 
                     value *= 10;
                 }
             }
 
-            if (b == '.')
+            if (ch == '.')
             {
                 ++_position;
 
@@ -396,19 +396,19 @@ namespace YARG.Core.Song.Deserialization
                 int count = 0;
                 if (_position < _next)
                 {
-                    b = data[_position].ToChar(null);
-                    if ('0' <= b && b <= '9')
+                    ch = data[_position].ToChar(null);
+                    if ('0' <= ch && ch <= '9')
                     {
                         ++count;
                         while (true)
                         {
-                            dec += b - '0';
+                            dec += ch - '0';
                             ++_position;
                             if (_position == _next)
                                 break;
 
-                            b = data[_position].ToChar(null);
-                            if (b < '0' || b > '9')
+                            ch = data[_position].ToChar(null);
+                            if (ch < '0' || ch > '9')
                                 break;
                             dec *= 10;
                             ++count;
@@ -433,39 +433,39 @@ namespace YARG.Core.Song.Deserialization
             if (_position >= _next)
                 return false;
 
-            char b = data[_position].ToChar(null);
-            double sign = b == '-' ? -1 : 1;
+            char ch = data[_position].ToChar(null);
+            double sign = ch == '-' ? -1 : 1;
 
-            if (b == '-' || b == '+')
+            if (ch == '-' || ch == '+')
             {
                 ++_position;
                 if (_position == _next)
                     return false;
-                b = data[_position].ToChar(null);
+                ch = data[_position].ToChar(null);
             }
 
-            if (b > '9' || (b < '0' && b != '.'))
+            if (ch > '9' || (ch < '0' && ch != '.'))
                 return false;
 
             value = 0;
-            if (b != '.')
+            if (ch != '.')
             {
                 while (true)
                 {
                     ++_position;
-                    value += b - '0';
+                    value += ch - '0';
                     if (_position == _next)
                         break;
 
-                    b = data[_position].ToChar(null);
-                    if (b < '0' || b > '9')
+                    ch = data[_position].ToChar(null);
+                    if (ch < '0' || ch > '9')
                         break;
 
                     value *= 10;
                 }
             }
 
-            if (b == '.')
+            if (ch == '.')
             {
                 ++_position;
 
@@ -473,19 +473,19 @@ namespace YARG.Core.Song.Deserialization
                 int count = 0;
                 if (_position < _next)
                 {
-                    b = data[_position].ToChar(null);
-                    if ('0' <= b && b <= '9')
+                    ch = data[_position].ToChar(null);
+                    if ('0' <= ch && ch <= '9')
                     {
                         ++count;
                         while (true)
                         {
-                            dec += b - '0';
+                            dec += ch - '0';
                             ++_position;
                             if (_position == _next)
                                 break;
 
-                            b = data[_position].ToChar(null);
-                            if (b < '0' || b > '9')
+                            ch = data[_position].ToChar(null);
+                            if (ch < '0' || ch > '9')
                                 break;
                             dec *= 10;
                             ++count;

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Char.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Char.cs
@@ -24,7 +24,7 @@ namespace YARG.Core.Song.Deserialization
             while (_position < length)
             {
                 char ch = data[_position];
-                if (IsWhitespace(ch))
+                if (ITXTReader.IsWhitespace(ch))
                 {
                     if (ch == '\n')
                         return ch;
@@ -78,7 +78,7 @@ namespace YARG.Core.Song.Deserialization
             if (checkForQuotes && data[_position] == '\"')
             {
                 int end = boundaries.Item2 - 1;
-                while (_position + 1 < end && IsWhitespace(data[end]))
+                while (_position + 1 < end && ITXTReader.IsWhitespace(data[end]))
                     --end;
 
                 if (_position < end && data[end] == '\"' && data[end - 1] != '\\')
@@ -91,7 +91,7 @@ namespace YARG.Core.Song.Deserialization
             if (boundaries.Item2 < boundaries.Item1)
                 return string.Empty;
 
-            while (boundaries.Item2 > boundaries.Item1 && IsWhitespace(data[boundaries.Item2 - 1]))
+            while (boundaries.Item2 > boundaries.Item1 && ITXTReader.IsWhitespace(data[boundaries.Item2 - 1]))
                 --boundaries.Item2;
 
             _position = _next;
@@ -103,8 +103,8 @@ namespace YARG.Core.Song.Deserialization
             int curr = _position;
             while (curr < length)
             {
-                char b = data[curr];
-                if (IsWhitespace(b) || b == '=')
+                char ch = data[curr];
+                if (ITXTReader.IsWhitespace(ch) || ch == '=')
                     break;
                 ++curr;
             }

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Char.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader_Char.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace YARG.Core.Song.Deserialization
 {
-    public class YARGTXTReader_Char : YARGTXTReader_BaseChar, ITXTReader
+    public class YARGTXTReader_Char : YARGTXTReader_Base<char>, ITXTReader
     {
         static YARGTXTReader_Char() { }
 

--- a/YARG.Core/Song/Deserialization/YARGDTAReader.cs
+++ b/YARG.Core/Song/Deserialization/YARGDTAReader.cs
@@ -54,16 +54,16 @@ namespace YARG.Core.Song.Deserialization
             nodeEnds.Add(reader.nodeEnds[0]);
         }
 
-        public override byte SkipWhiteSpace()
+        public override char SkipWhiteSpace()
         {
             while (_position < length)
             {
-                byte ch = data[_position];
-                if (!IsWhitespace(ch) && ch != ';')
+                char ch = (char)data[_position];
+                if (!ITXTReader.IsWhitespace(ch) && ch != ';')
                     return ch;
 
                 ++_position;
-                if (!IsWhitespace(ch))
+                if (!ITXTReader.IsWhitespace(ch))
                 {
                     while (_position < length)
                     {
@@ -73,12 +73,12 @@ namespace YARG.Core.Song.Deserialization
                     }
                 }
             }
-            return 0;
+            return (char)0;
         }
 
         public string GetNameOfNode()
         {
-            byte ch = data[_position];
+            char ch = (char)data[_position];
             if (ch == '(')
                 return string.Empty;
 
@@ -90,18 +90,18 @@ namespace YARG.Core.Song.Deserialization
                 hasApostrophe = false;
             }
             else
-                ch = data[++_position];
+                ch = (char)data[++_position];
 
             int start = _position;
             while (ch != '\'')
             {
-                if (IsWhitespace(ch))
+                if (ITXTReader.IsWhitespace(ch))
                 {
                     if (hasApostrophe)
                         throw new Exception("Invalid name format");
                     break;
                 }
-                ch = data[++_position];
+                ch = (char)data[++_position];
             }
             int end = _position++;
             SkipWhiteSpace();
@@ -110,7 +110,7 @@ namespace YARG.Core.Song.Deserialization
 
         public string ExtractText()
         {
-            byte ch = data[_position];
+            char ch = (char)data[_position];
             bool inSquirley = ch == '{';
             bool inQuotes = !inSquirley && ch == '\"';
             bool inApostrophes = !inQuotes && ch == '\'';
@@ -121,7 +121,7 @@ namespace YARG.Core.Song.Deserialization
             int start = _position++;
             while (_position < _next)
             {
-                ch = data[_position];
+                ch = (char)data[_position];
                 if (ch == '{')
                     throw new Exception("Text error - no { braces allowed");
 
@@ -145,7 +145,7 @@ namespace YARG.Core.Song.Deserialization
                     if (!inSquirley && !inQuotes)
                         throw new Exception("Text error - no apostrophes allowed");
                 }
-                else if (IsWhitespace(ch))
+                else if (ITXTReader.IsWhitespace(ch))
                 {
                     if (inApostrophes)
                         throw new Exception("Text error - no whitespace allowed");

--- a/YARG.Core/Song/Deserialization/YARGDTAReader.cs
+++ b/YARG.Core/Song/Deserialization/YARGDTAReader.cs
@@ -5,14 +5,13 @@ using System.Text;
 
 namespace YARG.Core.Song.Deserialization
 {
-    public class YARGDTAReader : YARGTXTReader_Base
+    public class YARGDTAReader : YARGTXTReader_Base<byte>
     {
         private static readonly byte[] BOM_UTF8 = { 0xEF, 0xBB, 0xBF };
         private static readonly byte[] BOM_OTHER = { 0xFF, 0xFE };
 
         private readonly List<int> nodeEnds = new();
         public Encoding encoding;
-        
 
         public YARGDTAReader(byte[] data) : base(data)
         {
@@ -40,7 +39,7 @@ namespace YARG.Core.Song.Deserialization
                 _position += 2;
             }
             else
-                encoding = Latin1;
+                encoding = ITXTReader.Latin1;
 
             SkipWhiteSpace();
         }

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -459,7 +459,7 @@ namespace YARG.Core.Song
                     case "encoding":
                         var encoding = reader.ExtractText().ToLower() switch
                         {
-                            "latin1" => YARGTXTReader_Base.Latin1,
+                            "latin1" => ITXTReader.Latin1,
                             "utf-8" or
                             "utf8" => Encoding.UTF8,
                             _ => reader.encoding


### PR DESCRIPTION
The generic must implement the IConvertible class, which allows us to specify types that can convert to char where necessary. No longer do we split the byte & char variants into different classes.

+ Use char for any comparisons or arithmetic against const character values.