### PR TITLE
Rework instrument enums for future-proofing

### DIFF
--- a/YARG.Core/InstrumentEnums.cs
+++ b/YARG.Core/InstrumentEnums.cs
@@ -1,74 +1,95 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace YARG.Core
 {
+    // !DO NOT MODIFY THE VALUES OR ORDER OF THESE ENUMS!
+    // Since they are serialized in replays, they *must* remain the same across changes.
+    // Add new values in the gaps between reserved ranges, or reserve a new range at the end of the enum.
+
     /// <summary>
     /// Available game modes.
     /// </summary>
-    public enum GameMode
+    public enum GameMode : byte
     {
-        FiveFretGuitar,
-        SixFretGuitar,
+        // Game modes are reserved in multiples of 5
+        // 0-4: Guitar
+        FiveFretGuitar = 0,
+        SixFretGuitar = 1,
 
-        FourLaneDrums,
-        FiveLaneDrums,
-        // TrueDrums,
+        // 5-9: Drums
+        FourLaneDrums = 5,
+        FiveLaneDrums = 6,
+        // TrueDrums = 7,
 
-        ProGuitar,
-        ProKeys,
+        // 10-14: Pro instruments
+        ProGuitar = 10,
+        ProKeys = 11,
 
-        Vocals,
+        // 15-19: Vocals
+        Vocals = 15,
 
-        // Dj,
+        // 20-24: Other
+        // Dj = 20,
     }
 
     /// <summary>
     /// Available instruments.
     /// </summary>
-    public enum Instrument
+    public enum Instrument : byte
     {
-        FiveFretGuitar,
-        FiveFretBass,
-        FiveFretRhythm,
-        FiveFretCoopGuitar,
-        Keys,
+        // Instruments are reserved in multiples of 10
+        // 0-9: 5-fret guitar
+        FiveFretGuitar = 0,
+        FiveFretBass = 1,
+        FiveFretRhythm = 2,
+        FiveFretCoopGuitar = 3,
+        Keys = 4,
 
-        SixFretGuitar,
-        SixFretBass,
-        SixFretRhythm,
-        SixFretCoopGuitar,
+        // 10-19: 6-fret guitar
+        SixFretGuitar = 10,
+        SixFretBass = 11,
+        SixFretRhythm = 12,
+        SixFretCoopGuitar = 13,
 
-        FourLaneDrums,
-        ProDrums,
+        // 20-29: Drums
+        FourLaneDrums = 20,
+        ProDrums = 21,
 
-        FiveLaneDrums,
+        FiveLaneDrums = 22,
 
-        // TrueDrums,
+        // TrueDrums = 23,
 
-        ProGuitar_17Fret,
-        ProGuitar_22Fret,
-        ProBass_17Fret,
-        ProBass_22Fret,
+        // 30-39: Pro instruments
+        ProGuitar_17Fret = 30,
+        ProGuitar_22Fret = 31,
+        ProBass_17Fret = 32,
+        ProBass_22Fret = 33,
 
-        ProKeys,
+        ProKeys = 34,
 
-        Vocals,
-        Harmony,
+        // 40-49: Vocals
+        Vocals = 40,
+        Harmony = 41,
 
-        // Dj,
-        Band,
+        // 50-59: DJ
+        // DjSingle = 50,
+        // DjDouble = 51,
+
+        Band = byte.MaxValue
     }
 
     /// <summary>
     /// Available difficulty levels.
     /// </summary>
-    public enum Difficulty
+    public enum Difficulty : byte
     {
-        Easy,
-        Medium,
-        Hard,
-        Expert,
-        ExpertPlus,
+        Beginner = 0,
+        Easy = 1,
+        Medium = 2,
+        Hard = 3,
+        Expert = 4,
+        ExpertPlus = 5,
     }
 
     /// <summary>
@@ -79,13 +100,14 @@ namespace YARG.Core
     {
         None = 0,
 
-        Easy   = 1 << 0,
-        Medium = 1 << 1,
-        Hard   = 1 << 2,
-        Expert = 1 << 3,
-        ExpertPlus = 1 << 4,
+        Beginner   = 1 << Difficulty.Beginner,
+        Easy       = 1 << Difficulty.Easy,
+        Medium     = 1 << Difficulty.Medium,
+        Hard       = 1 << Difficulty.Hard,
+        Expert     = 1 << Difficulty.Expert,
+        ExpertPlus = 1 << Difficulty.ExpertPlus,
 
-        All = Easy | Medium | Hard | Expert | ExpertPlus,
+        All = Beginner | Easy | Medium | Hard | Expert | ExpertPlus,
     }
 
     public static class ChartEnumExtensions
@@ -122,7 +144,8 @@ namespace YARG.Core
                 Instrument.Vocals or
                 Instrument.Harmony => GameMode.Vocals,
 
-                // Instrument.Dj => GameMode.Dj,
+                // Instrument.DjSingle => GameMode.Dj,
+                // Instrument.DjDouble => GameMode.Dj,
 
                 _ => throw new NotImplementedException($"Unhandled instrument {instrument}!")
             };
@@ -156,10 +179,16 @@ namespace YARG.Core
                 {
                     Instrument.FiveLaneDrums
                 },
+                // GameMode.TrueDrums      => new[]
+                // {
+                //     Instrument.TrueDrums,
+                // },
                 GameMode.ProGuitar      => new[]
                 {
                     Instrument.ProGuitar_17Fret,
+                    Instrument.ProGuitar_22Fret,
                     Instrument.ProBass_17Fret,
+                    Instrument.ProBass_22Fret,
                 },
                 GameMode.ProKeys        => new[]
                 {
@@ -170,30 +199,29 @@ namespace YARG.Core
                     Instrument.Vocals,
                     Instrument.Harmony
                 },
+                // GameMode.Dj             => new[]
+                // {
+                //     Instrument.DjSingle,
+                //     Instrument.DjDouble,
+                // },
                 _  => throw new NotImplementedException($"Unhandled game mode {gameMode}!")
             };
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static DifficultyMask ToDifficultyMask(this Difficulty difficulty)
         {
-            return difficulty switch
-            {
-                Difficulty.Easy       => DifficultyMask.Easy,
-                Difficulty.Medium     => DifficultyMask.Easy,
-                Difficulty.Hard       => DifficultyMask.Easy,
-                Difficulty.Expert     => DifficultyMask.Expert,
-                Difficulty.ExpertPlus => DifficultyMask.ExpertPlus,
-                _ => throw new ArgumentException($"Invalid difficulty {difficulty}!")
-            };
+            return (DifficultyMask) (1 << (int) difficulty);
         }
 
         public static Difficulty ToDifficulty(this DifficultyMask difficulty)
         {
             return difficulty switch
             {
+                DifficultyMask.Beginner   => Difficulty.Beginner,
                 DifficultyMask.Easy       => Difficulty.Easy,
-                DifficultyMask.Medium     => Difficulty.Easy,
-                DifficultyMask.Hard       => Difficulty.Easy,
+                DifficultyMask.Medium     => Difficulty.Medium,
+                DifficultyMask.Hard       => Difficulty.Hard,
                 DifficultyMask.Expert     => Difficulty.Expert,
                 DifficultyMask.ExpertPlus => Difficulty.ExpertPlus,
                 _ => throw new ArgumentException($"Cannot convert difficulty mask {difficulty} into a single difficulty!")

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -50,7 +50,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 23_08_31_01;
+        public const int CACHE_VERSION = 23_09_15_01;
 
         public readonly List<object> errorList = new();
         public ScanProgress Progress { get; private set; }

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -50,7 +50,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 23_09_15_01;
+        public const int CACHE_VERSION = 23_09_15_02;
 
         public readonly List<object> errorList = new();
         public ScanProgress Progress { get; private set; }

--- a/YARG.Core/Song/Deserialization/ChartReader/IYARGChartReader.cs
+++ b/YARG.Core/Song/Deserialization/ChartReader/IYARGChartReader.cs
@@ -34,7 +34,7 @@ namespace YARG.Core.Song.Deserialization
     public interface IYARGChartReader
     {
         public NoteTracks_Chart Instrument { get; }
-        public int Difficulty { get; }
+        public Difficulty Difficulty { get; }
         public bool IsStartOfTrack();
         public bool ValidateHeaderTrack();
         public bool ValidateSyncTrack();

--- a/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader.cs
+++ b/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader.cs
@@ -29,12 +29,12 @@ namespace YARG.Core.Song.Deserialization
         private static readonly EventCombo NOTE =    new(Encoding.ASCII.GetBytes("N"),  ChartEvent_FW.NOTE);
         private static readonly EventCombo SPECIAL = new(Encoding.ASCII.GetBytes("S"),  ChartEvent_FW.SPECIAL);
 
-        private static readonly byte[][] DIFFICULTIES =
+        private static readonly (byte[] name, Difficulty difficulty)[] DIFFICULTIES =
         {
-            Encoding.ASCII.GetBytes("[Easy"),
-            Encoding.ASCII.GetBytes("[Medium"),
-            Encoding.ASCII.GetBytes("[Hard"),
-            Encoding.ASCII.GetBytes("[Expert")
+            (Encoding.ASCII.GetBytes("[Easy"), Difficulty.Easy),
+            (Encoding.ASCII.GetBytes("[Medium"), Difficulty.Medium),
+            (Encoding.ASCII.GetBytes("[Hard"), Difficulty.Hard),
+            (Encoding.ASCII.GetBytes("[Expert"), Difficulty.Expert),
         };
 
         private static readonly (byte[], NoteTracks_Chart)[] NOTETRACKS =
@@ -64,10 +64,10 @@ namespace YARG.Core.Song.Deserialization
         private EventCombo[] eventSet = Array.Empty<EventCombo>();
         private long tickPosition = 0;
         private NoteTracks_Chart _instrument;
-        private int _difficulty;
+        private Difficulty _difficulty;
 
         public NoteTracks_Chart Instrument => _instrument;
-        public int Difficulty => _difficulty;
+        public Difficulty Difficulty => _difficulty;
 
         public YARGChartFileReader(YARGTXTReader reader)
         {
@@ -107,13 +107,16 @@ namespace YARG.Core.Song.Deserialization
         public bool ValidateDifficulty()
         {
             for (int diff = 3; diff >= 0; --diff)
-                if (DoesStringMatch(DIFFICULTIES[diff]))
+            {
+                var (name, difficulty) = DIFFICULTIES[diff];
+                if (DoesStringMatch(name))
                 {
-                    _difficulty = diff;
+                    _difficulty = difficulty;
                     eventSet = EVENTS_DIFF;
-                    reader.Position += DIFFICULTIES[diff].Length;
+                    reader.Position += name.Length;
                     return true;
                 }
+            }
             return false;
         }
 

--- a/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader_Char.cs
+++ b/YARG.Core/Song/Deserialization/ChartReader/YARGChartFileReader_Char.cs
@@ -28,12 +28,12 @@ namespace YARG.Core.Song.Deserialization
         private static readonly EventCombo NOTE =    new("N",  ChartEvent_FW.NOTE);
         private static readonly EventCombo SPECIAL = new("S",  ChartEvent_FW.SPECIAL);
 
-        private static readonly string[] DIFFICULTIES =
+        private static readonly (string name, Difficulty difficulty)[] DIFFICULTIES =
         {
-            "[Easy",
-            "[Medium",
-            "[Hard",
-            "[Expert"
+            ("[Easy", Difficulty.Easy),
+            ("[Medium", Difficulty.Medium),
+            ("[Hard", Difficulty.Hard),
+            ("[Expert", Difficulty.Expert),
         };
 
         private static readonly (string, NoteTracks_Chart)[] NOTETRACKS =
@@ -63,10 +63,10 @@ namespace YARG.Core.Song.Deserialization
         private EventCombo[] eventSet = Array.Empty<EventCombo>();
         private long tickPosition = 0;
         private NoteTracks_Chart _instrument;
-        private int _difficulty;
+        private Difficulty _difficulty;
 
         public NoteTracks_Chart Instrument => _instrument;
-        public int Difficulty => _difficulty;
+        public Difficulty Difficulty => _difficulty;
 
         public YARGChartFileReader_Char(YARGTXTReader_Char reader)
         {
@@ -110,13 +110,16 @@ namespace YARG.Core.Song.Deserialization
         public bool ValidateDifficulty()
         {
             for (int diff = 3; diff >= 0; --diff)
-                if (DoesStringMatch(DIFFICULTIES[diff]))
+            {
+                var (name, difficulty) = DIFFICULTIES[diff];
+                if (DoesStringMatch(name))
                 {
-                    _difficulty = diff;
+                    _difficulty = difficulty;
                     eventSet = EVENTS_DIFF;
-                    reader.Position += DIFFICULTIES[diff].Length;
+                    reader.Position += name.Length;
                     return true;
                 }
+            }
             return false;
         }
 

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.Midi.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.Midi.cs
@@ -26,33 +26,29 @@ namespace YARG.Core.Song
                     {
                         switch (type)
                         {
-                            case MidiTrackType.Guitar_5:      if (!FiveFretGuitar.WasParsed())     FiveFretGuitar.subTracks      = Midi_FiveFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Bass_5:        if (!FiveFretBass.WasParsed())       FiveFretBass.subTracks        = Midi_FiveFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Rhythm_5:      if (!FiveFretRhythm.WasParsed())     FiveFretRhythm.subTracks      = Midi_FiveFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Coop_5:        if (!FiveFretCoopGuitar.WasParsed()) FiveFretCoopGuitar.subTracks  = Midi_FiveFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Guitar_6:      if (!SixFretGuitar.WasParsed())      SixFretGuitar.subTracks       = Midi_SixFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Bass_6:        if (!SixFretBass.WasParsed())        SixFretBass.subTracks         = Midi_SixFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Rhythm_6:      if (!SixFretRhythm.WasParsed())      SixFretRhythm.subTracks       = Midi_SixFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Coop_6:        if (!SixFretCoopGuitar.WasParsed())  SixFretCoopGuitar.subTracks   = Midi_SixFret_Preparser.Parse(reader); break;
-                            case MidiTrackType.Pro_Guitar_17: if (!ProGuitar_17Fret.WasParsed())   ProGuitar_17Fret.subTracks    = Midi_ProGuitar_Preparser.Parse_17Fret(reader); break;
-                            case MidiTrackType.Pro_Guitar_22: if (!ProGuitar_22Fret.WasParsed())   ProGuitar_22Fret.subTracks    = Midi_ProGuitar_Preparser.Parse_22Fret(reader); break;
-                            case MidiTrackType.Pro_Bass_17:   if (!ProBass_17Fret.WasParsed())     ProBass_17Fret.subTracks      = Midi_ProGuitar_Preparser.Parse_17Fret(reader); break;
-                            case MidiTrackType.Pro_Bass_22:   if (!ProBass_22Fret.WasParsed())     ProBass_22Fret.subTracks      = Midi_ProGuitar_Preparser.Parse_22Fret(reader); break;
-                            case MidiTrackType.Keys:          if (!Keys.WasParsed())               Keys.subTracks                = Midi_Keys_Preparser.Parse(reader); break;
-                            case MidiTrackType.Pro_Keys_E:
-                            case MidiTrackType.Pro_Keys_M:
-                            case MidiTrackType.Pro_Keys_H:
-                            case MidiTrackType.Pro_Keys_X:
-                                {
-                                    int index = type - MidiTrackType.Pro_Keys_E;
-                                    if (!ProKeys[index] && Midi_ProKeys_Preparser.Parse(reader))
-                                        ProKeys.Set(index);
-                                    break;
-                                }
-                            case MidiTrackType.Vocals: if (!LeadVocals[0]    && Midi_Vocal_Preparser.ParseLeadTrack(reader))    LeadVocals.Set(0); break;
-                            case MidiTrackType.Harm1:  if (!HarmonyVocals[0] && Midi_Vocal_Preparser.ParseLeadTrack(reader))    HarmonyVocals.Set(0); break;
-                            case MidiTrackType.Harm2:  if (!HarmonyVocals[1] && Midi_Vocal_Preparser.ParseHarmonyTrack(reader)) HarmonyVocals.Set(1); break;
-                            case MidiTrackType.Harm3:  if (!HarmonyVocals[2] && Midi_Vocal_Preparser.ParseHarmonyTrack(reader)) HarmonyVocals.Set(2); break;
+                            case MidiTrackType.Guitar_5:      if (!FiveFretGuitar.WasParsed())     FiveFretGuitar.Difficulties      = Midi_FiveFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Bass_5:        if (!FiveFretBass.WasParsed())       FiveFretBass.Difficulties        = Midi_FiveFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Rhythm_5:      if (!FiveFretRhythm.WasParsed())     FiveFretRhythm.Difficulties      = Midi_FiveFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Coop_5:        if (!FiveFretCoopGuitar.WasParsed()) FiveFretCoopGuitar.Difficulties  = Midi_FiveFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Guitar_6:      if (!SixFretGuitar.WasParsed())      SixFretGuitar.Difficulties       = Midi_SixFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Bass_6:        if (!SixFretBass.WasParsed())        SixFretBass.Difficulties         = Midi_SixFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Rhythm_6:      if (!SixFretRhythm.WasParsed())      SixFretRhythm.Difficulties       = Midi_SixFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Coop_6:        if (!SixFretCoopGuitar.WasParsed())  SixFretCoopGuitar.Difficulties   = Midi_SixFret_Preparser.Parse(reader); break;
+                            case MidiTrackType.Pro_Guitar_17: if (!ProGuitar_17Fret.WasParsed())   ProGuitar_17Fret.Difficulties    = Midi_ProGuitar_Preparser.Parse_17Fret(reader); break;
+                            case MidiTrackType.Pro_Guitar_22: if (!ProGuitar_22Fret.WasParsed())   ProGuitar_22Fret.Difficulties    = Midi_ProGuitar_Preparser.Parse_22Fret(reader); break;
+                            case MidiTrackType.Pro_Bass_17:   if (!ProBass_17Fret.WasParsed())     ProBass_17Fret.Difficulties      = Midi_ProGuitar_Preparser.Parse_17Fret(reader); break;
+                            case MidiTrackType.Pro_Bass_22:   if (!ProBass_22Fret.WasParsed())     ProBass_22Fret.Difficulties      = Midi_ProGuitar_Preparser.Parse_22Fret(reader); break;
+                            case MidiTrackType.Keys:          if (!Keys.WasParsed())               Keys.Difficulties                = Midi_Keys_Preparser.Parse(reader); break;
+
+                            case MidiTrackType.Pro_Keys_E: if (!ProKeys[Difficulty.Easy]   && Midi_ProKeys_Preparser.Parse(reader)) ProKeys.SetDifficulty(Difficulty.Easy); break;
+                            case MidiTrackType.Pro_Keys_M: if (!ProKeys[Difficulty.Medium] && Midi_ProKeys_Preparser.Parse(reader)) ProKeys.SetDifficulty(Difficulty.Medium); break;
+                            case MidiTrackType.Pro_Keys_H: if (!ProKeys[Difficulty.Hard]   && Midi_ProKeys_Preparser.Parse(reader)) ProKeys.SetDifficulty(Difficulty.Hard); break;
+                            case MidiTrackType.Pro_Keys_X: if (!ProKeys[Difficulty.Expert] && Midi_ProKeys_Preparser.Parse(reader)) ProKeys.SetDifficulty(Difficulty.Expert); break;
+
+                            case MidiTrackType.Vocals: if (!LeadVocals[0]    && Midi_Vocal_Preparser.ParseLeadTrack(reader))    LeadVocals.SetSubtrack(0); break;
+                            case MidiTrackType.Harm1:  if (!HarmonyVocals[0] && Midi_Vocal_Preparser.ParseLeadTrack(reader))    HarmonyVocals.SetSubtrack(0); break;
+                            case MidiTrackType.Harm2:  if (!HarmonyVocals[1] && Midi_Vocal_Preparser.ParseHarmonyTrack(reader)) HarmonyVocals.SetSubtrack(1); break;
+                            case MidiTrackType.Harm3:  if (!HarmonyVocals[2] && Midi_Vocal_Preparser.ParseHarmonyTrack(reader)) HarmonyVocals.SetSubtrack(2); break;
                         }
                     }
                     else

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.cs
@@ -250,6 +250,18 @@ namespace YARG.Core.Song
             }
         }
 
+        public bool HasDifficulty(Instrument instrument, Difficulty difficulty)
+        {
+            try
+            {
+                return GetValues(instrument)[difficulty];
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
         public bool HasPart(Instrument instrument, int subtrack)
         {
             try
@@ -276,12 +288,12 @@ namespace YARG.Core.Song
         private void SetDrums(DrumPreparseHandler drums)
         {
             if (drums.Type == DrumsType.FiveLane)
-                FiveLaneDrums.subTracks = (byte) drums.ValidatedDiffs;
+                FiveLaneDrums.Difficulties = drums.ValidatedDiffs;
             else
             {
-                FourLaneDrums.subTracks = (byte) drums.ValidatedDiffs;
+                FourLaneDrums.Difficulties = drums.ValidatedDiffs;
                 if (drums.Type == DrumsType.ProDrums)
-                    ProDrums.subTracks = (byte) drums.ValidatedDiffs;
+                    ProDrums.Difficulties = drums.ValidatedDiffs;
             }
         }
 

--- a/YARG.Core/Song/Metadata/AvailableParts/PartValues.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/PartValues.cs
@@ -13,11 +13,6 @@ namespace YARG.Core.Song
             intensity = baseIntensity;
         }
 
-        public void Set(int subTrack)
-        {
-            subTracks |= (byte) (1 << subTrack);
-        }
-
         public bool this[int subTrack]
         {
             get
@@ -27,6 +22,22 @@ namespace YARG.Core.Song
                 return ((byte) (1 << subTrack) & subTracks) > 0;
             }
         }
+
+        public bool this[Difficulty difficulty] => this[(int) difficulty];
+
+        public DifficultyMask Difficulties
+        {
+            get => (DifficultyMask) subTracks;
+            set => subTracks = (byte) value;
+        }
+
+        public void SetSubtrack(int subTrack)
+        {
+            subTracks |= (byte) (1 << subTrack);
+        }
+
+        public void SetDifficulty(Difficulty difficulty)
+            => SetSubtrack((int) difficulty);
 
         public bool WasParsed() { return subTracks > 0; }
 

--- a/YARG.Core/Song/Preparsers/Chart/ChartPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Chart/ChartPreparser.cs
@@ -10,8 +10,8 @@ namespace YARG.Core.Song
     {
         public static bool Preparse(IYARGChartReader reader, ref PartValues scan, Func<int, bool> func)
         {
-            int index = reader.Difficulty;
-            if (scan[index])
+            var difficulty = reader.Difficulty;
+            if (scan[difficulty])
                 return true;
 
             while (reader.IsStillCurrentTrack())
@@ -20,7 +20,7 @@ namespace YARG.Core.Song
                 {
                     if (func(reader.ExtractLaneAndSustain().Item1))
                     {
-                        scan.Set(index);
+                        scan.SetDifficulty(difficulty);
                         return true;
                     }
                 }

--- a/YARG.Core/Song/Preparsers/DrumPreparseHandler.cs
+++ b/YARG.Core/Song/Preparsers/DrumPreparseHandler.cs
@@ -40,7 +40,7 @@ namespace YARG.Core.Song.Preparsers
 
         public void ParseChart(IYARGChartReader reader)
         {
-            var difficulty = (DifficultyMask)(1 << reader.Difficulty);
+            var difficulty = reader.Difficulty.ToDifficultyMask();
 
             bool skip = true;
             if ((_validations & difficulty) == 0)

--- a/YARG.Core/Song/Preparsers/Midi/MidiDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiDrumPreparser.cs
@@ -5,12 +5,10 @@
         private const int DOUBLE_BASS_NOTE = 95;
         private const int DOUBLE_BASS_INDEX = 1;
         private const int EXPERT_INDEX = 3;
-        private const int EXPERT_AND_EXPERT_PLUS = 24;
         protected const int FIVELANE_MAX = 101;
         protected const int MAX_NUMPADS = 7;
         protected const int YELLOW_FLAG = 110;
         protected const int GREEN_FLAG = 112;
-        protected const int FULL_VALIDATION = 31;
 
         protected Midi_Drum_Preparser_Base() { }
 
@@ -38,7 +36,7 @@
                 return false;
 
             if (statuses[EXPERT_INDEX, DOUBLE_BASS_INDEX])
-                validations |= EXPERT_AND_EXPERT_PLUS;
+                validations |= DifficultyMask.Expert | DifficultyMask.ExpertPlus;
             return true;
         }
     }

--- a/YARG.Core/Song/Preparsers/Midi/MidiFiveFretPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiFiveFretPreparser.cs
@@ -21,11 +21,11 @@ namespace YARG.Core.Song
 
         private Midi_FiveFret_Preparser() { }
 
-        public static byte Parse(YARGMidiReader reader)
+        public static DifficultyMask Parse(YARGMidiReader reader)
         {
             Midi_FiveFret_Preparser preparser = new();
             preparser.Process(reader);
-            return (byte) preparser.validations;
+            return preparser.validations;
         }
 
         protected override bool IsNote() { return FIVEFRET_MIN <= note.value && note.value <= DEFAULT_MAX; }

--- a/YARG.Core/Song/Preparsers/Midi/MidiFiveLaneDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiFiveLaneDrumPreparser.cs
@@ -7,7 +7,7 @@ namespace YARG.Core.Song
         private const int NUM_LANES = MAX_NUMPADS;
         protected override bool IsNote() { return DEFAULT_MIN <= note.value && note.value <= FIVELANE_MAX; }
 
-        protected override bool IsFullyScanned() { return validations == FULL_VALIDATION; }
+        protected override bool IsFullyScanned() { return validations == ALL_DIFFICULTIES_PLUS; }
 
         private Midi_FiveLane_Preparser() { }
 
@@ -15,7 +15,7 @@ namespace YARG.Core.Song
         {
             Midi_FiveLane_Preparser preparser = new();
             preparser.Process(reader);
-            return (DifficultyMask) preparser.validations;
+            return preparser.validations;
         }
 
         protected override bool ParseLaneColor_ON()

--- a/YARG.Core/Song/Preparsers/Midi/MidiFourLaneDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiFourLaneDrumPreparser.cs
@@ -16,19 +16,19 @@ namespace YARG.Core.Song
         {
             Midi_FourLane_Preparser preparser = new(DrumsType.FourLane);
             preparser.Process(reader);
-            return ((DifficultyMask) preparser.validations, preparser._type);
+            return (preparser.validations, preparser._type);
         }
 
         public static DifficultyMask ParseProDrums(YARGMidiReader reader)
         {
             Midi_FourLane_Preparser preparser = new(DrumsType.ProDrums);
             preparser.Process(reader);
-            return (DifficultyMask) preparser.validations;
+            return preparser.validations;
         }
 
         protected override bool IsNote() { return DEFAULT_MIN <= note.value && note.value <= 100; }
 
-        protected override bool IsFullyScanned() { return validations == FULL_VALIDATION && _type == DrumsType.ProDrums; }
+        protected override bool IsFullyScanned() { return validations == ALL_DIFFICULTIES_PLUS && _type == DrumsType.ProDrums; }
 
         protected override bool ParseLaneColor_ON()
         {

--- a/YARG.Core/Song/Preparsers/Midi/MidiInstrumentPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiInstrumentPreparser.cs
@@ -2,11 +2,18 @@
 {
     public abstract class Midi_Instrument_Preparser : Midi_Preparser
     {
-        private const int ALL_DIFFICULTIES = 15;
+        protected const DifficultyMask ALL_DIFFICULTIES = DifficultyMask.Easy | DifficultyMask.Medium | DifficultyMask.Hard | DifficultyMask.Expert;
+        protected const DifficultyMask ALL_DIFFICULTIES_PLUS = ALL_DIFFICULTIES | DifficultyMask.ExpertPlus;
+
+        protected static readonly DifficultyMask[] DIFFINDEX_TO_DIFF = new DifficultyMask[NUM_DIFFICULTIES] {
+            DifficultyMask.Easy, DifficultyMask.Medium, DifficultyMask.Hard, DifficultyMask.Expert
+        };
+
         protected const int DEFAULT_MIN = 60;
         protected const int DEFAULT_MAX = 100;
         protected const int NUM_DIFFICULTIES = 4;
-        protected int validations;
+
+        protected DifficultyMask validations;
 
         protected Midi_Instrument_Preparser() { }
 
@@ -39,7 +46,7 @@
 
         protected virtual bool ToggleExtraValues() { return false; }
 
-        protected void Validate(int diffIndex) { validations |= 1 << diffIndex; }
+        protected void Validate(int diffIndex) { validations |= DIFFINDEX_TO_DIFF[diffIndex]; }
     }
 
     public abstract class MidiInstrument_Common : Midi_Instrument_Preparser

--- a/YARG.Core/Song/Preparsers/Midi/MidiKeysPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiKeysPreparser.cs
@@ -16,11 +16,11 @@ namespace YARG.Core.Song
 
         private Midi_Keys_Preparser() { }
 
-        public static byte Parse(YARGMidiReader reader)
+        public static DifficultyMask Parse(YARGMidiReader reader)
         {
             Midi_Keys_Preparser preparser = new();
             preparser.Process(reader);
-            return (byte) preparser.validations;
+            return preparser.validations;
         }
 
         protected override bool ParseLaneColor_ON()

--- a/YARG.Core/Song/Preparsers/Midi/MidiProGuitarPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiProGuitarPreparser.cs
@@ -32,18 +32,18 @@ namespace YARG.Core.Song
             this.maxVelocity = maxVelocity;
         }
 
-        public static byte Parse_17Fret(YARGMidiReader reader)
+        public static DifficultyMask Parse_17Fret(YARGMidiReader reader)
         {
             Midi_ProGuitar_Preparser preparser = new(117);
             preparser.Process(reader);
-            return (byte) preparser.validations;
+            return preparser.validations;
         }
 
-        public static byte Parse_22Fret(YARGMidiReader reader)
+        public static DifficultyMask Parse_22Fret(YARGMidiReader reader)
         {
             Midi_ProGuitar_Preparser preparser = new(122);
             preparser.Process(reader);
-            return (byte) preparser.validations;
+            return preparser.validations;
         }
 
         protected override bool IsNote() { return PROGUITAR_MIN <= note.value && note.value <= PROGUITAR_MAX; }

--- a/YARG.Core/Song/Preparsers/Midi/MidiSixFretPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiSixFretPreparser.cs
@@ -17,11 +17,11 @@ namespace YARG.Core.Song
 
         private Midi_SixFret_Preparser() { }
 
-        public static byte Parse(YARGMidiReader reader)
+        public static DifficultyMask Parse(YARGMidiReader reader)
         {
             Midi_SixFret_Preparser preparser = new();
             preparser.Process(reader);
-            return (byte) preparser.validations;
+            return preparser.validations;
         }
 
         protected override bool IsNote() { return 58 <= note.value && note.value <= 103; }

--- a/YARG.Core/Song/Preparsers/Midi/MidiUnknownDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiUnknownDrumPreparser.cs
@@ -18,10 +18,10 @@ namespace YARG.Core.Song
         {
             Midi_UnknownDrums_Preparser preparser = new(type);
             preparser.Process(reader);
-            return ((DifficultyMask) preparser.validations, preparser.type);
+            return (preparser.validations, preparser.type);
         }
 
-        protected override bool IsFullyScanned() { return validations == FULL_VALIDATION && type != DrumsType.FourLane; }
+        protected override bool IsFullyScanned() { return validations == ALL_DIFFICULTIES_PLUS && type != DrumsType.FourLane; }
         protected override bool IsNote() { return DEFAULT_MIN <= note.value && note.value <= FIVELANE_MAX; }
 
         protected override bool ParseLaneColor_ON()


### PR DESCRIPTION
Summary:

- Game mode and instrument values have been reworked into fixed-size groups of instrument types, so that potential new modes don't result in nonsensical ordering down the line.
- A value for Beginner has been added below Easy, so that we can support it later down the line if desired. Some scanning code had to be adjusted to work with this change.

Since these enums are serialized, it's best to make these changes now, rather than have to deal with compatibility or ordering issues that might arise if we do it later.