### PR TITLE
Enable nullable analysis and fix all nullable warnings

### DIFF
--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -84,7 +84,7 @@ namespace YARG.Core.Chart
             return chartEvent.TickEnd;
         }
 
-        public static TEvent GetPrevious<TEvent>(this IList<TEvent> events, double time)
+        public static TEvent? GetPrevious<TEvent>(this IList<TEvent> events, double time)
             where TEvent : ChartEvent
         {
             int index = GetIndexOfPrevious(events, time);
@@ -94,7 +94,7 @@ namespace YARG.Core.Chart
             return events[index];
         }
 
-        public static TEvent GetPrevious<TEvent>(this IList<TEvent> events, uint tick)
+        public static TEvent? GetPrevious<TEvent>(this IList<TEvent> events, uint tick)
             where TEvent : ChartEvent
         {
             int index = GetIndexOfPrevious(events, tick);
@@ -104,7 +104,7 @@ namespace YARG.Core.Chart
             return events[index];
         }
 
-        public static TEvent GetNext<TEvent>(this IList<TEvent> events, double time)
+        public static TEvent? GetNext<TEvent>(this IList<TEvent> events, double time)
             where TEvent : ChartEvent
         {
             int index = GetIndexOfNext(events, time);
@@ -114,7 +114,7 @@ namespace YARG.Core.Chart
             return events[index];
         }
 
-        public static TEvent GetNext<TEvent>(this IList<TEvent> events, uint tick)
+        public static TEvent? GetNext<TEvent>(this IList<TEvent> events, uint tick)
             where TEvent : ChartEvent
         {
             int index = GetIndexOfNext(events, tick);
@@ -234,7 +234,7 @@ namespace YARG.Core.Chart
             return true;
         }
 
-        public static TEvent FindClosestEvent<TEvent>(this IList<TEvent> events, double time)
+        public static TEvent? FindClosestEvent<TEvent>(this IList<TEvent> events, double time)
             where TEvent : ChartEvent
         {
             return events.BinarySearch(time, Compare);
@@ -250,7 +250,7 @@ namespace YARG.Core.Chart
             }
         }
 
-        public static TEvent FindClosestEvent<TEvent>(this IList<TEvent> events, uint tick)
+        public static TEvent? FindClosestEvent<TEvent>(this IList<TEvent> events, uint tick)
             where TEvent : ChartEvent
         {
             return events.BinarySearch(tick, Compare);

--- a/YARG.Core/Chart/Loaders/ISongLoader.cs
+++ b/YARG.Core/Chart/Loaders/ISongLoader.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using Melanchall.DryWetMidi.Core;
 
 namespace YARG.Core.Chart
 {
@@ -8,10 +7,6 @@ namespace YARG.Core.Chart
     /// </summary>
     internal interface ISongLoader
     {
-        void LoadSong(ParseSettings settings, string filePath);
-        void LoadMidi(ParseSettings settings, MidiFile midi);
-        void LoadDotChart(ParseSettings settings, string chartText);
-
         List<TextEvent> LoadGlobalEvents();
         SyncTrack LoadSyncTrack();
         VenueTrack LoadVenueTrack();

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Venue.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Venue.cs
@@ -117,8 +117,8 @@ namespace YARG.Core.Chart
             var otherEvents = new List<VenueTextEvent>(venueCount / 20);
 
             // For merging spotlights/singalongs into a single event
-            MoonVenueEvent spotlightCurrentEvent = null;
-            MoonVenueEvent singalongCurrentEvent = null;
+            MoonVenueEvent? spotlightCurrentEvent = null;
+            MoonVenueEvent? singalongCurrentEvent = null;
             var spotlightPerformers = Performer.None;
             var singalongPerformers = Performer.None;
 
@@ -192,7 +192,7 @@ namespace YARG.Core.Chart
         }
 
         private void HandlePerformerEvent(List<PerformerEvent> events, PerformerEventType type, MoonVenueEvent moonEvent,
-            ref MoonVenueEvent currentEvent, ref Performer performers)
+            ref MoonVenueEvent? currentEvent, ref Performer performers)
         {
             // First event
             if (currentEvent == null)

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -117,7 +117,7 @@ namespace YARG.Core.Chart
                 // Go through each note and lyric in the phrase
                 var notes = new List<VocalNote>();
                 var lyrics = new List<TextEvent>();
-                VocalNote previousNote = null;
+                VocalNote? previousNote = null;
                 while (moonNoteIndex < moonChart.notes.Count)
                 {
                     var moonNote = moonChart.notes[moonNoteIndex];

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -25,13 +25,13 @@ namespace YARG.Core.Chart
 
         public NoteFlags Flags;
 
-        private TNote _originalPreviousNote;
-        private TNote _originalNextNote;
+        private TNote? _originalPreviousNote;
+        private TNote? _originalNextNote;
 
-        public TNote PreviousNote;
-        public TNote NextNote;
+        public TNote? PreviousNote;
+        public TNote? NextNote;
 
-        public TNote Parent { get; private set; }
+        public TNote? Parent { get; private set; }
         public IReadOnlyList<TNote> ChildNotes => _childNotes;
 
         /// <summary>

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -200,23 +200,20 @@ namespace YARG.Core.Chart
 
         public static SongChart FromFile(ParseSettings settings, string filePath)
         {
-            ISongLoader loader = new MoonSongLoader();
-            loader.LoadSong(settings, filePath);
-            return new SongChart(loader);
+            var loader = MoonSongLoader.LoadSong(settings, filePath);
+            return new(loader);
         }
 
         public static SongChart FromMidi(ParseSettings settings, MidiFile midi)
         {
-            ISongLoader loader = new MoonSongLoader();
-            loader.LoadMidi(settings, midi);
-            return new SongChart(loader);
+            var loader = MoonSongLoader.LoadMidi(settings, midi);
+            return new(loader);
         }
 
         public static SongChart FromDotChart(ParseSettings settings, string chartText)
         {
-            ISongLoader loader = new MoonSongLoader();
-            loader.LoadDotChart(settings, chartText);
-            return new SongChart(loader);
+            var loader = MoonSongLoader.LoadDotChart(settings, chartText);
+            return new(loader);
         }
 
         public InstrumentTrack<GuitarNote> GetFiveFretTrack(Instrument instrument)

--- a/YARG.Core/Chart/Sync/SyncTrack.cs
+++ b/YARG.Core/Chart/Sync/SyncTrack.cs
@@ -191,6 +191,9 @@ namespace YARG.Core.Chart
         {
             // Find the current tempo marker at the given tick
             var currentTempo = Tempos.GetPrevious(tick);
+            if (currentTempo is null)
+                return 0;
+
             return TickToTime(tick, currentTempo);
 
             // Fun little tidbit: if you're between two tempo markers, you can just lerp
@@ -206,6 +209,9 @@ namespace YARG.Core.Chart
 
             // Find the current tempo marker at the given time
             var currentTempo = Tempos.GetPrevious(time);
+            if (currentTempo is null)
+                return 0;
+
             return TimeToTick(time, currentTempo);
         }
 

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -27,14 +27,21 @@ namespace YARG.Core.Engine
 
         protected GameInput CurrentInput;
 
-        protected List<SoloSection> Solos;
+        protected List<SoloSection> Solos = new();
 
-        protected BaseEngine(SyncTrack syncTrack)
+        protected BaseEngine(BaseEngineParameters parameters, SyncTrack syncTrack)
         {
             SyncTrack = syncTrack;
             Resolution = syncTrack.Resolution;
 
             TicksPerSustainPoint = Resolution / 25;
+
+            float[] multiplierThresholds = parameters.StarMultiplierThresholds;
+            StarScoreThresholds = new int[multiplierThresholds.Length];
+            for (int i = 0; i < multiplierThresholds.Length; i++)
+            {
+                StarScoreThresholds[i] = (int)(BaseScore * multiplierThresholds[i]);
+            }
 
             InputQueue = new Queue<GameInput>();
             CurrentInput = new GameInput(-9999, -9999, -9999);
@@ -181,15 +188,15 @@ namespace YARG.Core.Engine
 
         public delegate void SoloEndEvent(SoloSection soloSection);
 
-        public NoteHitEvent    OnNoteHit;
-        public NoteMissedEvent OnNoteMissed;
+        public NoteHitEvent?    OnNoteHit;
+        public NoteMissedEvent? OnNoteMissed;
 
-        public StarPowerPhraseHitEvent  OnStarPowerPhraseHit;
-        public StarPowerPhraseMissEvent OnStarPowerPhraseMissed;
-        public StarPowerStatusEvent     OnStarPowerStatus;
+        public StarPowerPhraseHitEvent?  OnStarPowerPhraseHit;
+        public StarPowerPhraseMissEvent? OnStarPowerPhraseMissed;
+        public StarPowerStatusEvent?     OnStarPowerStatus;
 
-        public SoloStartEvent OnSoloStart;
-        public SoloEndEvent   OnSoloEnd;
+        public SoloStartEvent? OnSoloStart;
+        public SoloEndEvent?   OnSoloEnd;
 
         public readonly TEngineStats EngineStats;
 
@@ -201,7 +208,7 @@ namespace YARG.Core.Engine
         public TEngineState State;
 
         protected BaseEngine(InstrumentDifficulty<TNoteType> chart, SyncTrack syncTrack,
-            TEngineParams engineParameters) : base(syncTrack)
+            TEngineParams engineParameters) : base(engineParameters, syncTrack)
         {
             Chart = chart;
             Notes = Chart.Notes;
@@ -288,9 +295,9 @@ namespace YARG.Core.Engine
             }
         }
 
-        protected virtual void StripStarPower(TNoteType note)
+        protected virtual void StripStarPower(TNoteType? note)
         {
-            if (!note.IsStarPower)
+            if (note is null || !note.IsStarPower)
             {
                 return;
             }

--- a/YARG.Core/Engine/BaseEngineParameters.cs
+++ b/YARG.Core/Engine/BaseEngineParameters.cs
@@ -24,6 +24,7 @@ namespace YARG.Core.Engine
 
         protected BaseEngineParameters()
         {
+            StarMultiplierThresholds = Array.Empty<float>();
         }
 
         protected BaseEngineParameters(double hitWindow, double frontBackRatio, float[] starMultiplierThresholds)

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -10,22 +10,14 @@ namespace YARG.Core.Engine.Drums
 
         public delegate void PadHitEvent(DrumsAction action, bool noteWasHit);
 
-        public OverhitEvent OnOverhit;
-        public PadHitEvent  OnPadHit;
+        public OverhitEvent? OnOverhit;
+        public PadHitEvent?  OnPadHit;
 
         protected DrumsEngine(InstrumentDifficulty<DrumNote> chart, SyncTrack syncTrack,
             DrumsEngineParameters engineParameters)
             : base(chart, syncTrack, engineParameters)
         {
             BaseScore = CalculateBaseScore();
-
-            float[] multiplierThresholds = engineParameters.StarMultiplierThresholds;
-
-            StarScoreThresholds = new int[multiplierThresholds.Length];
-            for (int i = 0; i < multiplierThresholds.Length; i++)
-            {
-                StarScoreThresholds[i] = (int)(BaseScore * multiplierThresholds[i]);
-            }
         }
 
         public override void Reset(bool keepCurrentButtons = false)

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -14,26 +14,17 @@ namespace YARG.Core.Engine.Guitar
 
         public delegate void SustainEndEvent(GuitarNote note, double timeEnded);
 
-        public OverstrumEvent    OnOverstrum;
-        public SustainStartEvent OnSustainStart;
-        public SustainEndEvent   OnSustainEnd;
+        public OverstrumEvent?    OnOverstrum;
+        public SustainStartEvent? OnSustainStart;
+        public SustainEndEvent?   OnSustainEnd;
 
-        protected List<GuitarNote> ActiveSustains;
+        protected List<GuitarNote> ActiveSustains = new();
 
         protected GuitarEngine(InstrumentDifficulty<GuitarNote> chart, SyncTrack syncTrack,
             GuitarEngineParameters engineParameters)
             : base(chart, syncTrack, engineParameters)
         {
             BaseScore = CalculateBaseScore();
-            ActiveSustains = new List<GuitarNote>();
-
-            float[] multiplierThresholds = engineParameters.StarMultiplierThresholds;
-
-            StarScoreThresholds = new int[multiplierThresholds.Length];
-            for (int i = 0; i < multiplierThresholds.Length; i++)
-            {
-                StarScoreThresholds[i] = (int)(BaseScore * multiplierThresholds[i]);
-            }
         }
 
         public override void Reset(bool keepCurrentButtons = false)

--- a/YARG.Core/Extensions/CollectionExtensions.cs
+++ b/YARG.Core/Extensions/CollectionExtensions.cs
@@ -55,7 +55,7 @@ namespace YARG.Core.Extensions
         /// The item from the list, or default if the list contains no elements.<br/>
         /// If no exact match was found, the item returned is the one that matches the most closely.
         /// </returns>
-        public static TItem BinarySearch<TItem, TSearch>(this IList<TItem> list, TSearch searchObject,
+        public static TItem? BinarySearch<TItem, TSearch>(this IList<TItem> list, TSearch searchObject,
             Func<TItem, TSearch, int> comparer)
         {
             int index = list.BinarySearchIndex(searchObject, comparer);
@@ -112,7 +112,7 @@ namespace YARG.Core.Extensions
         /// <returns>
         /// The peeked value, if available; otherwise the default value of <typeparamref name="T"/>.
         /// </returns>
-        public static T PeekOrDefault<T>(this Queue<T> queue)
+        public static T? PeekOrDefault<T>(this Queue<T> queue)
         {
             if (queue.TryPeek(out var o))
             {
@@ -128,7 +128,7 @@ namespace YARG.Core.Extensions
         /// <returns>
         /// The peeked value, if available; otherwise the default value of <typeparamref name="T"/>.
         /// </returns>
-        public static T DequeueOrDefault<T>(this Queue<T> queue)
+        public static T? DequeueOrDefault<T>(this Queue<T> queue)
         {
             if (queue.TryDequeue(out var o))
             {

--- a/YARG.Core/Extensions/ICloneable.cs
+++ b/YARG.Core/Extensions/ICloneable.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+
 // Since this is a generic version of an existing interface
 // in the System namespace
 namespace System
@@ -10,6 +12,7 @@ namespace System
         /// <summary>
         /// Creates a copy of this object with the same set of values.
         /// </summary>
+        [return: NotNull] // thanks Roslyn
         new T Clone();
 
         object ICloneable.Clone() => Clone();

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -94,7 +94,9 @@ namespace YARG.Core.Game
             switch (Instrument.ToGameMode())
             {
                 case GameMode.FiveFretGuitar:
-                    var guitarTrack = track as InstrumentDifficulty<GuitarNote>;
+                    if (track is not InstrumentDifficulty<GuitarNote> guitarTrack)
+                        throw new InvalidOperationException($"Cannot apply guitar modifiers to non-guitar track with notes of {typeof(TNote)}!");
+
                     if(IsModifierActive(Modifier.AllStrums)) guitarTrack.ConvertToGuitarType(GuitarNoteType.Strum);
                     else if(IsModifierActive(Modifier.AllHopos)) guitarTrack.ConvertToGuitarType(GuitarNoteType.Hopo);
                     else if(IsModifierActive(Modifier.AllTaps)) guitarTrack.ConvertToGuitarType(GuitarNoteType.Tap);

--- a/YARG.Core/MoonscraperChartParser/Events/ChartEvent.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/ChartEvent.cs
@@ -22,7 +22,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (b.GetType() == typeof(ChartEvent))
             {
-                var realB = b as ChartEvent;
+                var realB = (ChartEvent) b;
                 return tick == realB.tick && eventName == realB.eventName;
             }
             else
@@ -33,7 +33,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (b.GetType() == typeof(ChartEvent))
             {
-                var realB = b as ChartEvent;
+                var realB = (ChartEvent) b;
                 if (tick < b.tick)
                     return true;
                 else if (tick == b.tick)

--- a/YARG.Core/MoonscraperChartParser/Events/ChartObject.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/ChartObject.cs
@@ -11,7 +11,11 @@ namespace MoonscraperChartEditor.Song
         [NonSerialized]
         public MoonChart chart;
 
+// Non-nullable field 'chart' must contain a non-null value when exiting constructor
+// 'chart' is assigned externally as part of this object being added to a chart
+#pragma warning disable 8618
         public ChartObject(uint position) : base(position) { }
+#pragma warning restore 8618
 
         // Clone needs to be hideable so it can return a different type in derived classes
         protected override SongObject SongClone() => ChartClone();

--- a/YARG.Core/MoonscraperChartParser/Events/Event.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/Event.cs
@@ -22,7 +22,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (base.Equals(b))
             {
-                var realB = b as Event;
+                var realB = (Event) b;
                 return realB != null && tick == realB.tick && title == realB.title;
             }
 
@@ -33,7 +33,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (classID == b.classID)
             {
-                var realB = b as Event;
+                var realB = (Event) b;
                 if (tick < b.tick)
                     return true;
                 else if (tick == b.tick)

--- a/YARG.Core/MoonscraperChartParser/Events/MoonNote.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/MoonNote.cs
@@ -144,11 +144,11 @@ namespace MoonscraperChartEditor.Song
         /// <summary>
         /// The previous note in the linked-list.
         /// </summary>
-        public MoonNote previous;
+        public MoonNote? previous;
         /// <summary>
         /// The next note in the linked-list.
         /// </summary>
-        public MoonNote next;
+        public MoonNote? next;
 
         public Chord chord => new(this);
 
@@ -182,7 +182,7 @@ namespace MoonscraperChartEditor.Song
         /// <summary>
         /// Gets the next note in the linked-list that's not part of this note's chord.
         /// </summary>
-        public MoonNote NextSeperateMoonNote
+        public MoonNote? NextSeperateMoonNote
         {
             get
             {
@@ -196,7 +196,7 @@ namespace MoonscraperChartEditor.Song
         /// <summary>
         /// Gets the previous note in the linked-list that's not part of this note's chord.
         /// </summary>
-        public MoonNote PreviousSeperateMoonNote
+        public MoonNote? PreviousSeperateMoonNote
         {
             get
             {
@@ -211,7 +211,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (b.GetType() == typeof(MoonNote))
             {
-                var realB = b as MoonNote;
+                var realB = (MoonNote) b;
                 if (tick == realB.tick && rawNote == realB.rawNote)
                     return true;
                 else
@@ -225,7 +225,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (b.GetType() == typeof(MoonNote))
             {
-                var realB = b as MoonNote;
+                var realB = (MoonNote) b;
                 if (tick < b.tick)
                     return true;
                 else if (tick == b.tick)

--- a/YARG.Core/MoonscraperChartParser/Events/SongObject.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/SongObject.cs
@@ -20,10 +20,14 @@ namespace MoonscraperChartEditor.Song
 
         public abstract int classID { get; }
 
+// Non-nullable field 'song' must contain a non-null value when exiting constructor
+// 'song' is assigned externally as part of this object being added to a song
+#pragma warning disable 8618
         public SongObject(uint _tick)
         {
             tick = _tick;
         }
+#pragma warning restore 8618
 
         /// <summary>
         /// Automatically converts the object's tick position into the time it will appear in the song.
@@ -34,15 +38,15 @@ namespace MoonscraperChartEditor.Song
         protected abstract SongObject SongClone();
         public SongObject Clone() => SongClone();
 
-        public static bool operator ==(SongObject a, SongObject b)
+        public static bool operator ==(SongObject? a, SongObject? b)
         {
-            bool aIsNull = a is null;
-            bool bIsNull = b is null;
+            if (ReferenceEquals(a, b))
+                return true;
 
-            if (aIsNull || bIsNull)
-                return aIsNull == bIsNull;
-            else
-                return a.Equals(b);
+            if (a is null || b is null)
+                return false;
+
+            return a.Equals(b);
         }
 
         protected virtual bool Equals(SongObject b)
@@ -50,7 +54,7 @@ namespace MoonscraperChartEditor.Song
             return tick == b.tick && classID == b.classID;
         }
 
-        public static bool operator !=(SongObject a, SongObject b)
+        public static bool operator !=(SongObject? a, SongObject? b)
         {
             return !(a == b);
         }
@@ -85,7 +89,7 @@ namespace MoonscraperChartEditor.Song
 
         public override bool Equals(object obj)
         {
-            return base.Equals(obj);
+            return obj is SongObject songObj && this == songObj;
         }
 
         public override int GetHashCode()

--- a/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
@@ -43,7 +43,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (b.GetType() == typeof(SpecialPhrase))
             {
-                var realB = b as SpecialPhrase;
+                var realB = (SpecialPhrase) b;
                 if (tick == realB.tick && type == realB.type)
                     return true;
                 else
@@ -57,7 +57,7 @@ namespace MoonscraperChartEditor.Song
         {
             if (b.GetType() == typeof(SpecialPhrase))
             {
-                var realB = b as SpecialPhrase;
+                var realB = (SpecialPhrase) b;
                 if (tick < b.tick)
                     return true;
                 else if (tick == b.tick)
@@ -80,7 +80,7 @@ namespace MoonscraperChartEditor.Song
             else
                 newLength = 0;
 
-            SpecialPhrase nextSp = null;
+            SpecialPhrase? nextSp = null;
             if (song != null && chart != null)
             {
                 int arrayPos = SongObjectHelper.FindClosestPosition(this, chart.specialPhrases);

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.ProcessLists.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.ProcessLists.cs
@@ -515,8 +515,11 @@ namespace MoonscraperChartEditor.Song.IO
                     int key = (int)proString + difficultyStartRange;
                     processFnDict.Add(key, (in EventProcessParams eventProcessParams) =>
                     {
-                        var noteEvent = eventProcessParams.timedEvent.midiEvent as NoteEvent;
-                        YargTrace.Assert(noteEvent != null, $"Wrong note event type passed to Pro Guitar note process. Expected: {typeof(NoteEvent)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+                        if (eventProcessParams.timedEvent.midiEvent is not NoteEvent noteEvent)
+                        {
+                            YargTrace.Fail($"Wrong note event type passed to Pro Guitar note process. Expected: {typeof(NoteEvent)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+                            return;
+                        }
 
                         if (noteEvent.Velocity < 100)
                         {
@@ -597,8 +600,11 @@ namespace MoonscraperChartEditor.Song.IO
                         {
                             processFnDict.Add(key, (in EventProcessParams eventProcessParams) =>
                             {
-                                var noteEvent = eventProcessParams.timedEvent.midiEvent as NoteEvent;
-                                YargTrace.Assert(noteEvent != null, $"Wrong note event type passed to drums note process. Expected: {typeof(NoteEvent)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+                                if (eventProcessParams.timedEvent.midiEvent is not NoteEvent noteEvent)
+                                {
+                                    YargTrace.Fail($"Wrong note event type passed to drums note process. Expected: {typeof(NoteEvent)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+                                    return;
+                                }
 
                                 var flags = defaultFlags;
                                 switch (noteEvent.Velocity)

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -10,6 +10,7 @@ using YARG.Core;
 using YARG.Core.Chart;
 using YARG.Core.Song;
 using YARG.Core.Extensions;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MoonscraperChartEditor.Song.IO
 {
@@ -562,7 +563,7 @@ namespace MoonscraperChartEditor.Song.IO
         }
 
         private static bool TryFindMatchingNote(NoteEventQueue unpairedNotes, NoteEvent noteToMatch,
-            out NoteEvent matchingNote, out long matchTick, out int matchIndex)
+            [NotNullWhen(true)] out NoteEvent? matchingNote, out long matchTick, out int matchIndex)
         {
             for (int i = 0; i < unpairedNotes.Count; i++)
             {
@@ -582,7 +583,7 @@ namespace MoonscraperChartEditor.Song.IO
         }
 
         private static bool TryFindMatchingSysEx(SysExEventQueue unpairedSysex, PhaseShiftSysEx sysexToMatch,
-            out PhaseShiftSysEx matchingSysex, out long matchTick, out int matchIndex)
+            [NotNullWhen(true)] out PhaseShiftSysEx? matchingSysex, out long matchTick, out int matchIndex)
         {
             for (int i = 0; i < unpairedSysex.Count; i++)
             {
@@ -773,8 +774,11 @@ namespace MoonscraperChartEditor.Song.IO
         private static void ProcessSysExEventPairAsForcedType(in EventProcessParams eventProcessParams, MoonNote.MoonNoteType noteType)
         {
             var timedEvent = eventProcessParams.timedEvent;
-            var startEvent = eventProcessParams.timedEvent.midiEvent as PhaseShiftSysEx;
-            YargTrace.Assert(startEvent != null, $"Wrong note event type passed to {nameof(ProcessSysExEventPairAsForcedType)}. Expected: {typeof(PhaseShiftSysEx)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+            if (eventProcessParams.timedEvent.midiEvent is not PhaseShiftSysEx startEvent)
+            {
+                YargTrace.Fail($"Wrong note event type passed to {nameof(ProcessSysExEventPairAsForcedType)}. Expected: {typeof(PhaseShiftSysEx)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+                return;
+            }
 
             uint startTick = (uint)timedEvent.startTick;
             uint endTick = (uint)timedEvent.endTick;
@@ -805,8 +809,11 @@ namespace MoonscraperChartEditor.Song.IO
         private static void ProcessSysExEventPairAsOpenNoteModifier(in EventProcessParams eventProcessParams)
         {
             var timedEvent = eventProcessParams.timedEvent;
-            var startEvent = timedEvent.midiEvent as PhaseShiftSysEx;
-            YargTrace.Assert(startEvent != null, $"Wrong note event type passed to {nameof(ProcessSysExEventPairAsOpenNoteModifier)}. Expected: {typeof(PhaseShiftSysEx)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+            if (eventProcessParams.timedEvent.midiEvent is not PhaseShiftSysEx startEvent)
+            {
+                YargTrace.Fail($"Wrong note event type passed to {nameof(ProcessSysExEventPairAsOpenNoteModifier)}. Expected: {typeof(PhaseShiftSysEx)}, Actual: {eventProcessParams.timedEvent.midiEvent.GetType()}");
+                return;
+            }
 
             uint startTick = (uint)timedEvent.startTick;
             uint endTick = (uint)timedEvent.endTick;

--- a/YARG.Core/MoonscraperChartParser/IO/NoteFlagPriority.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/NoteFlagPriority.cs
@@ -2,6 +2,7 @@
 // See LICENSE in project root for license information.
 
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace MoonscraperChartEditor.Song.IO
@@ -104,7 +105,7 @@ namespace MoonscraperChartEditor.Song.IO
             return true;
         }
 
-        public static bool AreFlagsValidForAll(MoonNote.Flags flags, out NoteFlagPriority invalidPriority)
+        public static bool AreFlagsValidForAll(MoonNote.Flags flags, [NotNullWhen(false)] out NoteFlagPriority? invalidPriority)
         {
             foreach (var priority in priorities)
             {

--- a/YARG.Core/MoonscraperChartParser/Metadata.cs
+++ b/YARG.Core/MoonscraperChartParser/Metadata.cs
@@ -1,17 +1,49 @@
 ﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace MoonscraperChartEditor.Song
 {
     internal class Metadata
     {
         private string m_name, m_artist, m_charter, m_genre, m_album;
 
-        public string name { get => m_name; set => m_name = MakeValidMetadataString(value); }
-        public string artist { get => m_artist; set => m_artist = MakeValidMetadataString(value); }
-        public string charter { get => m_charter; set => m_charter = MakeValidMetadataString(value); }
-        public string genre { get => m_genre; set => m_genre = MakeValidMetadataString(value); }
-        public string album { get => m_album; set => m_album = MakeValidMetadataString(value); }
+        public string name
+        {
+            get => m_name;
+            [MemberNotNull(nameof(m_name))]
+            set => m_name = MakeValidMetadataString(value);
+        }
+
+        public string artist
+        {
+            get => m_artist;
+            [MemberNotNull(nameof(m_artist))]
+            set => m_artist = MakeValidMetadataString(value);
+        }
+
+        public string charter
+        {
+            get => m_charter;
+            [MemberNotNull(nameof(m_charter))]
+            set => m_charter = MakeValidMetadataString(value);
+        }
+
+        public string genre
+        {
+            get => m_genre;
+            [MemberNotNull(nameof(m_genre))]
+            set => m_genre = MakeValidMetadataString(value);
+        }
+
+        public string album
+        {
+            get => m_album;
+            [MemberNotNull(nameof(m_album))]
+            set => m_album = MakeValidMetadataString(value);
+        }
+
         public string year;
 
         public int difficulty;

--- a/YARG.Core/MoonscraperChartParser/MoonChart.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonChart.cs
@@ -103,12 +103,6 @@ namespace MoonscraperChartEditor.Song
         {
             bool success = SongObjectHelper.Remove(chartObject, _chartObjects);
 
-            if (success)
-            {
-                chartObject.chart = null;
-                chartObject.song = null;
-            }
-
             if (update)
                 UpdateCache();
 

--- a/YARG.Core/MoonscraperChartParser/MoonSong.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonSong.cs
@@ -144,7 +144,7 @@ namespace MoonscraperChartEditor.Song
         /// </summary>
         /// <param name="position">The tick position</param>
         /// <returns>Returns the value of the bpm that was found.</returns>
-        public BPM GetPrevBPM(uint position)
+        public BPM? GetPrevBPM(uint position)
         {
             return SongObjectHelper.GetPrevious(bpms, position);
         }
@@ -154,12 +154,12 @@ namespace MoonscraperChartEditor.Song
         /// </summary>
         /// <param name="position">The tick position</param>
         /// <returns>Returns the value of the time signature that was found.</returns>
-        public TimeSignature GetPrevTS(uint position)
+        public TimeSignature? GetPrevTS(uint position)
         {
             return SongObjectHelper.GetPrevious(timeSignatures, position);
         }
 
-        public Section GetPrevSection(uint position)
+        public Section? GetPrevSection(uint position)
         {
             return SongObjectHelper.GetPrevious(sections, position);
         }
@@ -223,11 +223,6 @@ namespace MoonscraperChartEditor.Song
                 success = SongObjectHelper.Remove(syncTrackObject, _syncTrack);
             }
 
-            if (success)
-            {
-                syncTrackObject.song = null;
-            }
-
             if (autoUpdate)
                 UpdateCache();
 
@@ -259,11 +254,6 @@ namespace MoonscraperChartEditor.Song
         {
             bool success = SongObjectHelper.Remove(eventObject, _events);
 
-            if (success)
-            {
-                eventObject.song = null;
-            }
-
             if (autoUpdate)
                 UpdateCache();
 
@@ -281,7 +271,7 @@ namespace MoonscraperChartEditor.Song
             {
                 if (objectToCache.GetType() == typeof(T))
                 {
-                    cacheObjectList.Add(objectToCache as T);
+                    cacheObjectList.Add((T) objectToCache);
                 }
             }
         }

--- a/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
@@ -194,7 +194,7 @@ namespace MoonscraperChartEditor.Song
             }
         }
 
-        private static T FindPreviousOfType<T>(System.Type type, int startPosition, IList<T> list) where T : SongObject
+        private static T? FindPreviousOfType<T>(System.Type type, int startPosition, IList<T> list) where T : SongObject
         {
             int pos = FindPreviousPosition(type, startPosition, list);
 
@@ -224,7 +224,7 @@ namespace MoonscraperChartEditor.Song
             }
         }
 
-        private static T FindNextOfType<T>(System.Type type, int startPosition, IList<T> list) where T : SongObject
+        private static T? FindNextOfType<T>(System.Type type, int startPosition, IList<T> list) where T : SongObject
         {
             int pos = FindNextPosition(type, startPosition, list);
             if (pos == NOTFOUND)
@@ -299,11 +299,9 @@ namespace MoonscraperChartEditor.Song
                 insertionPos = list.Count - 1;
             }
 
-            if ((SongObject.ID)item.classID == SongObject.ID.Note)
+            if ((SongObject.ID)item.classID == SongObject.ID.Note && list[insertionPos] is MoonNote current)
             {
                 // Update linked list
-                var current = list[insertionPos] as MoonNote;
-
                 var previous = FindPreviousOfType(typeof(MoonNote), insertionPos, list) as MoonNote;
                 var next = FindNextOfType(typeof(MoonNote), insertionPos, list) as MoonNote;
 
@@ -535,7 +533,7 @@ namespace MoonscraperChartEditor.Song
             return closestPos;
         }
 
-        public static T GetPrevious<T>(IList<T> songObjects, uint position) where T : SongObject
+        public static T? GetPrevious<T>(IList<T> songObjects, uint position) where T : SongObject
         {
             int pos = GetIndexOfPrevious(songObjects, position);
             if (pos != NOTFOUND)
@@ -544,7 +542,7 @@ namespace MoonscraperChartEditor.Song
                 return null;
         }
 
-        public static T GetPreviousNonInclusive<T>(IList<T> songObjects, uint position) where T : SongObject
+        public static T? GetPreviousNonInclusive<T>(IList<T> songObjects, uint position) where T : SongObject
         {
             int pos = GetIndexOfPrevious(songObjects, position);
             if (pos != NOTFOUND)
@@ -558,7 +556,7 @@ namespace MoonscraperChartEditor.Song
                 return null;
         }
 
-        public static T GetNextNonInclusive<T>(IList<T> songObjects, uint position) where T : SongObject
+        public static T? GetNextNonInclusive<T>(IList<T> songObjects, uint position) where T : SongObject
         {
             int pos = GetIndexOfNext(songObjects, position);
             if (pos != NOTFOUND)

--- a/YARG.Core/Replays/Replay.cs
+++ b/YARG.Core/Replays/Replay.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using YARG.Core.Game;
 using YARG.Core.Song;
@@ -49,6 +50,22 @@ namespace YARG.Core.Replays
 
         public ReplayFrame[] Frames;
 
+        public Replay()
+        {
+            SongName = string.Empty;
+            ArtistName = string.Empty;
+            CharterName = string.Empty;
+
+            ColorProfiles = Array.Empty<ColorProfile>();
+            PlayerNames = Array.Empty<string>();
+            Frames = Array.Empty<ReplayFrame>();
+        }
+
+        public Replay(BinaryReader reader, int version = 0)
+        {
+            Deserialize(reader, version);
+        }
+
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(SongName);
@@ -78,6 +95,12 @@ namespace YARG.Core.Replays
             }
         }
 
+        [MemberNotNull(nameof(SongName))]
+        [MemberNotNull(nameof(ArtistName))]
+        [MemberNotNull(nameof(CharterName))]
+        [MemberNotNull(nameof(ColorProfiles))]
+        [MemberNotNull(nameof(PlayerNames))]
+        [MemberNotNull(nameof(Frames))]
         public void Deserialize(BinaryReader reader, int version = 0)
         {
             SongName = reader.ReadString();

--- a/YARG.Core/Replays/ReplayFrame.cs
+++ b/YARG.Core/Replays/ReplayFrame.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using YARG.Core.Engine;
 using YARG.Core.Engine.Drums;
@@ -15,6 +17,18 @@ namespace YARG.Core.Replays
         public int                  InputCount;
         public GameInput[]          Inputs;
 
+        public ReplayFrame()
+        {
+            EngineParameters = new GuitarEngineParameters();
+            Stats = new GuitarStats();
+            Inputs = Array.Empty<GameInput>();
+        }
+
+        public ReplayFrame(BinaryReader reader, int version = 0)
+        {
+            Deserialize(reader, version);
+        }
+
         public void Serialize(BinaryWriter writer)
         {
             PlayerInfo.Serialize(writer);
@@ -30,10 +44,12 @@ namespace YARG.Core.Replays
             }
         }
 
+        [MemberNotNull(nameof(EngineParameters))]
+        [MemberNotNull(nameof(Stats))]
+        [MemberNotNull(nameof(Inputs))]
         public void Deserialize(BinaryReader reader, int version = 0)
         {
-            PlayerInfo = new ReplayPlayerInfo();
-            PlayerInfo.Deserialize(reader, version);
+            PlayerInfo = new ReplayPlayerInfo(reader, version);
 
             switch (PlayerInfo.Profile.Instrument.ToGameMode())
             {

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 
@@ -20,7 +21,9 @@ namespace YARG.Core.Replays
         // Some versions may be invalidated (such as significant format changes)
         private static readonly int[] InvalidVersions = { 0, 1, 2 };
 
-        public static ReplayReadResult ReadReplay(string path, out ReplayFile replayFile)
+        // note: [NotNullWhen(ReplayReadResult.Valid)] is not a valid form of [NotNullWhen],
+        // so replayFile will always be indicated as possibly being null
+        public static ReplayReadResult ReadReplay(string path, out ReplayFile? replayFile)
         {
             using var stream = File.OpenRead(path);
             using var reader = new BinaryReader(stream);

--- a/YARG.Core/Replays/ReplayPlayerInfo.cs
+++ b/YARG.Core/Replays/ReplayPlayerInfo.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using YARG.Core.Game;
 using YARG.Core.Utility;
@@ -10,6 +11,11 @@ namespace YARG.Core.Replays
         public int         ColorProfileId;
         public YargProfile Profile;
 
+        public ReplayPlayerInfo(BinaryReader reader, int version = 0) : this()
+        {
+            Deserialize(reader, version);
+        }
+
         public void Serialize(BinaryWriter writer)
         {
             writer.Write(PlayerId);
@@ -18,6 +24,7 @@ namespace YARG.Core.Replays
             Profile.Serialize(writer);
         }
 
+        [MemberNotNull(nameof(Profile))]
         public void Deserialize(BinaryReader reader, int version = 0)
         {
             PlayerId = reader.ReadInt32();

--- a/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song.Cache
 {
     public abstract class CONGroup

--- a/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song.Cache
 {
     public class PackedCONGroup : CONGroup, ICacheGroup, IModificationGroup

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song.Cache
 {
     public class UnpackedCONGroup : CONGroup, ICacheGroup

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Threading.Tasks;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song.Cache
 {
     public sealed partial class CacheHandler

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading.Tasks;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song.Cache
 {
     public sealed partial class CacheHandler

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using YARG.Core.Extensions;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song.Cache
 {
     public sealed partial class CacheHandler

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Threading.Tasks;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song.Cache
 {
     public enum ScanProgress

--- a/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader.cs
+++ b/YARG.Core/Song/Deserialization/TXTReader/YARGTXTReader.cs
@@ -6,7 +6,6 @@ using YARG.Core.Extensions;
 
 namespace YARG.Core.Song.Deserialization
 {
-#nullable enable
     public class YARGTXTReader : YARGTXTReader_Base<byte>, ITXTReader
     {
         private static readonly byte[] BOM_UTF8 = { 0xEF, 0xBB, 0xBF };

--- a/YARG.Core/Song/Deserialization/YARGBinaryReader.cs
+++ b/YARG.Core/Song/Deserialization/YARGBinaryReader.cs
@@ -15,7 +15,6 @@ namespace YARG.Core.Song.Deserialization
         BigEndian = 1,
     };
 
-#nullable enable
     public sealed class YARGBinaryReader
     {
         private readonly byte[] data;

--- a/YARG.Core/Song/Deserialization/YARGCONLoader.cs
+++ b/YARG.Core/Song/Deserialization/YARGCONLoader.cs
@@ -86,7 +86,7 @@ namespace YARG.Core.Song.Deserialization
         private const int BYTES_16BIT = 2;
 
         private const int BYTES_PER_BLOCK = 0x1000;
-#nullable enable
+
         public static CONFile? LoadCON(string filename)
         {
             byte[] buffer = new byte[BYTES_32BIT];

--- a/YARG.Core/Song/Deserialization/YARGMidiReader.cs
+++ b/YARG.Core/Song/Deserialization/YARGMidiReader.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text;
 using YARG.Core.Extensions;
@@ -159,6 +160,7 @@ namespace YARG.Core.Song.Deserialization
 
         public YARGMidiReader(string path) : this(new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read)) { }
 
+        [MemberNotNullWhen(true, nameof(trackReader))]
         private bool LoadTrack(Span<byte> tag)
         {
             Span<byte> tagBuffer = stackalloc byte[4];
@@ -279,6 +281,7 @@ namespace YARG.Core.Song.Deserialization
             note.velocity = trackReader.ReadByte();
         }
 
+        [MemberNotNull(nameof(trackReader))]
         private void ProcessHeaderChunk()
         {
             if (!LoadTrack(TRACKTAGS[0]))

--- a/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
@@ -83,7 +83,6 @@ namespace YARG.Core.Song
             _hash.Serialize(writer);
         }
 
-#nullable enable
         private static AbridgedFileInfo? ParseFileInfo(YARGBinaryReader reader)
         {
             return ParseFileInfo(reader.ReadLEBString(), reader);

--- a/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
@@ -21,7 +21,6 @@ namespace YARG.Core.Song
             Chart,
         };
 
-#nullable enable
         [Serializable]
         public sealed class IniSubmetadata
         {

--- a/YARG.Core/Song/Metadata/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongPackedRBCON.cs
@@ -6,7 +6,6 @@ using YARG.Core.Extensions;
 using YARG.Core.Song.Cache;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song
 {
     public sealed partial class SongMetadata

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -10,7 +10,6 @@ using YARG.Core.Song.Cache;
 using YARG.Core.Song.Deserialization;
 using YARG.Core.Song.Preparsers;
 
-#nullable enable
 namespace YARG.Core.Song
 {
     public sealed partial class SongMetadata

--- a/YARG.Core/Song/Metadata/SongMetadata.SongUnpackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongUnpackedRBCON.cs
@@ -6,7 +6,6 @@ using YARG.Core.Extensions;
 using YARG.Core.Song.Cache;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song
 {
     public sealed partial class SongMetadata

--- a/YARG.Core/Song/Metadata/SongMetadata.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.cs
@@ -2,7 +2,6 @@
 using System.Text.RegularExpressions;
 using YARG.Core.Chart;
 
-#nullable enable
 namespace YARG.Core.Song
 {
     public enum ScanResult

--- a/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
+++ b/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Text;
 using YARG.Core.Song.Deserialization;
 
-#nullable enable
 namespace YARG.Core.Song
 {
     public interface IRBProUpgrade

--- a/YARG.Core/YARG.Core.csproj
+++ b/YARG.Core/YARG.Core.csproj
@@ -11,6 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Melanchall.DryWetMidi.Nativeless" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="PolySharp" Version="1.13.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 

--- a/YARG.Core/YARG.Core.csproj
+++ b/YARG.Core/YARG.Core.csproj
@@ -5,6 +5,7 @@
     <LangVersion>9</LangVersion>
     <PublishRelease>true</PublishRelease>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
There might be a couple things I missed, but this should be pretty much everything according to the absence of warnings.

The [PolySharp](https://github.com/Sergio0694/PolySharp) package was brought in to polyfill some nullable analysis attributes that are missing from .NET Standard 2.1. This package also allows us to use C# 9 language features that rely on other missing attributes, such as init-only setters.