### PR TITLE
Rename *.Song.Deserialization to *.IO; some cleanup for it

### DIFF
--- a/YARG.Core/Extensions/CharacterExtensions.cs
+++ b/YARG.Core/Extensions/CharacterExtensions.cs
@@ -65,7 +65,7 @@ namespace YARG.Core.Extensions
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsAsciiWhitespace(this char c)
-            => c.IsAscii() && (uint) c <= 32;
+            => (uint) c <= 32;
         #endregion
 
         #region Latin1

--- a/YARG.Core/Extensions/CharacterExtensions.cs
+++ b/YARG.Core/Extensions/CharacterExtensions.cs
@@ -66,6 +66,14 @@ namespace YARG.Core.Extensions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsAsciiWhitespace(this char c)
             => (uint) c <= 32;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static char ToAsciiUpper(this char c)
+            => (char) (c & ~ASCII_LOWERCASE_FLAG);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static char ToAsciiLower(this char c)
+            => (char) (c | ASCII_LOWERCASE_FLAG);
         #endregion
 
         #region Latin1

--- a/YARG.Core/IO/Ini/IniHandler.cs
+++ b/YARG.Core/IO/Ini/IniHandler.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace YARG.Core.Song.Deserialization.Ini
+namespace YARG.Core.IO.Ini
 {
     public static class IniHandler
     {

--- a/YARG.Core/IO/Ini/IniHandler.cs
+++ b/YARG.Core/IO/Ini/IniHandler.cs
@@ -11,7 +11,7 @@ namespace YARG.Core.IO.Ini
         {
             try
             {
-                if (ITextReader.Load(File.ReadAllBytes(iniFile), out var reader))
+                if (YARGTextReader.Load(File.ReadAllBytes(iniFile), out var reader))
                     return ProcessIni<byte, ByteStringDecoder>(reader, sections);
                 return ProcessIni<char, CharStringDecoder>(reader, sections);
             }
@@ -22,7 +22,7 @@ namespace YARG.Core.IO.Ini
             }
         }
 
-        private static Dictionary<string, IniSection> ProcessIni<TType, TDecoder>(ITextReader textReader, Dictionary<string, Dictionary<string, IniModifierCreator>> sections)
+        private static Dictionary<string, IniSection> ProcessIni<TType, TDecoder>(IYARGTextReader textReader, Dictionary<string, Dictionary<string, IniModifierCreator>> sections)
             where TType : unmanaged, IEquatable<TType>, IConvertible
             where TDecoder : IStringDecoder<TType>, new()
         {

--- a/YARG.Core/IO/Ini/IniHandler.cs
+++ b/YARG.Core/IO/Ini/IniHandler.cs
@@ -11,7 +11,7 @@ namespace YARG.Core.IO.Ini
         {
             try
             {
-                if (ITXTReader.Load(File.ReadAllBytes(iniFile), out var reader))
+                if (ITextReader.Load(File.ReadAllBytes(iniFile), out var reader))
                     return ProcessIni<byte, ByteStringDecoder>(reader, sections);
                 return ProcessIni<char, CharStringDecoder>(reader, sections);
             }
@@ -22,13 +22,13 @@ namespace YARG.Core.IO.Ini
             }
         }
 
-        private static Dictionary<string, IniSection> ProcessIni<TType, TDecoder>(ITXTReader txtReader, Dictionary<string, Dictionary<string, IniModifierCreator>> sections)
+        private static Dictionary<string, IniSection> ProcessIni<TType, TDecoder>(ITextReader textReader, Dictionary<string, Dictionary<string, IniModifierCreator>> sections)
             where TType : unmanaged, IEquatable<TType>, IConvertible
             where TDecoder : IStringDecoder<TType>, new()
         {
             Dictionary<string, IniSection> modifierMap = new();
 
-            YARGIniReader<TType, TDecoder> iniReader = new(txtReader);
+            YARGIniReader<TType, TDecoder> iniReader = new(textReader);
             while (iniReader.TrySection(out string section))
             {
                 if (sections.TryGetValue(section, out var nodes))

--- a/YARG.Core/IO/Ini/IniModifier.cs
+++ b/YARG.Core/IO/Ini/IniModifier.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using YARG.Core.Song;
 
-namespace YARG.Core.Song.Deserialization.Ini
+namespace YARG.Core.IO.Ini
 {
     public enum ModifierType
     {

--- a/YARG.Core/IO/Ini/IniModifier.cs
+++ b/YARG.Core/IO/Ini/IniModifier.cs
@@ -18,7 +18,7 @@ namespace YARG.Core.IO.Ini
         UInt64,
         Int64,
         UInt32,
-        Int332,
+        Int32,
         UInt16,
         Int16,
         Bool,
@@ -77,7 +77,7 @@ namespace YARG.Core.IO.Ini
         }
         public IniModifier(int value)
         {
-            type = ModifierType.Int332;
+            type = ModifierType.Int32;
             union.i = value;
         }
         public IniModifier(ushort value)
@@ -196,13 +196,13 @@ namespace YARG.Core.IO.Ini
         {
             get
             {
-                if (type != ModifierType.Int332)
+                if (type != ModifierType.Int32)
                     throw new ArgumentException("Modifier is not a INT32");
                 return union.i;
             }
             set
             {
-                if (type != ModifierType.Int332)
+                if (type != ModifierType.Int32)
                     throw new ArgumentException("Modifier is not a INT32");
                 union.i = value;
             }

--- a/YARG.Core/IO/Ini/IniModifierCreator.cs
+++ b/YARG.Core/IO/Ini/IniModifierCreator.cs
@@ -37,7 +37,7 @@ namespace YARG.Core.IO.Ini
             this.type = type;
         }
 
-        public IniModifier CreateModifier(ITextReader reader)
+        public IniModifier CreateModifier(IYARGTextReader reader)
         {
             try
             {

--- a/YARG.Core/IO/Ini/IniModifierCreator.cs
+++ b/YARG.Core/IO/Ini/IniModifierCreator.cs
@@ -37,7 +37,7 @@ namespace YARG.Core.IO.Ini
             this.type = type;
         }
 
-        public IniModifier CreateModifier(ITXTReader reader)
+        public IniModifier CreateModifier(ITextReader reader)
         {
             try
             {

--- a/YARG.Core/IO/Ini/IniModifierCreator.cs
+++ b/YARG.Core/IO/Ini/IniModifierCreator.cs
@@ -5,7 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using YARG.Core.Song;
 
-namespace YARG.Core.Song.Deserialization.Ini
+namespace YARG.Core.IO.Ini
 {
     public enum ModifierCreatorType
     {

--- a/YARG.Core/IO/Ini/IniSection.cs
+++ b/YARG.Core/IO/Ini/IniSection.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using YARG.Core.Song;
 
-namespace YARG.Core.Song.Deserialization.Ini
+namespace YARG.Core.IO.Ini
 {
     public class IniSection
     {

--- a/YARG.Core/IO/Ini/YARGIniReader.cs
+++ b/YARG.Core/IO/Ini/YARGIniReader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using YARG.Core.Extensions;
 
 namespace YARG.Core.IO.Ini
 {
@@ -9,7 +10,7 @@ namespace YARG.Core.IO.Ini
     {
         private readonly YARGTextReader<TType, TDecoder> reader;
 
-        public YARGIniReader(ITextReader reader)
+        public YARGIniReader(IYARGTextReader reader)
         {
             this.reader = (YARGTextReader<TType, TDecoder>)reader;
         }
@@ -41,7 +42,7 @@ namespace YARG.Core.IO.Ini
                 while (point > position)
                 {
                     char character = reader.Data[point].ToChar(null);
-                    if (!ITextReader.IsWhitespace(character) || character == '\n')
+                    if (!character.IsAsciiWhitespace() || character == '\n')
                         break;
                     --point;
                 }

--- a/YARG.Core/IO/Ini/YARGIniReader.cs
+++ b/YARG.Core/IO/Ini/YARGIniReader.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace YARG.Core.Song.Deserialization.Ini
+namespace YARG.Core.IO.Ini
 {
     public sealed class YARGIniReader<TType, TDecoder>
         where TType : unmanaged, IEquatable<TType>, IConvertible

--- a/YARG.Core/IO/Ini/YARGIniReader.cs
+++ b/YARG.Core/IO/Ini/YARGIniReader.cs
@@ -7,11 +7,11 @@ namespace YARG.Core.IO.Ini
         where TType : unmanaged, IEquatable<TType>, IConvertible
         where TDecoder : IStringDecoder<TType>, new()
     {
-        private readonly YARGTXTReader<TType, TDecoder> reader;
+        private readonly YARGTextReader<TType, TDecoder> reader;
 
-        public YARGIniReader(ITXTReader reader)
+        public YARGIniReader(ITextReader reader)
         {
-            this.reader = (YARGTXTReader<TType, TDecoder>)reader;
+            this.reader = (YARGTextReader<TType, TDecoder>)reader;
         }
 
         public bool TrySection(out string section)
@@ -41,7 +41,7 @@ namespace YARG.Core.IO.Ini
                 while (point > position)
                 {
                     char character = reader.Data[point].ToChar(null);
-                    if (!ITXTReader.IsWhitespace(character) || character == '\n')
+                    if (!ITextReader.IsWhitespace(character) || character == '\n')
                         break;
                     --point;
                 }

--- a/YARG.Core/IO/TXTReader/ITXTReader.cs
+++ b/YARG.Core/IO/TXTReader/ITXTReader.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public interface ITXTReader
     {

--- a/YARG.Core/IO/TXTReader/YARGTXTReader.cs
+++ b/YARG.Core/IO/TXTReader/YARGTXTReader.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using YARG.Core.Extensions;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public interface IStringDecoder<TType>
         where TType : unmanaged

--- a/YARG.Core/IO/TXTReader/YARGTXTReader_Base.cs
+++ b/YARG.Core/IO/TXTReader/YARGTXTReader_Base.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public abstract class YARGTXTReader_Base<T>
         where T : IConvertible

--- a/YARG.Core/IO/TextReader/ITextReader.cs
+++ b/YARG.Core/IO/TextReader/ITextReader.cs
@@ -2,7 +2,7 @@
 
 namespace YARG.Core.IO
 {
-    public interface ITXTReader
+    public interface ITextReader
     {
         public static readonly Encoding Latin1 = Encoding.GetEncoding(28591);
         public const char SPACE_ASCII = (char) 32;
@@ -13,28 +13,28 @@ namespace YARG.Core.IO
 
         private static readonly UTF32Encoding UTF32BE = new(true, false);
 
-        public static bool Load(byte[] data, out ITXTReader reader)
+        public static bool Load(byte[] data, out ITextReader reader)
         {
             if (data[0] == 0xFF && data[1] == 0xFE)
             {
                 if (data[2] != 0)
-                    reader = new YARGTXTReader<char, CharStringDecoder>(Encoding.Unicode.GetChars(data, 2, data.Length - 2), 0);
+                    reader = new YARGTextReader<char, CharStringDecoder>(Encoding.Unicode.GetChars(data, 2, data.Length - 2), 0);
                 else
-                    reader = new YARGTXTReader<char, CharStringDecoder>(Encoding.UTF32.GetChars(data, 3, data.Length - 3), 0);
+                    reader = new YARGTextReader<char, CharStringDecoder>(Encoding.UTF32.GetChars(data, 3, data.Length - 3), 0);
                 return false;
             }
 
             if (data[0] == 0xFE && data[1] == 0xFF)
             {
                 if (data[2] != 0)
-                    reader = new YARGTXTReader<char, CharStringDecoder>(Encoding.BigEndianUnicode.GetChars(data, 2, data.Length - 2), 0);
+                    reader = new YARGTextReader<char, CharStringDecoder>(Encoding.BigEndianUnicode.GetChars(data, 2, data.Length - 2), 0);
                 else
-                    reader = new YARGTXTReader<char, CharStringDecoder>(UTF32BE.GetChars(data, 3, data.Length - 3), 0);
+                    reader = new YARGTextReader<char, CharStringDecoder>(UTF32BE.GetChars(data, 3, data.Length - 3), 0);
                 return false;
             }
 
             int position = data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF ? 3 : 0;
-            reader = new YARGTXTReader<byte, ByteStringDecoder>(data, position);
+            reader = new YARGTextReader<byte, ByteStringDecoder>(data, position);
             return true;
         }
 

--- a/YARG.Core/IO/TextReader/IYARGTextReader.cs
+++ b/YARG.Core/IO/TextReader/IYARGTextReader.cs
@@ -2,18 +2,39 @@
 
 namespace YARG.Core.IO
 {
-    public interface ITextReader
+    public interface IYARGTextReader
+    {
+        public bool ReadInt16(out short value);
+        public bool ReadUInt16(out ushort value);
+        public bool ReadInt32(out int value);
+        public bool ReadUInt32(out uint value);
+        public bool ReadInt64(out long value);
+        public bool ReadUInt64(out ulong value);
+
+        public bool ReadFloat(out float value);
+        public bool ReadDouble(out double value);
+
+        public bool ReadBoolean();
+
+        public short ReadInt16();
+        public ushort ReadUInt16();
+        public int ReadInt32();
+        public uint ReadUInt32();
+        public long ReadInt64();
+        public ulong ReadUInt64();
+
+        public float ReadFloat();
+        public double ReadDouble();
+
+        public string ExtractText(bool checkForQuotes = true);
+    }
+
+    public static class YARGTextReader
     {
         public static readonly Encoding Latin1 = Encoding.GetEncoding(28591);
-        public const char SPACE_ASCII = (char) 32;
-        public static bool IsWhitespace(char character)
-        {
-            return character <= SPACE_ASCII;
-        }
-
         private static readonly UTF32Encoding UTF32BE = new(true, false);
 
-        public static bool Load(byte[] data, out ITextReader reader)
+        public static bool Load(byte[] data, out IYARGTextReader reader)
         {
             if (data[0] == 0xFF && data[1] == 0xFE)
             {
@@ -37,41 +58,5 @@ namespace YARG.Core.IO
             reader = new YARGTextReader<byte, ByteStringDecoder>(data, position);
             return true;
         }
-
-        public bool ReadInt16(out short value);
-
-        public bool ReadUInt16(out ushort value);
-
-        public bool ReadInt32(out int value);
-
-        public bool ReadUInt32(out uint value);
-
-        public bool ReadInt64(out long value);
-
-        public bool ReadUInt64(out ulong value);
-
-        public bool ReadFloat(out float value);
-
-        public bool ReadDouble(out double value);
-
-        public bool ReadBoolean();
-
-        public short ReadInt16();
-
-        public ushort ReadUInt16();
-
-        public int ReadInt32();
-
-        public uint ReadUInt32();
-
-        public long ReadInt64();
-
-        public ulong ReadUInt64();
-
-        public float ReadFloat();
-
-        public double ReadDouble();
-
-        public string ExtractText(bool checkForQuotes = true);
     }
 }

--- a/YARG.Core/IO/TextReader/YARGTextReader.cs
+++ b/YARG.Core/IO/TextReader/YARGTextReader.cs
@@ -42,13 +42,13 @@ namespace YARG.Core.IO
         }
     }
 
-    public class YARGTXTReader<TType, TDecoder> : YARGTXTReader_Base<TType>, ITXTReader
+    public class YARGTextReader<TType, TDecoder> : YARGTextReader_Base<TType>, ITextReader
         where TType : unmanaged, IConvertible
         where TDecoder : IStringDecoder<TType>, new()
     {
         private TDecoder Decoder = new();
 
-        public YARGTXTReader(TType[] data, int position) : base(data)
+        public YARGTextReader(TType[] data, int position) : base(data)
         {
             _position = position;
 
@@ -63,7 +63,7 @@ namespace YARG.Core.IO
             while (_position < Length)
             {
                 char ch = Data[_position].ToChar(null);
-                if (ITXTReader.IsWhitespace(ch))
+                if (ITextReader.IsWhitespace(ch))
                 {
                     if (ch == '\n')
                         return ch;
@@ -117,7 +117,7 @@ namespace YARG.Core.IO
             if (checkForQuotes && Data[_position].ToChar(null) == '\"')
             {
                 int end = boundaries.Item2 - 1;
-                while (_position + 1 < end && ITXTReader.IsWhitespace(Data[end].ToChar(null)))
+                while (_position + 1 < end && ITextReader.IsWhitespace(Data[end].ToChar(null)))
                     --end;
 
                 if (_position < end && Data[end].ToChar(null) == '\"' && Data[end - 1].ToChar(null) != '\\')
@@ -130,7 +130,7 @@ namespace YARG.Core.IO
             if (boundaries.Item2 < boundaries.Item1)
                 return new();
 
-            while (boundaries.Item2 > boundaries.Item1 && ITXTReader.IsWhitespace(Data[boundaries.Item2 - 1].ToChar(null)))
+            while (boundaries.Item2 > boundaries.Item1 && ITextReader.IsWhitespace(Data[boundaries.Item2 - 1].ToChar(null)))
                 --boundaries.Item2;
 
             _position = _next;
@@ -146,7 +146,7 @@ namespace YARG.Core.IO
             }
             catch
             {
-                Decoder.SetEncoding(ITXTReader.Latin1);
+                Decoder.SetEncoding(ITextReader.Latin1);
                 return Decode(span);
             }
         }
@@ -157,7 +157,7 @@ namespace YARG.Core.IO
             while (curr < Length)
             {
                 char b = Data[curr].ToChar(null);
-                if (ITXTReader.IsWhitespace(b) || b == '=')
+                if (ITextReader.IsWhitespace(b) || b == '=')
                     break;
                 ++curr;
             }

--- a/YARG.Core/IO/TextReader/YARGTextReader.cs
+++ b/YARG.Core/IO/TextReader/YARGTextReader.cs
@@ -110,31 +110,31 @@ namespace YARG.Core.IO
 
         private ReadOnlySpan<TType> InternalExtractTextSpan(bool checkForQuotes = true)
         {
-            (int, int) boundaries = new(_position, _next);
-            if (Data[boundaries.Item2 - 1].ToChar(null) == '\r')
-                --boundaries.Item2;
+            (int position, int next) boundaries = (_position, _next);
+            if (Data[boundaries.next - 1].ToChar(null) == '\r')
+                --boundaries.next;
 
             if (checkForQuotes && Data[_position].ToChar(null) == '\"')
             {
-                int end = boundaries.Item2 - 1;
+                int end = boundaries.next - 1;
                 while (_position + 1 < end && Data[end].ToChar(null).IsAsciiWhitespace())
                     --end;
 
                 if (_position < end && Data[end].ToChar(null) == '\"' && Data[end - 1].ToChar(null) != '\\')
                 {
-                    ++boundaries.Item1;
-                    boundaries.Item2 = end;
+                    ++boundaries.position;
+                    boundaries.next = end;
                 }
             }
 
-            if (boundaries.Item2 < boundaries.Item1)
+            if (boundaries.next < boundaries.position)
                 return new();
 
-            while (boundaries.Item2 > boundaries.Item1 && Data[boundaries.Item2 - 1].ToChar(null).IsAsciiWhitespace())
-                --boundaries.Item2;
+            while (boundaries.next > boundaries.position && Data[boundaries.next - 1].ToChar(null).IsAsciiWhitespace())
+                --boundaries.next;
 
             _position = _next;
-            return new(Data, boundaries.Item1, boundaries.Item2 - boundaries.Item1);
+            return new(Data, boundaries.position, boundaries.next - boundaries.position);
         }
 
         public string ExtractText(bool checkForQuotes = true)

--- a/YARG.Core/IO/TextReader/YARGTextReader.cs
+++ b/YARG.Core/IO/TextReader/YARGTextReader.cs
@@ -42,7 +42,7 @@ namespace YARG.Core.IO
         }
     }
 
-    public class YARGTextReader<TType, TDecoder> : YARGTextReader_Base<TType>, ITextReader
+    public class YARGTextReader<TType, TDecoder> : YARGTextReader_Base<TType>, IYARGTextReader
         where TType : unmanaged, IConvertible
         where TDecoder : IStringDecoder<TType>, new()
     {
@@ -63,7 +63,7 @@ namespace YARG.Core.IO
             while (_position < Length)
             {
                 char ch = Data[_position].ToChar(null);
-                if (ITextReader.IsWhitespace(ch))
+                if (ch.IsAsciiWhitespace())
                 {
                     if (ch == '\n')
                         return ch;
@@ -117,7 +117,7 @@ namespace YARG.Core.IO
             if (checkForQuotes && Data[_position].ToChar(null) == '\"')
             {
                 int end = boundaries.Item2 - 1;
-                while (_position + 1 < end && ITextReader.IsWhitespace(Data[end].ToChar(null)))
+                while (_position + 1 < end && Data[end].ToChar(null).IsAsciiWhitespace())
                     --end;
 
                 if (_position < end && Data[end].ToChar(null) == '\"' && Data[end - 1].ToChar(null) != '\\')
@@ -130,7 +130,7 @@ namespace YARG.Core.IO
             if (boundaries.Item2 < boundaries.Item1)
                 return new();
 
-            while (boundaries.Item2 > boundaries.Item1 && ITextReader.IsWhitespace(Data[boundaries.Item2 - 1].ToChar(null)))
+            while (boundaries.Item2 > boundaries.Item1 && Data[boundaries.Item2 - 1].ToChar(null).IsAsciiWhitespace())
                 --boundaries.Item2;
 
             _position = _next;
@@ -146,7 +146,7 @@ namespace YARG.Core.IO
             }
             catch
             {
-                Decoder.SetEncoding(ITextReader.Latin1);
+                Decoder.SetEncoding(YARGTextReader.Latin1);
                 return Decode(span);
             }
         }
@@ -157,7 +157,7 @@ namespace YARG.Core.IO
             while (curr < Length)
             {
                 char b = Data[curr].ToChar(null);
-                if (ITextReader.IsWhitespace(b) || b == '=')
+                if (b.IsAsciiWhitespace() || b == '=')
                     break;
                 ++curr;
             }

--- a/YARG.Core/IO/TextReader/YARGTextReader_Base.cs
+++ b/YARG.Core/IO/TextReader/YARGTextReader_Base.cs
@@ -3,7 +3,7 @@ using System.Text;
 
 namespace YARG.Core.IO
 {
-    public abstract class YARGTXTReader_Base<T>
+    public abstract class YARGTextReader_Base<T>
         where T : IConvertible
     {
         public readonly T[] Data;
@@ -29,7 +29,7 @@ namespace YARG.Core.IO
             return Data[_position].ToChar(null).Equals(cmp);
         }
 
-        protected YARGTXTReader_Base(T[] data)
+        protected YARGTextReader_Base(T[] data)
         {
             Data = data;
             Length = data.Length;

--- a/YARG.Core/IO/TextReader/YARGTextReader_Base.cs
+++ b/YARG.Core/IO/TextReader/YARGTextReader_Base.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using YARG.Core.Extensions;
 
 namespace YARG.Core.IO
 {
@@ -42,7 +43,7 @@ namespace YARG.Core.IO
             while (_position < _next)
             {
                 char ch = Data[_position].ToChar(null);
-                if (ch < '0' || '9' < ch)
+                if (!ch.IsAsciiDigit())
                     break;
                 ++_position;
             }
@@ -144,10 +145,10 @@ namespace YARG.Core.IO
                 ch = Data[_position].ToChar(null);
             }
 
-            if (ch > '9' || (ch < '0' && ch != '.'))
+            if (!ch.IsAsciiDigit() && ch != '.')
                 return false;
 
-            while ('0' <= ch && ch <= '9')
+            while (ch.IsAsciiDigit())
             {
                 value *= 10;
                 value += ch - '0';
@@ -165,7 +166,7 @@ namespace YARG.Core.IO
                 {
                     double divisor = 1;
                     ch = Data[_position].ToChar(null);
-                    while ('0' <= ch && ch <= '9')
+                    while (ch.IsAsciiDigit())
                     {
                         divisor *= 10;
                         value += (ch - '0') / divisor;
@@ -192,10 +193,10 @@ namespace YARG.Core.IO
                 '0' => false,
                 '1' => true,
                 _ => _position + 4 <= _next &&
-                    (Data[_position].ToChar(null) == 't' || Data[_position].ToChar(null) == 'T') &&
-                    (Data[_position + 1].ToChar(null) == 'r' || Data[_position + 1].ToChar(null) == 'R') &&
-                    (Data[_position + 2].ToChar(null) == 'u' || Data[_position + 2].ToChar(null) == 'U') &&
-                    (Data[_position + 3].ToChar(null) == 'e' || Data[_position + 3].ToChar(null) == 'E'),
+                    (Data[_position].ToChar(null).ToAsciiLower() == 't') &&
+                    (Data[_position + 1].ToChar(null).ToAsciiLower() == 'r') &&
+                    (Data[_position + 2].ToChar(null).ToAsciiLower() == 'u') &&
+                    (Data[_position + 3].ToChar(null).ToAsciiLower() == 'e')
             };
         }
 
@@ -282,7 +283,7 @@ namespace YARG.Core.IO
                     break;
             }
 
-            if (ch < '0' || '9' < ch)
+            if (!ch.IsAsciiDigit())
                 return false;
 
             while (true)
@@ -293,7 +294,7 @@ namespace YARG.Core.IO
                 if (_position < _next)
                 {
                     ch = Data[_position].ToChar(null);
-                    if ('0' <= ch && ch <= '9')
+                    if (ch.IsAsciiDigit())
                     {
                         if (value < softMax || value == softMax && ch <= LAST_DIGIT_SIGNED)
                         {
@@ -329,7 +330,7 @@ namespace YARG.Core.IO
                 ch = Data[_position].ToChar(null);
             }
 
-            if (ch < '0' || '9' < ch)
+            if (!ch.IsAsciiDigit())
                 return false;
 
             while (true)
@@ -340,7 +341,7 @@ namespace YARG.Core.IO
                 if (_position < _next)
                 {
                     ch = Data[_position].ToChar(null);
-                    if ('0' <= ch && ch <= '9')
+                    if (ch.IsAsciiDigit())
                     {
                         if (value < softMax || value == softMax && ch <= LAST_DIGIT_UNSIGNED)
                         {

--- a/YARG.Core/IO/YARGBinaryReader.cs
+++ b/YARG.Core/IO/YARGBinaryReader.cs
@@ -7,7 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using YARG.Core.Extensions;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public enum Endianness
     {

--- a/YARG.Core/IO/YARGCONLoader.cs
+++ b/YARG.Core/IO/YARGCONLoader.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public enum CONFileListingFlag : byte
     {

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using YARG.Core.Song.Deserialization.Ini;
+using YARG.Core.IO.Ini;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public enum ChartEventType
     {

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using YARG.Core.Extensions;
 using YARG.Core.IO.Ini;
 
 namespace YARG.Core.IO
@@ -224,7 +225,7 @@ namespace YARG.Core.IO
         public NoteTracks_Chart Instrument => _instrument;
         public Difficulty Difficulty => _difficulty;
 
-        public YARGChartFileReader(ITextReader reader)
+        public YARGChartFileReader(IYARGTextReader reader)
         {
             this.reader = (YARGTextReader<TType, TDecoder>) reader;
         }
@@ -378,7 +379,7 @@ namespace YARG.Core.IO
                 while (point > position)
                 {
                     char character = reader.Data[point].ToChar(null);
-                    if (!ITextReader.IsWhitespace(character) || character == '\n')
+                    if (!character.IsAsciiWhitespace() || character == '\n')
                         break;
                     --point;
                 }

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -318,8 +318,6 @@ namespace YARG.Core.IO
             return true;
         }
 
-        private const int LOWER_CASE_MASK = ~32;
-
         public bool TryParseEvent(ref DotChartEvent ev)
         {
             if (!IsStillCurrentTrack())
@@ -331,8 +329,8 @@ namespace YARG.Core.IO
             int end = start;
             while (true)
             {
-                char curr = (char) (reader.Data[end].ToChar(null) & LOWER_CASE_MASK);
-                if (curr < 'A' || 'Z' < curr)
+                char curr = reader.Data[end].ToChar(null);
+                if (!curr.IsAsciiLetter())
                     break;
                 ++end;
             }

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -215,7 +215,7 @@ namespace YARG.Core.IO
     {
         private static readonly TBase CONFIG = default;
 
-        private readonly YARGTXTReader<TType, TDecoder> reader;
+        private readonly YARGTextReader<TType, TDecoder> reader;
 
         private DotChartEventCombo<TType>[] eventSet = Array.Empty<DotChartEventCombo<TType>>();
         private NoteTracks_Chart _instrument;
@@ -224,9 +224,9 @@ namespace YARG.Core.IO
         public NoteTracks_Chart Instrument => _instrument;
         public Difficulty Difficulty => _difficulty;
 
-        public YARGChartFileReader(ITXTReader reader)
+        public YARGChartFileReader(ITextReader reader)
         {
-            this.reader = (YARGTXTReader<TType, TDecoder>) reader;
+            this.reader = (YARGTextReader<TType, TDecoder>) reader;
         }
 
         public bool IsStartOfTrack()
@@ -378,7 +378,7 @@ namespace YARG.Core.IO
                 while (point > position)
                 {
                     char character = reader.Data[point].ToChar(null);
-                    if (!ITXTReader.IsWhitespace(character) || character == '\n')
+                    if (!ITextReader.IsWhitespace(character) || character == '\n')
                         break;
                     --point;
                 }

--- a/YARG.Core/IO/YARGDTAReader.cs
+++ b/YARG.Core/IO/YARGDTAReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using YARG.Core.Extensions;
 
 namespace YARG.Core.IO
 {
@@ -39,7 +40,7 @@ namespace YARG.Core.IO
                 _position += 2;
             }
             else
-                encoding = ITextReader.Latin1;
+                encoding = YARGTextReader.Latin1;
 
             SkipWhiteSpace();
         }
@@ -59,11 +60,11 @@ namespace YARG.Core.IO
             while (_position < Length)
             {
                 char ch = (char)Data[_position];
-                if (!ITextReader.IsWhitespace(ch) && ch != ';')
+                if (!ch.IsAsciiWhitespace() && ch != ';')
                     return ch;
 
                 ++_position;
-                if (!ITextReader.IsWhitespace(ch))
+                if (!ch.IsAsciiWhitespace())
                 {
                     while (_position < Length)
                     {
@@ -95,7 +96,7 @@ namespace YARG.Core.IO
             int start = _position;
             while (ch != '\'')
             {
-                if (ITextReader.IsWhitespace(ch))
+                if (ch.IsAsciiWhitespace())
                 {
                     if (hasApostrophe)
                         throw new Exception("Invalid name format");
@@ -145,7 +146,7 @@ namespace YARG.Core.IO
                     if (!inSquirley && !inQuotes)
                         throw new Exception("Text error - no apostrophes allowed");
                 }
-                else if (ITextReader.IsWhitespace(ch))
+                else if (ch.IsAsciiWhitespace())
                 {
                     if (inApostrophes)
                         throw new Exception("Text error - no whitespace allowed");

--- a/YARG.Core/IO/YARGDTAReader.cs
+++ b/YARG.Core/IO/YARGDTAReader.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public class YARGDTAReader : YARGTXTReader_Base<byte>
     {

--- a/YARG.Core/IO/YARGDTAReader.cs
+++ b/YARG.Core/IO/YARGDTAReader.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace YARG.Core.IO
 {
-    public class YARGDTAReader : YARGTXTReader_Base<byte>
+    public class YARGDTAReader : YARGTextReader_Base<byte>
     {
         private static readonly byte[] BOM_UTF8 = { 0xEF, 0xBB, 0xBF };
         private static readonly byte[] BOM_OTHER = { 0xFF, 0xFE };
@@ -39,7 +39,7 @@ namespace YARG.Core.IO
                 _position += 2;
             }
             else
-                encoding = ITXTReader.Latin1;
+                encoding = ITextReader.Latin1;
 
             SkipWhiteSpace();
         }
@@ -59,11 +59,11 @@ namespace YARG.Core.IO
             while (_position < Length)
             {
                 char ch = (char)Data[_position];
-                if (!ITXTReader.IsWhitespace(ch) && ch != ';')
+                if (!ITextReader.IsWhitespace(ch) && ch != ';')
                     return ch;
 
                 ++_position;
-                if (!ITXTReader.IsWhitespace(ch))
+                if (!ITextReader.IsWhitespace(ch))
                 {
                     while (_position < Length)
                     {
@@ -95,7 +95,7 @@ namespace YARG.Core.IO
             int start = _position;
             while (ch != '\'')
             {
-                if (ITXTReader.IsWhitespace(ch))
+                if (ITextReader.IsWhitespace(ch))
                 {
                     if (hasApostrophe)
                         throw new Exception("Invalid name format");
@@ -145,7 +145,7 @@ namespace YARG.Core.IO
                     if (!inSquirley && !inQuotes)
                         throw new Exception("Text error - no apostrophes allowed");
                 }
-                else if (ITXTReader.IsWhitespace(ch))
+                else if (ITextReader.IsWhitespace(ch))
                 {
                     if (inApostrophes)
                         throw new Exception("Text error - no whitespace allowed");

--- a/YARG.Core/IO/YARGMidiReader.cs
+++ b/YARG.Core/IO/YARGMidiReader.cs
@@ -6,7 +6,7 @@ using System.IO;
 using System.Text;
 using YARG.Core.Extensions;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public enum MidiEventType : byte
     {

--- a/YARG.Core/IO/YARGMoggStream.cs
+++ b/YARG.Core/IO/YARGMoggStream.cs
@@ -4,7 +4,7 @@ using System.IO;
 using System.Text;
 using YARG.Core.Extensions;
 
-namespace YARG.Core.Song.Deserialization
+namespace YARG.Core.IO
 {
     public class YargMoggReadStream : Stream
     {

--- a/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using YARG.Core.Extensions;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Cache/CacheNodes.cs
+++ b/YARG.Core/Song/Cache/CacheNodes.cs
@@ -2,7 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using YARG.Core.Extensions;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.Chart.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.Chart.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using YARG.Core.Chart;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 using YARG.Core.Song.Preparsers;
 
 namespace YARG.Core.Song

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.Midi.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.Midi.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text;
 using YARG.Core.Chart;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 using YARG.Core.Song.Preparsers;
 
 namespace YARG.Core.Song

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.RBCON.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.RBCON.cs
@@ -1,4 +1,4 @@
-﻿using YARG.Core.Song.Deserialization;
+﻿using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.SongIni.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.SongIni.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using YARG.Core.Song.Deserialization.Ini;
+using YARG.Core.IO.Ini;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using YARG.Core.Chart;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 using YARG.Core.Song.Preparsers;
 
 namespace YARG.Core.Song

--- a/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using YARG.Core.Song.Cache;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
@@ -203,7 +203,7 @@ namespace YARG.Core.Song
             _iniData = iniData;
         }
 
-        private static DrumsType ParseChart<TType, TBase, TDecoder>(ITextReader textReader, IniSection modifiers, AvailableParts parts)
+        private static DrumsType ParseChart<TType, TBase, TDecoder>(IYARGTextReader textReader, IniSection modifiers, AvailableParts parts)
             where TType : unmanaged, IEquatable<TType>, IConvertible
             where TBase : unmanaged, IDotChartBases<TType>
             where TDecoder : IStringDecoder<TType>, new()
@@ -262,7 +262,7 @@ namespace YARG.Core.Song
             DrumsType drumType = default;
             if (chartType == ChartType.Chart)
             {
-                if (ITextReader.Load(file, out var reader))
+                if (YARGTextReader.Load(file, out var reader))
                     drumType = ParseChart<byte, DotChartByte, ByteStringDecoder>(reader, modifiers, parts);
                 else
                     drumType = ParseChart<char, DotChartChar, CharStringDecoder>(reader, modifiers, parts);

--- a/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.IO;
 using YARG.Core.Chart;
 using YARG.Core.Song.Cache;
-using YARG.Core.Song.Deserialization;
-using YARG.Core.Song.Deserialization.Ini;
+using YARG.Core.IO;
+using YARG.Core.IO.Ini;
 using YARG.Core.Song.Preparsers;
 
 namespace YARG.Core.Song

--- a/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
@@ -203,12 +203,12 @@ namespace YARG.Core.Song
             _iniData = iniData;
         }
 
-        private static DrumsType ParseChart<TType, TBase, TDecoder>(ITXTReader txtReader, IniSection modifiers, AvailableParts parts)
+        private static DrumsType ParseChart<TType, TBase, TDecoder>(ITextReader textReader, IniSection modifiers, AvailableParts parts)
             where TType : unmanaged, IEquatable<TType>, IConvertible
             where TBase : unmanaged, IDotChartBases<TType>
             where TDecoder : IStringDecoder<TType>, new()
         {
-            YARGChartFileReader<TType, TBase, TDecoder> chartReader = new(txtReader);
+            YARGChartFileReader<TType, TBase, TDecoder> chartReader = new(textReader);
             if (!chartReader.ValidateHeaderTrack())
                 return DrumsType.Unknown;
 
@@ -262,7 +262,7 @@ namespace YARG.Core.Song
             DrumsType drumType = default;
             if (chartType == ChartType.Chart)
             {
-                if (ITXTReader.Load(file, out var reader))
+                if (ITextReader.Load(file, out var reader))
                     drumType = ParseChart<byte, DotChartByte, ByteStringDecoder>(reader, modifiers, parts);
                 else
                     drumType = ParseChart<char, DotChartChar, CharStringDecoder>(reader, modifiers, parts);

--- a/YARG.Core/Song/Metadata/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongPackedRBCON.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using YARG.Core.Extensions;
 using YARG.Core.Song.Cache;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -458,7 +458,7 @@ namespace YARG.Core.Song
                     case "encoding":
                         var encoding = reader.ExtractText().ToLower() switch
                         {
-                            "latin1" => ITextReader.Latin1,
+                            "latin1" => YARGTextReader.Latin1,
                             "utf-8" or
                             "utf8" => Encoding.UTF8,
                             _ => reader.encoding

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -7,7 +7,7 @@ using Melanchall.DryWetMidi.Core;
 using YARG.Core.Chart;
 using YARG.Core.Extensions;
 using YARG.Core.Song.Cache;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 using YARG.Core.Song.Preparsers;
 
 namespace YARG.Core.Song

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -458,7 +458,7 @@ namespace YARG.Core.Song
                     case "encoding":
                         var encoding = reader.ExtractText().ToLower() switch
                         {
-                            "latin1" => ITXTReader.Latin1,
+                            "latin1" => ITextReader.Latin1,
                             "utf-8" or
                             "utf8" => Encoding.UTF8,
                             _ => reader.encoding

--- a/YARG.Core/Song/Metadata/SongMetadata.SongUnpackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongUnpackedRBCON.cs
@@ -4,7 +4,7 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using YARG.Core.Extensions;
 using YARG.Core.Song.Cache;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Metadata/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Metadata/Types/HashWrapper.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Metadata/Types/RBCONDifficulties.cs
+++ b/YARG.Core/Song/Metadata/Types/RBCONDifficulties.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
+++ b/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Chart/ChartPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Chart/ChartPreparser.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/DrumPreparseHandler.cs
+++ b/YARG.Core/Song/Preparsers/DrumPreparseHandler.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using YARG.Core.Chart;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Preparsers
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiFiveFretPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiFiveFretPreparser.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiFiveLaneDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiFiveLaneDrumPreparser.cs
@@ -1,4 +1,4 @@
-﻿using YARG.Core.Song.Deserialization;
+﻿using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiFourLaneDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiFourLaneDrumPreparser.cs
@@ -1,5 +1,5 @@
 ﻿using YARG.Core.Chart;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiKeysPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiKeysPreparser.cs
@@ -1,4 +1,4 @@
-﻿using YARG.Core.Song.Deserialization;
+﻿using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiPreparser.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiProGuitarPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiProGuitarPreparser.cs
@@ -1,4 +1,4 @@
-﻿using YARG.Core.Song.Deserialization;
+﻿using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiProKeysPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiProKeysPreparser.cs
@@ -1,4 +1,4 @@
-﻿using YARG.Core.Song.Deserialization;
+﻿using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiSixFretPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiSixFretPreparser.cs
@@ -1,4 +1,4 @@
-﻿using YARG.Core.Song.Deserialization;
+﻿using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiUnknownDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiUnknownDrumPreparser.cs
@@ -1,5 +1,5 @@
 ﻿using YARG.Core.Chart;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {

--- a/YARG.Core/Song/Preparsers/Midi/MidiVocalPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiVocalPreparser.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using YARG.Core.Song.Deserialization;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {


### PR DESCRIPTION
Changed the namespace to reduce verbosity, and so that additional IO reading/writing types aren't stuck in the Song namespace, where they might not make sense.

Other changes:

- Renamed *TXTReader to *TextReader, C# conventions generally prefer full names over shortenings
- Renamed ITextReader to IYARGTextReader to match YARGTextReader, and for less ambiguity with System.IO.TextReader
- Moved IYARGTextReader statics into a dedicated YARGTextReader static class; putting statics in interfaces is unusual IMO
- Removed `YARGTextReader.IsWhitespace` and replaced its usages with `CharacterExtensions.IsAsciiWhitespace`
  - Also removed a redundant check in the latter
- Added names to `YARGTextReader.InternalExtractTextSpan`'s `boundaries` tuple
- Replaced some open-coded ASCII checks with character extension methods
- Fixed a typo in IniModifier:
  ```diff
  - ModifierType.Int332
  + ModifierType.Int32
  ```