### PR TITLE
Added the rest of the strobe settings

### DIFF
--- a/YARG.Core/Chart/Venue/LightingEvent.cs
+++ b/YARG.Core/Chart/Venue/LightingEvent.cs
@@ -54,8 +54,11 @@ namespace YARG.Core.Chart
         Silhouettes,
         Silhouettes_Spotlight,
         Searchlights,
+        Strobe_Fastest,
         Strobe_Fast,
+        Strobe_Medium,
         Strobe_Slow,
+        Strobe_Off,
         Sweep,
         Warm_Automatic,
 


### PR DESCRIPTION
So Strobe_Medium, Strobe_Fastest, and Strobe_Off are not used in ANY official chart. However, the stagekit hardware itself DOES actually support them so a charter in the future could use them, or an extended mode, a funky fresh mode that can step from slow to fast using medium, etc