### PR TITLE
Conversion of CacheHandler to a Static Class 

### DIFF
--- a/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
+++ b/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
@@ -5,7 +5,7 @@ namespace YARG.Core.UnitTests.Scanning
 {
     public class SongScanningTests
     {
-        private string[] songDirectories;
+        private List<string> songDirectories;
         private readonly bool MULTITHREADING = true;
         private static readonly string SongCachePath = Path.Combine(Environment.CurrentDirectory, "songcache.bin");
         private static readonly string BadSongsPath = Path.Combine(Environment.CurrentDirectory, "badsongs.txt");
@@ -13,21 +13,19 @@ namespace YARG.Core.UnitTests.Scanning
         [SetUp]
         public void Setup()
         {
-            List<string> directories = new()
+            songDirectories = new()
             {
                 
             };       
-            Assert.That(directories, Is.Not.Empty, "Add directories to scan for the test");
-            songDirectories = directories.ToArray();
+            Assert.That(songDirectories, Is.Not.Empty, "Add directories to scan for the test");
         }
 
         [TestCase]
         public void FullScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            CacheHandler handler = new(SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
-
-            var cache = handler.RunScan(false);
+            CacheHandler handler = new(songDirectories);
+            var cache = handler.RunScan(false, SongCachePath, BadSongsPath, MULTITHREADING);
             // TODO: Any cache properties we want to check here?
             // Currently the only fail condition would be an unhandled exception
         }
@@ -36,9 +34,8 @@ namespace YARG.Core.UnitTests.Scanning
         public void QuickScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            CacheHandler handler = new(SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
-
-            var cache = handler.RunScan(true);
+            CacheHandler handler = new(songDirectories);
+            var cache = handler.RunScan(true, SongCachePath, BadSongsPath, MULTITHREADING);
             // TODO: see above
         }
     }

--- a/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
+++ b/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
@@ -24,8 +24,8 @@ namespace YARG.Core.UnitTests.Scanning
         public void FullScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            CacheHandler handler = new(songDirectories);
-            var cache = handler.RunScan(false, SongCachePath, BadSongsPath, MULTITHREADING);
+            CacheHandler handler = new();
+            var cache = handler.RunScan(false, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
             // TODO: Any cache properties we want to check here?
             // Currently the only fail condition would be an unhandled exception
         }
@@ -34,8 +34,8 @@ namespace YARG.Core.UnitTests.Scanning
         public void QuickScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            CacheHandler handler = new(songDirectories);
-            var cache = handler.RunScan(true, SongCachePath, BadSongsPath, MULTITHREADING);
+            CacheHandler handler = new();
+            var cache = handler.RunScan(true, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
             // TODO: see above
         }
     }

--- a/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
+++ b/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
@@ -24,8 +24,7 @@ namespace YARG.Core.UnitTests.Scanning
         public void FullScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            CacheHandler handler = new();
-            var cache = handler.RunScan(false, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
+            var cache = CacheHandler.RunScan(false, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
             // TODO: Any cache properties we want to check here?
             // Currently the only fail condition would be an unhandled exception
         }
@@ -34,8 +33,7 @@ namespace YARG.Core.UnitTests.Scanning
         public void QuickScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            CacheHandler handler = new();
-            var cache = handler.RunScan(true, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
+            var cache = CacheHandler.RunScan(true, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
             // TODO: see above
         }
     }

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -51,7 +51,7 @@ namespace YARG.Core.Song.Cache
                     action(group.Key, group.Value);
             }
 
-            Progress = ScanProgress.LoadingSongs;
+            _progress.Stage = ScanStage.LoadingSongs;
             if (multithreading)
             {
                 ParallelLoop(iniGroups, ScanDirectory_Parallel);
@@ -215,6 +215,7 @@ namespace YARG.Core.Song.Cache
                     return false;
 
                 preScannedDirectories.Add(directory);
+                _progress.NumScannedDirectories++;
                 return true;
             }
         }
@@ -233,7 +234,11 @@ namespace YARG.Core.Song.Cache
 
         private void AddToBadSongs(string filePath, ScanResult err)
         {
-            lock (badsongsLock) badSongs.Add(filePath, err);
+            lock (badsongsLock)
+            {
+                badSongs.Add(filePath, err);
+                _progress.BadSongCount++;
+            }
         }
     }
 }

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -38,7 +38,7 @@ namespace YARG.Core.Song.Cache
             }
         }
 
-        private void FindNewEntries()
+        private void FindNewEntries(bool multithreading)
         {
             static void ParallelLoop<T>(Dictionary<string, T> groups, Action<string, T> action)
             {

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -150,7 +150,7 @@ namespace YARG.Core.Song.Cache
                 RunEntryTasks(stream, strings, ReadCONGroup);
                 RunEntryTasks(stream, strings, ReadExtractedCONGroup);
             }
-            YargTrace.DebugInfo($"Ini Entries read: {_count}");
+            YargTrace.DebugInfo($"Ini Entries read: {_progress.Count}");
         }
 
         private bool Deserialize_Quick(string cacheLocation, bool multithreading)
@@ -195,7 +195,7 @@ namespace YARG.Core.Song.Cache
             else
             {
                 RunEntryTasks(stream, strings, QuickReadIniGroup);
-                YargTrace.DebugInfo($"Ini Entries quick read: {_count}");
+                YargTrace.DebugInfo($"Ini Entries quick read: {_progress.Count}");
 
                 int count = stream.ReadInt32LE();
                 for (int i = 0; i < count; ++i)
@@ -209,13 +209,13 @@ namespace YARG.Core.Song.Cache
                 RunEntryTasks(stream, strings, QuickReadCONGroup);
                 RunEntryTasks(stream, strings, QuickReadExtractedCONGroup);
             }
-            YargTrace.DebugInfo($"Total Entries: {_count}");
+            YargTrace.DebugInfo($"Total Entries: {_progress.Count}");
             return true;
         }
 
         private void Serialize(string cacheLocation)
         {
-            Progress = ScanProgress.WritingCache;
+            _progress.Stage = ScanStage.WritingCache;
             using var writer = new BinaryWriter(new FileStream(cacheLocation, FileMode.Create, FileAccess.Write));
             Dictionary<SongMetadata, CategoryCacheWriteNode> nodes = new();
 
@@ -561,7 +561,11 @@ namespace YARG.Core.Song.Cache
 
         private void MarkDirectory(string directory)
         {
-            lock (dirLock) preScannedDirectories.Add(directory);
+            lock (dirLock)
+            {
+                preScannedDirectories.Add(directory);
+                _progress.NumScannedDirectories++;
+            }
         }
 
         private void MarkFile(string file)

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -85,7 +85,7 @@ namespace YARG.Core.Song.Cache
         /// </summary>
         private const int MIN_CACHEFILESIZE = 92;
 
-        private FileStream? CheckCacheFile()
+        private FileStream? CheckCacheFile(string cacheLocation)
         {
             FileInfo info = new(cacheLocation);
             if (!info.Exists || info.Length < MIN_CACHEFILESIZE)
@@ -104,10 +104,9 @@ namespace YARG.Core.Song.Cache
             return fs;
         }
 
-        private void Deserialize()
+        private void Deserialize(string cacheLocation, bool multithreading)
         {
-            Progress = ScanProgress.LoadingCache;
-            using var stream = CheckCacheFile();
+            using var stream = CheckCacheFile(cacheLocation);
             if (stream == null)
                 return;
 
@@ -154,10 +153,9 @@ namespace YARG.Core.Song.Cache
             YargTrace.DebugInfo($"Ini Entries read: {_count}");
         }
 
-        private bool Deserialize_Quick()
+        private bool Deserialize_Quick(string cacheLocation, bool multithreading)
         {
-            Progress = ScanProgress.LoadingCache;
-            using var stream = CheckCacheFile();
+            using var stream = CheckCacheFile(cacheLocation);
             if (stream == null)
                 return false;
 
@@ -215,7 +213,7 @@ namespace YARG.Core.Song.Cache
             return true;
         }
 
-        private void Serialize()
+        private void Serialize(string cacheLocation)
         {
             Progress = ScanProgress.WritingCache;
             using var writer = new BinaryWriter(new FileStream(cacheLocation, FileMode.Create, FileAccess.Write));


### PR DESCRIPTION
Converted `RunScan()` into a static function that creates a privately constructed handler and returns a SongCache. Extracted the tracker count and state values into a separate structure entirely that *can* be accessed outside of the CacheHandler class.

+ Requires an accompanying main repo update