### PR TITLE
Various utility things

### DIFF
--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
@@ -235,9 +235,8 @@ namespace YARG.Core.UnitTests.Parsing
                     case BPM bpm:
                         // MIDI stores tempo as microseconds per quarter note, so we need to convert
                         // Moonscraper already ties BPM to quarter notes, so no additional conversion is needed
-                        double secondsPerBeat = 60 / bpm.displayValue;
-                        double microseconds = secondsPerBeat * 1000 * 1000;
-                        timedEvents.Add((sync.tick, new SetTempoEvent((long)microseconds)));
+                        long microseconds = Chart.TempoChange.BpmToMicroSeconds(bpm.displayValue);
+                        timedEvents.Add((sync.tick, new SetTempoEvent(microseconds)));
                         break;
                     case TimeSignature ts:
                         timedEvents.Add((sync.tick, new TimeSignatureEvent((byte)ts.numerator, (byte)ts.denominator)));

--- a/YARG.Core/Chart/Sync/TempoChange.cs
+++ b/YARG.Core/Chart/Sync/TempoChange.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 
 namespace YARG.Core.Chart
 {
@@ -8,8 +9,8 @@ namespace YARG.Core.Chart
 
         public float BeatsPerMinute { get; }
         public float SecondsPerBeat => SECONDS_PER_MINUTE / BeatsPerMinute;
-        public long MilliSecondsPerBeat => (long) (SECONDS_PER_MINUTE / BeatsPerMinute * 1000);
-        public long MicroSecondsPerBeat => (long) (SECONDS_PER_MINUTE / BeatsPerMinute * 1000 * 1000);
+        public long MilliSecondsPerBeat => BpmToMicroSeconds(BeatsPerMinute) / 1000;
+        public long MicroSecondsPerBeat => BpmToMicroSeconds(BeatsPerMinute);
 
         public TempoChange(float tempo, double time, uint tick) : base(time, tick)
         {
@@ -19,6 +20,22 @@ namespace YARG.Core.Chart
         public TempoChange Clone()
         {
             return new(BeatsPerMinute, Time, Tick);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static long BpmToMicroSeconds(float tempo)
+        {
+            double secondsPerBeat = SECONDS_PER_MINUTE / tempo;
+            double microseconds = secondsPerBeat * 1000 * 1000;
+            return (long) microseconds;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float MicroSecondsToBpm(long usecs)
+        {
+            double secondsPerBeat = usecs / 1000f / 1000f;
+            double tempo = SECONDS_PER_MINUTE / secondsPerBeat;
+            return (float) tempo;
         }
     }
 }

--- a/YARG.Core/Extensions/MemoryExtensions.cs
+++ b/YARG.Core/Extensions/MemoryExtensions.cs
@@ -1,0 +1,54 @@
+using System;
+
+namespace YARG.Core.Extensions
+{
+    public static class MemoryExtensions
+    {
+        public static string ToHexString(this byte[] buffer, bool dashes = true)
+            => ToHexString(buffer.AsSpan(), dashes);
+
+        public static string ToHexString(this ReadOnlyMemory<byte> buffer, bool dashes = true)
+            => ToHexString(buffer.Span, dashes);
+
+        public static string ToHexString(this ReadOnlySpan<byte> buffer, bool dashes = true)
+        {
+            const string characters = "0123456789ABCDEF";
+
+            if (buffer.IsEmpty)
+                return "";
+
+            if (dashes)
+            {
+                const int charsPerByte = 3;
+                Span<char> stringBuffer = stackalloc char[buffer.Length * charsPerByte];
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    byte value = buffer[i];
+                    int stringIndex = i * charsPerByte;
+                    stringBuffer[stringIndex] = characters[(value & 0xF0) >> 4];
+                    stringBuffer[stringIndex + 1] = characters[value & 0x0F];
+                    stringBuffer[stringIndex + 2] = '-';
+                }
+
+                // Exclude last '-'
+                stringBuffer = stringBuffer[..^1];
+
+                return new string(stringBuffer);
+            }
+            else
+            {
+                const int charsPerByte = 2;
+                Span<char> stringBuffer = stackalloc char[buffer.Length * charsPerByte];
+                for (int i = 0; i < buffer.Length; i++)
+                {
+                    byte value = buffer[i];
+                    int stringIndex = i * charsPerByte;
+                    stringBuffer[stringIndex] = characters[(value & 0xF0) >> 4];
+                    stringBuffer[stringIndex + 1] = characters[value & 0x0F];
+                }
+
+                return new string(stringBuffer);
+            }
+        }
+    }
+}

--- a/YARG.Core/Extensions/StreamExtensions.cs
+++ b/YARG.Core/Extensions/StreamExtensions.cs
@@ -1,22 +1,117 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.IO;
 
 namespace YARG.Core.Extensions
 {
     public static class StreamExtensions
     {
+        public static short ReadInt16LE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            if (s.Read(buffer) != sizeof(short))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
+
+            return BinaryPrimitives.ReadInt16LittleEndian(buffer);
+        }
+
+        public static short ReadInt16BE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            if (s.Read(buffer) != sizeof(short))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
+
+            return BinaryPrimitives.ReadInt16BigEndian(buffer);
+        }
+
+        public static ushort ReadUInt16LE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            if (s.Read(buffer) != sizeof(ushort))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
+
+            return BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+        }
+
+        public static ushort ReadUInt16BE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            if (s.Read(buffer) != sizeof(ushort))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
+
+            return BinaryPrimitives.ReadUInt16BigEndian(buffer);
+        }
+
         public static int ReadInt32LE(this Stream s)
         {
-            Span<byte> buffer = stackalloc byte[4];
-            s.Read(buffer);
-            return buffer[3] << 24 | buffer[2] << 16 | buffer[1] << 8 | buffer[0];
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            if (s.Read(buffer) != sizeof(int))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
+
+            return BinaryPrimitives.ReadInt32LittleEndian(buffer);
         }
 
         public static int ReadInt32BE(this Stream s)
         {
-            Span<byte> buffer = stackalloc byte[4];
-            s.Read(buffer);
-            return buffer[0] << 24 | buffer[1] << 16 | buffer[2] << 8 | buffer[3];
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            if (s.Read(buffer) != sizeof(int))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
+
+            return BinaryPrimitives.ReadInt32BigEndian(buffer);
+        }
+
+        public static uint ReadUInt32LE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            if (s.Read(buffer) != sizeof(uint))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
+
+            return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+        }
+
+        public static uint ReadUInt32BE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            if (s.Read(buffer) != sizeof(uint))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
+
+            return BinaryPrimitives.ReadUInt32BigEndian(buffer);
+        }
+
+        public static long ReadInt64LE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            if (s.Read(buffer) != sizeof(long))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
+
+            return BinaryPrimitives.ReadInt64LittleEndian(buffer);
+        }
+
+        public static long ReadInt64BE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            if (s.Read(buffer) != sizeof(long))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
+
+            return BinaryPrimitives.ReadInt64BigEndian(buffer);
+        }
+
+        public static ulong ReadUInt64LE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            if (s.Read(buffer) != sizeof(ulong))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
+
+            return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+        }
+
+        public static ulong ReadUInt64BE(this Stream s)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            if (s.Read(buffer) != sizeof(ulong))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
+
+            return BinaryPrimitives.ReadUInt64BigEndian(buffer);
         }
 
         public static byte[] ReadBytes(this Stream s, int length)

--- a/YARG.Core/Extensions/StreamExtensions.cs
+++ b/YARG.Core/Extensions/StreamExtensions.cs
@@ -6,119 +6,403 @@ namespace YARG.Core.Extensions
 {
     public static class StreamExtensions
     {
-        public static short ReadInt16LE(this Stream s)
+        #region Stream
+        public static short ReadInt16LE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(short)];
-            if (s.Read(buffer) != sizeof(short))
+            if (stream.Read(buffer) != sizeof(short))
                 throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
 
             return BinaryPrimitives.ReadInt16LittleEndian(buffer);
         }
 
-        public static short ReadInt16BE(this Stream s)
+        public static short ReadInt16BE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(short)];
-            if (s.Read(buffer) != sizeof(short))
+            if (stream.Read(buffer) != sizeof(short))
                 throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
 
             return BinaryPrimitives.ReadInt16BigEndian(buffer);
         }
 
-        public static ushort ReadUInt16LE(this Stream s)
+        public static ushort ReadUInt16LE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            if (s.Read(buffer) != sizeof(ushort))
+            if (stream.Read(buffer) != sizeof(ushort))
                 throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
 
             return BinaryPrimitives.ReadUInt16LittleEndian(buffer);
         }
 
-        public static ushort ReadUInt16BE(this Stream s)
+        public static ushort ReadUInt16BE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            if (s.Read(buffer) != sizeof(ushort))
+            if (stream.Read(buffer) != sizeof(ushort))
                 throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
 
             return BinaryPrimitives.ReadUInt16BigEndian(buffer);
         }
 
-        public static int ReadInt32LE(this Stream s)
+        public static int ReadInt32LE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(int)];
-            if (s.Read(buffer) != sizeof(int))
+            if (stream.Read(buffer) != sizeof(int))
                 throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
 
             return BinaryPrimitives.ReadInt32LittleEndian(buffer);
         }
 
-        public static int ReadInt32BE(this Stream s)
+        public static int ReadInt32BE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(int)];
-            if (s.Read(buffer) != sizeof(int))
+            if (stream.Read(buffer) != sizeof(int))
                 throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
 
             return BinaryPrimitives.ReadInt32BigEndian(buffer);
         }
 
-        public static uint ReadUInt32LE(this Stream s)
+        public static uint ReadUInt32LE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            if (s.Read(buffer) != sizeof(uint))
+            if (stream.Read(buffer) != sizeof(uint))
                 throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
 
             return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
         }
 
-        public static uint ReadUInt32BE(this Stream s)
+        public static uint ReadUInt32BE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            if (s.Read(buffer) != sizeof(uint))
+            if (stream.Read(buffer) != sizeof(uint))
                 throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
 
             return BinaryPrimitives.ReadUInt32BigEndian(buffer);
         }
 
-        public static long ReadInt64LE(this Stream s)
+        public static long ReadInt64LE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(long)];
-            if (s.Read(buffer) != sizeof(long))
+            if (stream.Read(buffer) != sizeof(long))
                 throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
 
             return BinaryPrimitives.ReadInt64LittleEndian(buffer);
         }
 
-        public static long ReadInt64BE(this Stream s)
+        public static long ReadInt64BE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(long)];
-            if (s.Read(buffer) != sizeof(long))
+            if (stream.Read(buffer) != sizeof(long))
                 throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
 
             return BinaryPrimitives.ReadInt64BigEndian(buffer);
         }
 
-        public static ulong ReadUInt64LE(this Stream s)
+        public static ulong ReadUInt64LE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            if (s.Read(buffer) != sizeof(ulong))
+            if (stream.Read(buffer) != sizeof(ulong))
                 throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
 
             return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
         }
 
-        public static ulong ReadUInt64BE(this Stream s)
+        public static ulong ReadUInt64BE(this Stream stream)
         {
             Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            if (s.Read(buffer) != sizeof(ulong))
+            if (stream.Read(buffer) != sizeof(ulong))
                 throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
 
             return BinaryPrimitives.ReadUInt64BigEndian(buffer);
         }
 
-        public static byte[] ReadBytes(this Stream s, int length)
+        public static byte[] ReadBytes(this Stream stream, int length)
         {
             byte[] buffer = new byte[length];
-            s.Read(buffer, 0, length);
+            if (stream.Read(buffer, 0, length) != length)
+                throw new EndOfStreamException($"Not enough data in the buffer to read {length} bytes!");
+
             return buffer;
         }
+
+        public static void WriteInt16LE(this Stream stream, short value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteInt16BE(this Stream stream, short value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            BinaryPrimitives.WriteInt16BigEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteUInt16LE(this Stream stream, ushort value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteUInt16BE(this Stream stream, ushort value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            BinaryPrimitives.WriteUInt16BigEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteInt32LE(this Stream stream, int value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteInt32BE(this Stream stream, int value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32BigEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteUInt32LE(this Stream stream, uint value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteUInt32BE(this Stream stream, uint value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteInt64LE(this Stream stream, long value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteInt64BE(this Stream stream, long value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64BigEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteUInt64LE(this Stream stream, ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+            stream.Write(buffer);
+        }
+
+        public static void WriteUInt64BE(this Stream stream, ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64BigEndian(buffer, value);
+            stream.Write(buffer);
+        }
+        #endregion
+
+        #region BinaryReader
+        public static short ReadInt16LE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            if (reader.Read(buffer) != sizeof(short))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
+
+            return BinaryPrimitives.ReadInt16LittleEndian(buffer);
+        }
+
+        public static short ReadInt16BE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            if (reader.Read(buffer) != sizeof(short))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
+
+            return BinaryPrimitives.ReadInt16BigEndian(buffer);
+        }
+
+        public static ushort ReadUInt16LE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            if (reader.Read(buffer) != sizeof(ushort))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
+
+            return BinaryPrimitives.ReadUInt16LittleEndian(buffer);
+        }
+
+        public static ushort ReadUInt16BE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            if (reader.Read(buffer) != sizeof(ushort))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
+
+            return BinaryPrimitives.ReadUInt16BigEndian(buffer);
+        }
+
+        public static int ReadInt32LE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            if (reader.Read(buffer) != sizeof(int))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
+
+            return BinaryPrimitives.ReadInt32LittleEndian(buffer);
+        }
+
+        public static int ReadInt32BE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            if (reader.Read(buffer) != sizeof(int))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
+
+            return BinaryPrimitives.ReadInt32BigEndian(buffer);
+        }
+
+        public static uint ReadUInt32LE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            if (reader.Read(buffer) != sizeof(uint))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
+
+            return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
+        }
+
+        public static uint ReadUInt32BE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            if (reader.Read(buffer) != sizeof(uint))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
+
+            return BinaryPrimitives.ReadUInt32BigEndian(buffer);
+        }
+
+        public static long ReadInt64LE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            if (reader.Read(buffer) != sizeof(long))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
+
+            return BinaryPrimitives.ReadInt64LittleEndian(buffer);
+        }
+
+        public static long ReadInt64BE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            if (reader.Read(buffer) != sizeof(long))
+                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
+
+            return BinaryPrimitives.ReadInt64BigEndian(buffer);
+        }
+
+        public static ulong ReadUInt64LE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            if (reader.Read(buffer) != sizeof(ulong))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
+
+            return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
+        }
+
+        public static ulong ReadUInt64BE(this BinaryReader reader)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            if (reader.Read(buffer) != sizeof(ulong))
+                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
+
+            return BinaryPrimitives.ReadUInt64BigEndian(buffer);
+        }
+        #endregion
+
+        #region BinaryWriter
+        public static void WriteInt16LE(this BinaryWriter writer, short value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteInt16BE(this BinaryWriter writer, short value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(short)];
+            BinaryPrimitives.WriteInt16BigEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteUInt16LE(this BinaryWriter writer, ushort value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteUInt16BE(this BinaryWriter writer, ushort value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
+            BinaryPrimitives.WriteUInt16BigEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteInt32LE(this BinaryWriter writer, int value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteInt32BE(this BinaryWriter writer, int value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(int)];
+            BinaryPrimitives.WriteInt32BigEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteUInt32LE(this BinaryWriter writer, uint value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteUInt32BE(this BinaryWriter writer, uint value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(uint)];
+            BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteInt64LE(this BinaryWriter writer, long value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteInt64BE(this BinaryWriter writer, long value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(long)];
+            BinaryPrimitives.WriteInt64BigEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteUInt64LE(this BinaryWriter writer, ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
+            writer.Write(buffer);
+        }
+
+        public static void WriteUInt64BE(this BinaryWriter writer, ulong value)
+        {
+            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+            BinaryPrimitives.WriteUInt64BigEndian(buffer, value);
+            writer.Write(buffer);
+        }
+        #endregion
     }
 }

--- a/YARG.Core/IO/CharacterCodes.cs
+++ b/YARG.Core/IO/CharacterCodes.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Buffers.Binary;
+using System.IO;
+using System.Runtime.CompilerServices;
+using YARG.Core.Extensions;
+using YARG.Core.Utility;
+
+namespace YARG.Core.IO
+{
+    /// <summary>
+    /// A four-byte identifier ("four-character code") used to identify data formats.
+    /// </summary>
+    /// <remarks>
+    /// These are read and written in big-endian, so that the characters used are
+    /// human-readable in a hex editor, for example.
+    /// </remarks>
+    public readonly struct FourCC : IBinarySerializable
+    {
+        private readonly uint _code;
+
+        private FourCC(uint code)
+        {
+            _code = code;
+        }
+
+        public FourCC(char a, char b, char c, char d)
+            : this((byte) a, (byte) b, (byte) c, (byte) d) {}
+
+        public FourCC(byte a, byte b, byte c, byte d)
+        {
+            _code = ((uint) a << 24) | ((uint) b << 16) | ((uint) c << 8) | d;
+        }
+
+        public FourCC(ReadOnlySpan<byte> data)
+        {
+            _code = BinaryPrimitives.ReadUInt32BigEndian(data);
+        }
+
+        public static FourCC Read(Stream stream) => new(stream.ReadUInt32BE());
+        public static FourCC Read(BinaryReader reader) => new(reader.ReadUInt32BE());
+        public static FourCC Read(YARGBinaryReader reader) => new(reader.ReadUInt32(Endianness.BigEndian));
+
+        public void Serialize(BinaryWriter writer)
+        {
+            writer.WriteUInt32BE(_code);
+        }
+
+        [Obsolete("FourCC is a readonly struct, use the Read static method instead.", true)]
+        public void Deserialize(BinaryReader reader, int version = 0)
+            => throw new InvalidOperationException("FourCC is a readonly struct, use the Read static method instead.");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(FourCC left, FourCC right) => left._code == right._code;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(FourCC left, FourCC right) => left._code != right._code;
+
+        public bool Equals(FourCC other) => this == other;
+        public override bool Equals(object obj) => obj is FourCC cc && Equals(cc);
+        public override int GetHashCode() => _code.GetHashCode();
+
+        public override string ToString()
+        {
+            char a = (char) ((_code >> 24) & 0xFF);
+            char b = (char) ((_code >> 16) & 0xFF);
+            char c = (char) ((_code >> 8) & 0xFF);
+            char d = (char) (_code & 0xFF);
+            return $"{a}{b}{c}{d}";
+        }
+    }
+
+    /// <summary>
+    /// An eight-byte identifier ("eight-character code") used to identify data formats.
+    /// </summary>
+    /// <remarks>
+    /// These are read and written in big-endian, so that the characters used are
+    /// human-readable in a hex editor, for example.
+    /// </remarks>
+    public readonly struct EightCC : IBinarySerializable
+    {
+        private readonly ulong _code;
+
+        private EightCC(ulong code)
+        {
+            _code = code;
+        }
+
+        public EightCC(char a, char b, char c, char d, char e, char f, char g, char h)
+            : this((byte) a, (byte) b, (byte) c, (byte) d, (byte) e, (byte) f, (byte) g, (byte) h) {}
+
+        public EightCC(byte a, byte b, byte c, byte d, byte e, byte f, byte g, byte h)
+        {
+            _code = ((ulong) a << 56) | ((ulong) b << 48) | ((ulong) c << 40) | ((ulong) d << 32) |
+                ((ulong) e << 24) | ((ulong) f << 16) | ((ulong) g << 8) | h;
+        }
+
+        public EightCC(ReadOnlySpan<byte> data)
+        {
+            _code = BinaryPrimitives.ReadUInt64BigEndian(data);
+        }
+
+        public static EightCC Read(Stream stream) => new(stream.ReadUInt64BE());
+        public static EightCC Read(BinaryReader reader) => new(reader.ReadUInt64BE());
+        public static EightCC Read(YARGBinaryReader reader) => new(reader.ReadUInt64(Endianness.BigEndian));
+
+        public void Serialize(BinaryWriter writer)
+        {
+            writer.WriteUInt64BE(_code);
+        }
+
+        [Obsolete("EightCC is a readonly struct, use the Read static method instead.", true)]
+        public void Deserialize(BinaryReader reader, int version = 0)
+            => throw new InvalidOperationException("EightCC is a readonly struct, use the Read static method instead.");
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator ==(EightCC left, EightCC right) => left._code == right._code;
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool operator !=(EightCC left, EightCC right) => left._code != right._code;
+
+        public bool Equals(EightCC other) => this == other;
+        public override bool Equals(object obj) => obj is EightCC cc && Equals(cc);
+        public override int GetHashCode() => _code.GetHashCode();
+
+        public override string ToString()
+        {
+            char a = (char) ((_code >> 56) & 0xFF);
+            char b = (char) ((_code >> 48) & 0xFF);
+            char c = (char) ((_code >> 40) & 0xFF);
+            char d = (char) ((_code >> 32) & 0xFF);
+            char e = (char) ((_code >> 24) & 0xFF);
+            char f = (char) ((_code >> 16) & 0xFF);
+            char g = (char) ((_code >> 8) & 0xFF);
+            char h = (char) (_code & 0xFF);
+            return $"{a}{b}{c}{d}{e}{f}{g}{h}";
+        }
+    }
+}

--- a/YARG.Core/IO/ConHandler/CONFileHandler.cs
+++ b/YARG.Core/IO/ConHandler/CONFileHandler.cs
@@ -7,6 +7,10 @@ namespace YARG.Core.IO
 {
     public static class CONFileHandler
     {
+        private static readonly FourCC CON_TAG = new('C', 'O', 'N', ' ');
+        private static readonly FourCC LIVE_TAG = new('L', 'I', 'V', 'E');
+        private static readonly FourCC PIRS_TAG = new('P', 'I', 'R', 'S');
+
         private const int METADATA_POSITION = 0x340;
         private const int FILETABLEBLOCKCOUNT_POSITION = 0x37C;
         private const int FILETABLEFIRSTBLOCK_POSITION = 0x37E;
@@ -25,8 +29,8 @@ namespace YARG.Core.IO
             if (stream.Read(int32Buffer) != BYTES_32BIT)
                 return null;
 
-            string tag = Encoding.Default.GetString(int32Buffer);
-            if (tag != "CON " && tag != "LIVE" && tag != "PIRS")
+            var tag = new FourCC(int32Buffer);
+            if (tag != CON_TAG && tag != LIVE_TAG && tag != PIRS_TAG)
                 return null;
 
             stream.Seek(METADATA_POSITION, SeekOrigin.Begin);

--- a/YARG.Core/IO/YARGBinaryReader.cs
+++ b/YARG.Core/IO/YARGBinaryReader.cs
@@ -62,20 +62,6 @@ namespace YARG.Core.IO
             baseReader._position += length;
         }
 
-        public bool CompareTag(byte[] tag)
-        {
-            var span = memory.Span;
-            Debug.Assert(tag.Length == 4);
-            if (tag[0] != span[_position] ||
-                tag[1] != span[_position + 1] ||
-                tag[2] != span[_position + 2] ||
-                tag[3] != span[_position + 3])
-                return false;
-
-            _position += 4;
-            return true;
-        }
-
         public void Move_Unsafe(int amount)
         {
             _position += amount;

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -535,7 +535,7 @@ namespace MoonscraperChartEditor.Song.IO
             if (!PhaseShiftSysEx.TryParse(sysex, out var psEvent))
             {
                 // SysEx event is not a Phase Shift SysEx event
-                YargTrace.DebugWarning($"Encountered unknown SysEx event at tick {absoluteTick}: {BitConverter.ToString(sysex.Data)}");
+                YargTrace.DebugWarning($"Encountered unknown SysEx event at tick {absoluteTick}: {sysex.Data.ToHexString()}");
                 return;
             }
 

--- a/YARG.Core/Replays/Replay.cs
+++ b/YARG.Core/Replays/Replay.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using YARG.Core.Game;
+using YARG.Core.IO;
 using YARG.Core.Song;
 using YARG.Core.Utility;
 
@@ -9,14 +10,14 @@ namespace YARG.Core.Replays
 {
     public class ReplayHeader : IBinarySerializable
     {
-        public long        Magic;
+        public EightCC     Magic;
         public int         ReplayVersion;
         public int         EngineVersion;
         public HashWrapper ReplayChecksum;
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.Write(Magic);
+            Magic.Serialize(writer);
             writer.Write(ReplayVersion);
             writer.Write(EngineVersion);
 
@@ -25,7 +26,7 @@ namespace YARG.Core.Replays
 
         public void Deserialize(BinaryReader reader, int version = 0)
         {
-            Magic = reader.ReadInt64();
+            Magic = EightCC.Read(reader);
             ReplayVersion = reader.ReadInt32();
             EngineVersion = reader.ReadInt32();
             ReplayChecksum = new HashWrapper(reader);

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using YARG.Core.IO;
 
 namespace YARG.Core.Replays
 {
@@ -15,8 +16,9 @@ namespace YARG.Core.Replays
 
     public static class ReplayIO
     {
-        public const long REPLAY_MAGIC_HEADER = 0x59414C5047524159;
-        public const int  REPLAY_VERSION      = 3;
+        public static readonly EightCC REPLAY_MAGIC_HEADER = new('Y', 'A', 'R', 'G', 'P', 'L', 'A', 'Y');
+
+        public const int REPLAY_VERSION = 3;
 
         // Some versions may be invalidated (such as significant format changes)
         private static readonly int[] InvalidVersions = { 0, 1, 2 };

--- a/YARG.Core/Song/Metadata/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Metadata/Types/HashWrapper.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using YARG.Core.Extensions;
 using YARG.Core.IO;
 
 namespace YARG.Core.Song
@@ -88,7 +89,7 @@ namespace YARG.Core.Song
 
         public override string ToString()
         {
-            return BitConverter.ToString(_hash).Replace("-", "");
+            return _hash.ToHexString(dashes: false);
         }
     }
 }


### PR DESCRIPTION
- Expand on stream reading extensions to include reading/writing of endian-specific values
- Add endian extensions for BinaryReader/Writer as well
- Add ToHexString to reduce allocations with Span/Memory (avoid stuff like `span.ToArray()`), with an option to exclude dashes for further reduction (avoid `.Replace("-", "")`)
- Add static methods to convert between beats per minute and microseconds per beat
- Add `FourCC`/`EightCC` utility structs for file format identifiers
- Remove unused `CompareTag` method on `YARGBinaryReader`, no longer needed due to `FourCC`