### PR TITLE
Use Explicit Direct Insertion Strategies To Boost Parsing Performance

### DIFF
--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
@@ -189,7 +189,7 @@ namespace YARG.Core.UnitTests.Parsing
                 while (noteIndex < chart.notes.Count &&
                     (phraseIndex == chart.specialPhrases.Count || chart.notes[noteIndex].tick <  chart.specialPhrases[phraseIndex].tick) &&
                     (eventIndex  == chart.events.Count         || chart.notes[noteIndex].tick <= chart.events[eventIndex].tick))
-                    AppendNote(builder, chart.notes[noteIndex++]);
+                    AppendNote(builder, chart.notes[noteIndex++], gameMode);
 
                 while (eventIndex < chart.events.Count &&
                     (phraseIndex == chart.specialPhrases.Count || chart.events[eventIndex].tick < chart.specialPhrases[phraseIndex].tick) &&
@@ -208,11 +208,10 @@ namespace YARG.Core.UnitTests.Parsing
             builder.Append($"}}{NEWLINE}");
         }
 
-        private static void AppendNote(StringBuilder builder, MoonNote note)
+        private static void AppendNote(StringBuilder builder, MoonNote note, GameMode gameMode)
         {
             uint tick = note.tick;
             var flags = note.flags;
-            var gameMode = note.gameMode;
 
             bool canForce = gameMode is GameMode.Guitar or GameMode.GHLGuitar;
             bool canTap = gameMode is GameMode.Guitar or GameMode.GHLGuitar;

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
@@ -91,13 +91,18 @@ namespace YARG.Core.UnitTests.Parsing
         private static void GenerateSyncSection(MoonSong sourceSong, StringBuilder builder)
         {
             builder.Append($"[{SECTION_SYNC_TRACK}]{NEWLINE}{{{NEWLINE}");
+
+            // Indexing the separate lists is the only way to
+            // 1: Not allocate more space for a combined list, and
+            // 2: Not rely on polymorphic queries
             int timeSigIndex = 0;
             int bpmIndex = 0;
             while (timeSigIndex < sourceSong.timeSignatures.Count ||
                    bpmIndex < sourceSong.bpms.Count)
             {
-                // Generate in this order: phrases, notes, then events
+                // Generate in this order: time sig, bpm
                 while (timeSigIndex < sourceSong.timeSignatures.Count &&
+                    // Time sig comes before or at the same time as a bpm
                     (bpmIndex == sourceSong.bpms.Count || sourceSong.timeSignatures[timeSigIndex].tick <= sourceSong.bpms[bpmIndex].tick))
                 {
                     var ts = sourceSong.timeSignatures[timeSigIndex++];
@@ -105,6 +110,7 @@ namespace YARG.Core.UnitTests.Parsing
                 }
 
                 while (bpmIndex < sourceSong.bpms.Count &&
+                    // Bpm comes before a time sig (equals does not count)
                     (timeSigIndex == sourceSong.timeSignatures.Count || sourceSong.bpms[bpmIndex].tick < sourceSong.timeSignatures[timeSigIndex].tick))
                 {
                     var bpm = sourceSong.bpms[bpmIndex++];
@@ -117,13 +123,18 @@ namespace YARG.Core.UnitTests.Parsing
         private static void GenerateEventsSection(MoonSong sourceSong, StringBuilder builder)
         {
             builder.Append($"[{SECTION_EVENTS}]{NEWLINE}{{{NEWLINE}");
+
+            // Indexing the separate lists is the only way to
+            // 1: Not allocate more space for a combined list, and
+            // 2: Not rely on polymorphic queries
             int sectionIndex = 0;
             int eventIndex = 0;
             while (sectionIndex < sourceSong.sections.Count ||
                    eventIndex < sourceSong.events.Count)
             {
-                // Generate in this order: phrases, notes, then events
+                // Generate in this order: sections, events
                 while (sectionIndex < sourceSong.sections.Count &&
+                    // Section comes before or at the same time as an event
                     (eventIndex == sourceSong.events.Count || sourceSong.sections[sectionIndex].tick <= sourceSong.events[eventIndex].tick))
                 {
                     var section = sourceSong.sections[sectionIndex++];
@@ -131,6 +142,7 @@ namespace YARG.Core.UnitTests.Parsing
                 }
 
                 while (eventIndex < sourceSong.events.Count &&
+                    // Event comes before a section (equals does not count)
                     (sectionIndex == sourceSong.sections.Count || sourceSong.bpms[eventIndex].tick < sourceSong.sections[sectionIndex].tick))
                 {
                     var ev = sourceSong.events[eventIndex++];
@@ -154,6 +166,10 @@ namespace YARG.Core.UnitTests.Parsing
             builder.Append($"[{difficultyName}{instrumentName}]{NEWLINE}{{{NEWLINE}");
 
             List<SpecialPhrase> phrasesToRemove = new();
+
+            // Indexing the separate lists is the only way to
+            // 1: Not allocate more space for a combined list, and
+            // 2: Not rely on polymorphic queries
             int noteIndex = 0;
             int phraseIndex = 0;
             int eventIndex = 0;
@@ -163,7 +179,9 @@ namespace YARG.Core.UnitTests.Parsing
             {
                 // Generate in this order: phrases, notes, then events
                 while (phraseIndex < chart.specialPhrases.Count &&
+                    // Phrase comes before or at the same time as a note
                     (noteIndex  == chart.notes.Count  || chart.specialPhrases[phraseIndex].tick <= chart.notes[noteIndex].tick) &&
+                    // Phrase comes before or at the same time as an event
                     (eventIndex == chart.events.Count || chart.specialPhrases[phraseIndex].tick <= chart.events[eventIndex].tick))
                 {
                     var phrase = chart.specialPhrases[phraseIndex++];
@@ -187,12 +205,16 @@ namespace YARG.Core.UnitTests.Parsing
                 }
 
                 while (noteIndex < chart.notes.Count &&
+                    // Note comes before a phrase (equals does not count)
                     (phraseIndex == chart.specialPhrases.Count || chart.notes[noteIndex].tick <  chart.specialPhrases[phraseIndex].tick) &&
+                    // Note comes before or at the same time as an event
                     (eventIndex  == chart.events.Count         || chart.notes[noteIndex].tick <= chart.events[eventIndex].tick))
                     AppendNote(builder, chart.notes[noteIndex++], gameMode);
 
                 while (eventIndex < chart.events.Count &&
+                    // Event comes before a phrase (equals does not count)
                     (phraseIndex == chart.specialPhrases.Count || chart.events[eventIndex].tick < chart.specialPhrases[phraseIndex].tick) &&
+                    // Event comes before a note (equals does not count)
                     (noteIndex   == chart.notes.Count          || chart.events[eventIndex].tick < chart.notes[noteIndex].tick))
                 {
                     var ev = chart.events[eventIndex++];

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -381,18 +381,23 @@ namespace YARG.Core.UnitTests.Parsing
             },
             new[]
             {
-                NewSpecial(0, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
                 NewSpecial(0, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
-                NewSpecial(12, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+                NewSpecial(0, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+
                 NewSpecial(12, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
+                NewSpecial(12, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+                
                 NewSpecial(12, SpecialPhrase.Type.Starpower, RESOLUTION * 12),
-                NewSpecial(24, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+
                 NewSpecial(24, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
+                NewSpecial(24, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
                 NewSpecial(24, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
-                NewSpecial(36, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
+
                 NewSpecial(36, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 13),
-                NewSpecial(49, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
+                NewSpecial(36, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
+                
                 NewSpecial(49, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 1),
+                NewSpecial(49, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
             }
         );
 

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -20,12 +20,6 @@ namespace YARG.Core.UnitTests.Parsing
 
         public static readonly SongObjectComparer Comparer = new();
 
-        public static readonly List<SyncTrack> TempoMap = new()
-        {
-            new BPM(0, (uint)(TEMPO * 1000)),
-            new TimeSignature(0, NUMERATOR, DENOMINATOR),
-        };
-
         public static readonly List<Event> GlobalEvents = new()
         {
         };
@@ -422,7 +416,7 @@ namespace YARG.Core.UnitTests.Parsing
             {
                 resolution = RESOLUTION,
             };
-            PopulateSyncTrack(song, TempoMap);
+            PopulateSyncTrack(song);
             PopulateGlobalEvents(song, GlobalEvents);
             foreach (var instrument in EnumExtensions<MoonInstrument>.Values)
             {
@@ -445,22 +439,18 @@ namespace YARG.Core.UnitTests.Parsing
             };
         }
 
-        public static void PopulateSyncTrack(MoonSong song, List<SyncTrack> tempoMap)
+        public static void PopulateSyncTrack(MoonSong song)
         {
-            foreach (var sync in tempoMap)
-            {
-                song.Add(sync.Clone(), false);
-            }
-            song.UpdateCache();
+            song.Add(new BPM(0, (uint) (TEMPO * 1000)));
+            song.Add(new TimeSignature(0, NUMERATOR, DENOMINATOR));
         }
 
         public static void PopulateGlobalEvents(MoonSong song, List<Event> events)
         {
             foreach (var text in events)
             {
-                song.Add(text.Clone(), false);
+                song.Add(text.Clone());
             }
-            song.UpdateCache();
         }
 
         public static void PopulateInstrument(MoonSong song, MoonInstrument instrument, IParseBehavior track)

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -441,15 +441,15 @@ namespace YARG.Core.UnitTests.Parsing
 
         public static void PopulateSyncTrack(MoonSong song)
         {
-            song.Add(new BPM(0, (uint) (TEMPO * 1000)));
-            song.Add(new TimeSignature(0, NUMERATOR, DENOMINATOR));
+            song.bpms.Add(new BPM(0, (uint) (TEMPO * 1000)));
+            song.timeSignatures.Add(new TimeSignature(0, NUMERATOR, DENOMINATOR));
         }
 
         public static void PopulateGlobalEvents(MoonSong song, List<Event> events)
         {
             foreach (var text in events)
             {
-                song.Add(text.Clone());
+                song.events.Add(text.Clone());
             }
         }
 
@@ -465,10 +465,14 @@ namespace YARG.Core.UnitTests.Parsing
         {
             var chart = song.GetChart(instrument, difficulty);
             foreach (var note in track.Notes)
-                chart.Add(note.Clone());
+            {
+                chart.notes.Add(note.Clone());
+            }
 
             foreach (var phrase in track.Phrases)
-                chart.Add(phrase.Clone());
+            {
+                chart.specialPhrases.Add(phrase.Clone());
+            }
         }
 
         public static void VerifySong(MoonSong sourceSong, MoonSong parsedSong, IEnumerable<GameMode> supportedModes)

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -1,4 +1,4 @@
-using MoonscraperChartEditor.Song;
+﻿using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
 using NUnit.Framework;
 using YARG.Core.Extensions;
@@ -43,333 +43,378 @@ namespace YARG.Core.UnitTests.Parsing
         private static SpecialPhrase NewSpecial(int index, SpecialPhrase.Type type, uint length = 0)
             => new((uint)(index * RESOLUTION), length, type);
 
-        public static readonly List<ChartObject> GuitarTrack = new()
+        public interface IParseBehavior
         {
-            NewNote(0, GuitarFret.Green),
-            NewNote(1, GuitarFret.Red),
-            NewNote(2, GuitarFret.Yellow),
-            NewNote(3, GuitarFret.Blue),
-            NewNote(4, GuitarFret.Orange),
-            NewNote(5, GuitarFret.Open),
+            public List<MoonNote> Notes { get; }
+            public List<SpecialPhrase> Phrases { get; }
+        }
 
-            NewSpecial(6, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 6),
-            NewNote(6, GuitarFret.Green, flags: Flags.Forced),
-            NewNote(7, GuitarFret.Red, flags: Flags.Forced),
-            NewNote(8, GuitarFret.Yellow, flags: Flags.Forced),
-            NewNote(9, GuitarFret.Blue, flags: Flags.Forced),
-            NewNote(10, GuitarFret.Orange, flags: Flags.Forced),
-            NewNote(11, GuitarFret.Open, flags: Flags.Forced),
-
-            NewSpecial(12, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 5),
-            NewNote(12, GuitarFret.Green, flags: Flags.Tap),
-            NewNote(13, GuitarFret.Red, flags: Flags.Tap),
-            NewNote(14, GuitarFret.Yellow, flags: Flags.Tap),
-            NewNote(15, GuitarFret.Blue, flags: Flags.Tap),
-            NewNote(16, GuitarFret.Orange, flags: Flags.Tap),
-
-            NewSpecial(17, SpecialPhrase.Type.Starpower, RESOLUTION * 6),
-            NewNote(17, GuitarFret.Green),
-            NewNote(18, GuitarFret.Red),
-            NewNote(19, GuitarFret.Yellow),
-            NewNote(20, GuitarFret.Blue),
-            NewNote(21, GuitarFret.Orange),
-            NewNote(22, GuitarFret.Open),
-
-            NewSpecial(23, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
-            NewNote(23, GuitarFret.Yellow),
-            NewNote(24, GuitarFret.Yellow),
-            NewNote(25, GuitarFret.Yellow),
-            NewNote(26, GuitarFret.Yellow),
-            NewNote(27, GuitarFret.Yellow),
-            NewNote(28, GuitarFret.Yellow),
-
-            NewSpecial(29, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
-            NewNote(29, GuitarFret.Green),
-            NewNote(30, GuitarFret.Red),
-            NewNote(31, GuitarFret.Green),
-            NewNote(32, GuitarFret.Red),
-            NewNote(33, GuitarFret.Green),
-            NewNote(34, GuitarFret.Red),
-
-            NewSpecial(35, SpecialPhrase.Type.Solo, RESOLUTION * 6),
-            NewNote(35, GuitarFret.Green, flags: Flags.Forced),
-            NewNote(36, GuitarFret.Red, flags: Flags.Forced),
-            NewNote(37, GuitarFret.Yellow, flags: Flags.Forced),
-            NewNote(38, GuitarFret.Blue, flags: Flags.Forced),
-            NewNote(39, GuitarFret.Orange, flags: Flags.Forced),
-            NewNote(40, GuitarFret.Open, flags: Flags.Forced),
-        };
-
-        public static readonly List<ChartObject> GhlGuitarTrack = new()
+        public class ParseBehaviorGuitar : IParseBehavior
         {
-            NewNote(0, GHLiveGuitarFret.Black1),
-            NewNote(1, GHLiveGuitarFret.Black2),
-            NewNote(2, GHLiveGuitarFret.Black3),
-            NewNote(3, GHLiveGuitarFret.White1),
-            NewNote(4, GHLiveGuitarFret.White2),
-            NewNote(5, GHLiveGuitarFret.White3),
-            NewNote(6, GHLiveGuitarFret.Open),
+            public List<MoonNote> Notes { get; } = new()
+            {
+                NewNote(0, GuitarFret.Green),
+                NewNote(1, GuitarFret.Red),
+                NewNote(2, GuitarFret.Yellow),
+                NewNote(3, GuitarFret.Blue),
+                NewNote(4, GuitarFret.Orange),
+                NewNote(5, GuitarFret.Open),
+                NewNote(6, GuitarFret.Green, flags: Flags.Forced),
+                NewNote(7, GuitarFret.Red, flags: Flags.Forced),
+                NewNote(8, GuitarFret.Yellow, flags: Flags.Forced),
+                NewNote(9, GuitarFret.Blue, flags: Flags.Forced),
+                NewNote(10, GuitarFret.Orange, flags: Flags.Forced),
+                NewNote(11, GuitarFret.Open, flags: Flags.Forced),
+                NewNote(12, GuitarFret.Green, flags: Flags.Tap),
+                NewNote(13, GuitarFret.Red, flags: Flags.Tap),
+                NewNote(14, GuitarFret.Yellow, flags: Flags.Tap),
+                NewNote(15, GuitarFret.Blue, flags: Flags.Tap),
+                NewNote(16, GuitarFret.Orange, flags: Flags.Tap),
+                NewNote(17, GuitarFret.Green),
+                NewNote(18, GuitarFret.Red),
+                NewNote(19, GuitarFret.Yellow),
+                NewNote(20, GuitarFret.Blue),
+                NewNote(21, GuitarFret.Orange),
+                NewNote(22, GuitarFret.Open),
+                NewNote(23, GuitarFret.Yellow),
+                NewNote(24, GuitarFret.Yellow),
+                NewNote(25, GuitarFret.Yellow),
+                NewNote(26, GuitarFret.Yellow),
+                NewNote(27, GuitarFret.Yellow),
+                NewNote(28, GuitarFret.Yellow),
+                NewNote(29, GuitarFret.Green),
+                NewNote(30, GuitarFret.Red),
+                NewNote(31, GuitarFret.Green),
+                NewNote(32, GuitarFret.Red),
+                NewNote(33, GuitarFret.Green),
+                NewNote(34, GuitarFret.Red),
+                NewNote(35, GuitarFret.Green, flags: Flags.Forced),
+                NewNote(36, GuitarFret.Red, flags: Flags.Forced),
+                NewNote(37, GuitarFret.Yellow, flags: Flags.Forced),
+                NewNote(38, GuitarFret.Blue, flags: Flags.Forced),
+                NewNote(39, GuitarFret.Orange, flags: Flags.Forced),
+                NewNote(40, GuitarFret.Open, flags: Flags.Forced),
+            };
 
-            NewNote(7, GHLiveGuitarFret.Black1, flags: Flags.Forced),
-            NewNote(8, GHLiveGuitarFret.Black2, flags: Flags.Forced),
-            NewNote(9, GHLiveGuitarFret.Black3, flags: Flags.Forced),
-            NewNote(10, GHLiveGuitarFret.White1, flags: Flags.Forced),
-            NewNote(11, GHLiveGuitarFret.White2, flags: Flags.Forced),
-            NewNote(12, GHLiveGuitarFret.White3, flags: Flags.Forced),
-            NewNote(13, GHLiveGuitarFret.Open, flags: Flags.Forced),
+            public List<SpecialPhrase> Phrases { get; } = new()
+            {
+                NewSpecial(6, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 6),
+                NewSpecial(12, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 5),
+                NewSpecial(17, SpecialPhrase.Type.Starpower, RESOLUTION * 6),
+                NewSpecial(23, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
+                NewSpecial(29, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
+                NewSpecial(35, SpecialPhrase.Type.Solo, RESOLUTION * 6),
+            };
+        }
 
-            NewNote(14, GHLiveGuitarFret.Black1, flags: Flags.Tap),
-            NewNote(15, GHLiveGuitarFret.Black2, flags: Flags.Tap),
-            NewNote(16, GHLiveGuitarFret.Black3, flags: Flags.Tap),
-            NewNote(17, GHLiveGuitarFret.White1, flags: Flags.Tap),
-            NewNote(18, GHLiveGuitarFret.White2, flags: Flags.Tap),
-            NewNote(19, GHLiveGuitarFret.White3, flags: Flags.Tap),
+        public static readonly ParseBehaviorGuitar GuitarTrack = new();
 
-            NewSpecial(20, SpecialPhrase.Type.Starpower, RESOLUTION * 7),
-            NewNote(20, GHLiveGuitarFret.Black1),
-            NewNote(21, GHLiveGuitarFret.Black2),
-            NewNote(22, GHLiveGuitarFret.Black3),
-            NewNote(23, GHLiveGuitarFret.White1),
-            NewNote(24, GHLiveGuitarFret.White2),
-            NewNote(25, GHLiveGuitarFret.White3),
-            NewNote(26, GHLiveGuitarFret.Open),
-
-            NewSpecial(27, SpecialPhrase.Type.Solo, RESOLUTION * 7),
-            NewNote(27, GHLiveGuitarFret.Black1),
-            NewNote(28, GHLiveGuitarFret.Black2),
-            NewNote(29, GHLiveGuitarFret.Black3),
-            NewNote(30, GHLiveGuitarFret.White1),
-            NewNote(31, GHLiveGuitarFret.White2),
-            NewNote(32, GHLiveGuitarFret.White3),
-            NewNote(33, GHLiveGuitarFret.Open),
-        };
-
-        public static readonly List<ChartObject> ProGuitarTrack = new()
+        public class ParseBehaviorGHLGuitar : IParseBehavior
         {
-            NewNote(0, ProGuitarString.Red, 0),
-            NewNote(1, ProGuitarString.Green, 1),
-            NewNote(2, ProGuitarString.Orange, 2),
-            NewNote(3, ProGuitarString.Blue, 3),
-            NewNote(4, ProGuitarString.Yellow, 4),
-            NewNote(5, ProGuitarString.Purple, 5),
+            public List<MoonNote> Notes { get; } = new()
+            {
+                NewNote(0, GHLiveGuitarFret.Black1),
+                NewNote(1, GHLiveGuitarFret.Black2),
+                NewNote(2, GHLiveGuitarFret.Black3),
+                NewNote(3, GHLiveGuitarFret.White1),
+                NewNote(4, GHLiveGuitarFret.White2),
+                NewNote(5, GHLiveGuitarFret.White3),
+                NewNote(6, GHLiveGuitarFret.Open),
 
-            NewNote(6, ProGuitarString.Red, 6, flags: Flags.Forced),
-            NewNote(7, ProGuitarString.Green, 7, flags: Flags.Forced),
-            NewNote(8, ProGuitarString.Orange, 8, flags: Flags.Forced),
-            NewNote(9, ProGuitarString.Blue, 9, flags: Flags.Forced),
-            NewNote(10, ProGuitarString.Yellow, 10, flags: Flags.Forced),
-            NewNote(11, ProGuitarString.Purple, 11, flags: Flags.Forced),
+                NewNote(7, GHLiveGuitarFret.Black1, flags: Flags.Forced),
+                NewNote(8, GHLiveGuitarFret.Black2, flags: Flags.Forced),
+                NewNote(9, GHLiveGuitarFret.Black3, flags: Flags.Forced),
+                NewNote(10, GHLiveGuitarFret.White1, flags: Flags.Forced),
+                NewNote(11, GHLiveGuitarFret.White2, flags: Flags.Forced),
+                NewNote(12, GHLiveGuitarFret.White3, flags: Flags.Forced),
+                NewNote(13, GHLiveGuitarFret.Open, flags: Flags.Forced),
 
-            NewNote(12, ProGuitarString.Red, 12, flags: Flags.ProGuitar_Muted),
-            NewNote(13, ProGuitarString.Green, 13, flags: Flags.ProGuitar_Muted),
-            NewNote(14, ProGuitarString.Orange, 14, flags: Flags.ProGuitar_Muted),
-            NewNote(15, ProGuitarString.Blue, 15, flags: Flags.ProGuitar_Muted),
-            NewNote(16, ProGuitarString.Yellow, 16, flags: Flags.ProGuitar_Muted),
-            NewNote(17, ProGuitarString.Purple, 17, flags: Flags.ProGuitar_Muted),
+                NewNote(14, GHLiveGuitarFret.Black1, flags: Flags.Tap),
+                NewNote(15, GHLiveGuitarFret.Black2, flags: Flags.Tap),
+                NewNote(16, GHLiveGuitarFret.Black3, flags: Flags.Tap),
+                NewNote(17, GHLiveGuitarFret.White1, flags: Flags.Tap),
+                NewNote(18, GHLiveGuitarFret.White2, flags: Flags.Tap),
+                NewNote(19, GHLiveGuitarFret.White3, flags: Flags.Tap),
 
-            NewSpecial(18, SpecialPhrase.Type.Starpower, RESOLUTION * 6),
-            NewNote(18, ProGuitarString.Red, 0),
-            NewNote(19, ProGuitarString.Green, 1),
-            NewNote(20, ProGuitarString.Orange, 2),
-            NewNote(21, ProGuitarString.Blue, 3),
-            NewNote(22, ProGuitarString.Yellow, 4),
-            NewNote(23, ProGuitarString.Purple, 5),
+                NewNote(20, GHLiveGuitarFret.Black1),
+                NewNote(21, GHLiveGuitarFret.Black2),
+                NewNote(22, GHLiveGuitarFret.Black3),
+                NewNote(23, GHLiveGuitarFret.White1),
+                NewNote(24, GHLiveGuitarFret.White2),
+                NewNote(25, GHLiveGuitarFret.White3),
+                NewNote(26, GHLiveGuitarFret.Open),
 
-            NewSpecial(24, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
-            NewNote(24, ProGuitarString.Red, 0),
-            NewNote(25, ProGuitarString.Red, 0),
-            NewNote(26, ProGuitarString.Red, 0),
-            NewNote(27, ProGuitarString.Red, 0),
-            NewNote(28, ProGuitarString.Red, 0),
-            NewNote(29, ProGuitarString.Red, 0),
+                NewNote(27, GHLiveGuitarFret.Black1),
+                NewNote(28, GHLiveGuitarFret.Black2),
+                NewNote(29, GHLiveGuitarFret.Black3),
+                NewNote(30, GHLiveGuitarFret.White1),
+                NewNote(31, GHLiveGuitarFret.White2),
+                NewNote(32, GHLiveGuitarFret.White3),
+                NewNote(33, GHLiveGuitarFret.Open),
+            };
 
-            NewSpecial(30, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
-            NewNote(30, ProGuitarString.Yellow, 5),
-            NewNote(31, ProGuitarString.Yellow, 6),
-            NewNote(32, ProGuitarString.Yellow, 5),
-            NewNote(33, ProGuitarString.Yellow, 6),
-            NewNote(34, ProGuitarString.Yellow, 5),
-            NewNote(35, ProGuitarString.Yellow, 6),
+            public List<SpecialPhrase> Phrases { get; } = new()
+            {
+                NewSpecial(20, SpecialPhrase.Type.Starpower, RESOLUTION * 7),
+                NewSpecial(27, SpecialPhrase.Type.Solo, RESOLUTION * 7),
+            };
+        }
 
-            NewSpecial(36, SpecialPhrase.Type.Solo, RESOLUTION * 6),
-            NewNote(36, ProGuitarString.Red, 0),
-            NewNote(37, ProGuitarString.Green, 1),
-            NewNote(38, ProGuitarString.Orange, 2),
-            NewNote(39, ProGuitarString.Blue, 3),
-            NewNote(40, ProGuitarString.Yellow, 4),
-            NewNote(41, ProGuitarString.Purple, 5),
-        };
+        public static readonly ParseBehaviorGHLGuitar GhlGuitarTrack = new();
 
-        public static readonly List<ChartObject> DrumsTrack = new()
+        public class ParseBehaviorProGuitar : IParseBehavior
         {
-            NewNote(0, DrumPad.Kick),
-            NewNote(1, DrumPad.Kick, flags: Flags.DoubleKick),
+            public List<MoonNote> Notes { get; } = new()
+            {
+                NewNote(0, ProGuitarString.Red, 0),
+                NewNote(1, ProGuitarString.Green, 1),
+                NewNote(2, ProGuitarString.Orange, 2),
+                NewNote(3, ProGuitarString.Blue, 3),
+                NewNote(4, ProGuitarString.Yellow, 4),
+                NewNote(5, ProGuitarString.Purple, 5),
 
-            NewNote(2, DrumPad.Red, length: 16),
-            NewNote(3, DrumPad.Yellow, length: 16),
-            NewNote(4, DrumPad.Blue, length: 16),
-            NewNote(5, DrumPad.Orange, length: 16),
-            NewNote(6, DrumPad.Green, length: 16),
-            NewNote(7, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(8, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-            NewNote(9, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+                NewNote(6, ProGuitarString.Red, 6, flags: Flags.Forced),
+                NewNote(7, ProGuitarString.Green, 7, flags: Flags.Forced),
+                NewNote(8, ProGuitarString.Orange, 8, flags: Flags.Forced),
+                NewNote(9, ProGuitarString.Blue, 9, flags: Flags.Forced),
+                NewNote(10, ProGuitarString.Yellow, 10, flags: Flags.Forced),
+                NewNote(11, ProGuitarString.Purple, 11, flags: Flags.Forced),
 
-            NewNote(10, DrumPad.Red, flags: Flags.ProDrums_Accent),
-            NewNote(11, DrumPad.Yellow, flags: Flags.ProDrums_Accent),
-            NewNote(12, DrumPad.Blue, flags: Flags.ProDrums_Accent),
-            NewNote(13, DrumPad.Orange, flags: Flags.ProDrums_Accent),
-            NewNote(14, DrumPad.Green, flags: Flags.ProDrums_Accent),
-            NewNote(15, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
-            NewNote(16, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
-            NewNote(17, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+                NewNote(12, ProGuitarString.Red, 12, flags: Flags.ProGuitar_Muted),
+                NewNote(13, ProGuitarString.Green, 13, flags: Flags.ProGuitar_Muted),
+                NewNote(14, ProGuitarString.Orange, 14, flags: Flags.ProGuitar_Muted),
+                NewNote(15, ProGuitarString.Blue, 15, flags: Flags.ProGuitar_Muted),
+                NewNote(16, ProGuitarString.Yellow, 16, flags: Flags.ProGuitar_Muted),
+                NewNote(17, ProGuitarString.Purple, 17, flags: Flags.ProGuitar_Muted),
 
-            NewNote(18, DrumPad.Red, flags: Flags.ProDrums_Ghost),
-            NewNote(19, DrumPad.Yellow, flags: Flags.ProDrums_Ghost),
-            NewNote(20, DrumPad.Blue, flags: Flags.ProDrums_Ghost),
-            NewNote(21, DrumPad.Orange, flags: Flags.ProDrums_Ghost),
-            NewNote(22, DrumPad.Green, flags: Flags.ProDrums_Ghost),
-            NewNote(23, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
-            NewNote(24, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
-            NewNote(25, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+                NewNote(18, ProGuitarString.Red, 0),
+                NewNote(19, ProGuitarString.Green, 1),
+                NewNote(20, ProGuitarString.Orange, 2),
+                NewNote(21, ProGuitarString.Blue, 3),
+                NewNote(22, ProGuitarString.Yellow, 4),
+                NewNote(23, ProGuitarString.Purple, 5),
 
-            NewSpecial(26, SpecialPhrase.Type.Starpower, RESOLUTION * 8),
-            NewNote(26, DrumPad.Red),
-            NewNote(27, DrumPad.Yellow),
-            NewNote(28, DrumPad.Blue),
-            NewNote(29, DrumPad.Orange),
-            NewNote(30, DrumPad.Green),
-            NewNote(31, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(32, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-            NewNote(33, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+                NewNote(24, ProGuitarString.Red, 0),
+                NewNote(25, ProGuitarString.Red, 0),
+                NewNote(26, ProGuitarString.Red, 0),
+                NewNote(27, ProGuitarString.Red, 0),
+                NewNote(28, ProGuitarString.Red, 0),
+                NewNote(29, ProGuitarString.Red, 0),
 
-            NewSpecial(34, SpecialPhrase.Type.ProDrums_Activation, RESOLUTION * 5),
-            NewNote(34, DrumPad.Red),
-            NewNote(35, DrumPad.Yellow),
-            NewNote(36, DrumPad.Blue),
-            NewNote(37, DrumPad.Orange),
-            NewNote(38, DrumPad.Green),
-            NewNote(39, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(40, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-            NewNote(41, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+                NewNote(30, ProGuitarString.Yellow, 5),
+                NewNote(31, ProGuitarString.Yellow, 6),
+                NewNote(32, ProGuitarString.Yellow, 5),
+                NewNote(33, ProGuitarString.Yellow, 6),
+                NewNote(34, ProGuitarString.Yellow, 5),
+                NewNote(35, ProGuitarString.Yellow, 6),
 
-            NewSpecial(42, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 8),
-            NewNote(42, DrumPad.Red),
-            NewNote(43, DrumPad.Yellow),
-            NewNote(44, DrumPad.Blue),
-            NewNote(45, DrumPad.Orange),
-            NewNote(46, DrumPad.Green),
-            NewNote(47, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(48, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-            NewNote(49, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+                NewNote(36, ProGuitarString.Red, 0),
+                NewNote(37, ProGuitarString.Green, 1),
+                NewNote(38, ProGuitarString.Orange, 2),
+                NewNote(39, ProGuitarString.Blue, 3),
+                NewNote(40, ProGuitarString.Yellow, 4),
+                NewNote(41, ProGuitarString.Purple, 5),
+            };
 
-            NewSpecial(50, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 8),
-            NewNote(50, DrumPad.Red),
-            NewNote(51, DrumPad.Yellow),
-            NewNote(52, DrumPad.Blue),
-            NewNote(53, DrumPad.Orange),
-            NewNote(54, DrumPad.Green),
-            NewNote(55, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(56, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-            NewNote(57, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            public List<SpecialPhrase> Phrases { get; } = new()
+            {
+                NewSpecial(18, SpecialPhrase.Type.Starpower, RESOLUTION * 6),
+                NewSpecial(24, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
+                NewSpecial(30, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
+                NewSpecial(36, SpecialPhrase.Type.Solo, RESOLUTION * 6),
+            };
+        }
 
-            NewSpecial(58, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
-            NewNote(58, DrumPad.Red),
-            NewNote(59, DrumPad.Red),
-            NewNote(60, DrumPad.Red),
-            NewNote(61, DrumPad.Red),
-            NewNote(62, DrumPad.Red),
-            NewNote(63, DrumPad.Red),
+        public static readonly ParseBehaviorProGuitar ProGuitarTrack = new();
 
-            NewSpecial(64, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
-            NewNote(64, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(65, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-            NewNote(66, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(67, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-            NewNote(68, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(69, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+        public class ParseBehaviorDrums : IParseBehavior
+        {
+            public List<MoonNote> Notes { get; } = new()
+            {
+                NewNote(0, DrumPad.Kick),
+                NewNote(1, DrumPad.Kick, flags: Flags.DoubleKick),
 
-            NewSpecial(70, SpecialPhrase.Type.Solo, RESOLUTION * 8),
-            NewNote(70, DrumPad.Red),
-            NewNote(71, DrumPad.Yellow),
-            NewNote(72, DrumPad.Blue),
-            NewNote(73, DrumPad.Orange),
-            NewNote(74, DrumPad.Green),
-            NewNote(75, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-            NewNote(76, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-            NewNote(77, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-        };
+                NewNote(2, DrumPad.Red, length: 16),
+                NewNote(3, DrumPad.Yellow, length: 16),
+                NewNote(4, DrumPad.Blue, length: 16),
+                NewNote(5, DrumPad.Orange, length: 16),
+                NewNote(6, DrumPad.Green, length: 16),
+                NewNote(7, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(8, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+                NewNote(9, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+
+                NewNote(10, DrumPad.Red, flags: Flags.ProDrums_Accent),
+                NewNote(11, DrumPad.Yellow, flags: Flags.ProDrums_Accent),
+                NewNote(12, DrumPad.Blue, flags: Flags.ProDrums_Accent),
+                NewNote(13, DrumPad.Orange, flags: Flags.ProDrums_Accent),
+                NewNote(14, DrumPad.Green, flags: Flags.ProDrums_Accent),
+                NewNote(15, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+                NewNote(16, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+                NewNote(17, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+
+                NewNote(18, DrumPad.Red, flags: Flags.ProDrums_Ghost),
+                NewNote(19, DrumPad.Yellow, flags: Flags.ProDrums_Ghost),
+                NewNote(20, DrumPad.Blue, flags: Flags.ProDrums_Ghost),
+                NewNote(21, DrumPad.Orange, flags: Flags.ProDrums_Ghost),
+                NewNote(22, DrumPad.Green, flags: Flags.ProDrums_Ghost),
+                NewNote(23, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+                NewNote(24, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+                NewNote(25, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+
+                NewNote(26, DrumPad.Red),
+                NewNote(27, DrumPad.Yellow),
+                NewNote(28, DrumPad.Blue),
+                NewNote(29, DrumPad.Orange),
+                NewNote(30, DrumPad.Green),
+                NewNote(31, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(32, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+                NewNote(33, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+
+                NewNote(34, DrumPad.Red),
+                NewNote(35, DrumPad.Yellow),
+                NewNote(36, DrumPad.Blue),
+                NewNote(37, DrumPad.Orange),
+                NewNote(38, DrumPad.Green),
+                NewNote(39, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(40, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+                NewNote(41, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+
+                NewNote(42, DrumPad.Red),
+                NewNote(43, DrumPad.Yellow),
+                NewNote(44, DrumPad.Blue),
+                NewNote(45, DrumPad.Orange),
+                NewNote(46, DrumPad.Green),
+                NewNote(47, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(48, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+                NewNote(49, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+
+                NewNote(50, DrumPad.Red),
+                NewNote(51, DrumPad.Yellow),
+                NewNote(52, DrumPad.Blue),
+                NewNote(53, DrumPad.Orange),
+                NewNote(54, DrumPad.Green),
+                NewNote(55, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(56, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+                NewNote(57, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+
+                NewNote(58, DrumPad.Red),
+                NewNote(59, DrumPad.Red),
+                NewNote(60, DrumPad.Red),
+                NewNote(61, DrumPad.Red),
+                NewNote(62, DrumPad.Red),
+                NewNote(63, DrumPad.Red),
+
+                NewNote(64, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(65, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+                NewNote(66, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(67, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+                NewNote(68, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(69, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+
+                NewNote(70, DrumPad.Red),
+                NewNote(71, DrumPad.Yellow),
+                NewNote(72, DrumPad.Blue),
+                NewNote(73, DrumPad.Orange),
+                NewNote(74, DrumPad.Green),
+                NewNote(75, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+                NewNote(76, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+                NewNote(77, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            };
+
+            public List<SpecialPhrase> Phrases { get; } = new()
+            {
+                NewSpecial(26, SpecialPhrase.Type.Starpower, RESOLUTION * 8),
+                NewSpecial(34, SpecialPhrase.Type.ProDrums_Activation, RESOLUTION * 5),
+                NewSpecial(42, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 8),
+                NewSpecial(50, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 8),
+                NewSpecial(58, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
+                NewSpecial(64, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
+                NewSpecial(70, SpecialPhrase.Type.Solo, RESOLUTION * 8),
+            };
+        }
+
+        public static readonly ParseBehaviorDrums DrumsTrack = new();
 
         private const byte VOCALS_RANGE_START = MidIOHelper.VOCALS_RANGE_START;
 
-        public static readonly List<ChartObject> VocalsNotes = new()
+        public class ParseBehaviorVocals : IParseBehavior
         {
-            NewSpecial(0, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-            NewSpecial(0, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
-            NewNote(0, VOCALS_RANGE_START + 0, length: RESOLUTION / 2),
-            NewNote(1, VOCALS_RANGE_START + 1, length: RESOLUTION / 2),
-            NewNote(2, VOCALS_RANGE_START + 2, length: RESOLUTION / 2),
-            NewNote(3, VOCALS_RANGE_START + 3, length: RESOLUTION / 2),
-            NewNote(4, VOCALS_RANGE_START + 4, length: RESOLUTION / 2),
-            NewNote(5, VOCALS_RANGE_START + 5, length: RESOLUTION / 2),
-            NewNote(6, VOCALS_RANGE_START + 6, length: RESOLUTION / 2),
-            NewNote(7, VOCALS_RANGE_START + 7, length: RESOLUTION / 2),
-            NewNote(8, VOCALS_RANGE_START + 8, length: RESOLUTION / 2),
-            NewNote(9, VOCALS_RANGE_START + 9, length: RESOLUTION / 2),
-            NewNote(10, VOCALS_RANGE_START + 10, length: RESOLUTION / 2),
-            NewNote(11, VOCALS_RANGE_START + 11, length: RESOLUTION / 2),
+            public List<MoonNote> Notes { get; } = new()
+            {
+                NewNote(0, VOCALS_RANGE_START + 0, length: RESOLUTION / 2),
+                NewNote(1, VOCALS_RANGE_START + 1, length: RESOLUTION / 2),
+                NewNote(2, VOCALS_RANGE_START + 2, length: RESOLUTION / 2),
+                NewNote(3, VOCALS_RANGE_START + 3, length: RESOLUTION / 2),
+                NewNote(4, VOCALS_RANGE_START + 4, length: RESOLUTION / 2),
+                NewNote(5, VOCALS_RANGE_START + 5, length: RESOLUTION / 2),
+                NewNote(6, VOCALS_RANGE_START + 6, length: RESOLUTION / 2),
+                NewNote(7, VOCALS_RANGE_START + 7, length: RESOLUTION / 2),
+                NewNote(8, VOCALS_RANGE_START + 8, length: RESOLUTION / 2),
+                NewNote(9, VOCALS_RANGE_START + 9, length: RESOLUTION / 2),
+                NewNote(10, VOCALS_RANGE_START + 10, length: RESOLUTION / 2),
+                NewNote(11, VOCALS_RANGE_START + 11, length: RESOLUTION / 2),
 
-            NewSpecial(12, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-            NewSpecial(12, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
-            NewSpecial(12, SpecialPhrase.Type.Starpower, RESOLUTION * 12),
-            NewNote(12, VOCALS_RANGE_START + 12, length: RESOLUTION / 2),
-            NewNote(13, VOCALS_RANGE_START + 13, length: RESOLUTION / 2),
-            NewNote(14, VOCALS_RANGE_START + 14, length: RESOLUTION / 2),
-            NewNote(15, VOCALS_RANGE_START + 15, length: RESOLUTION / 2),
-            NewNote(16, VOCALS_RANGE_START + 16, length: RESOLUTION / 2),
-            NewNote(17, VOCALS_RANGE_START + 17, length: RESOLUTION / 2),
-            NewNote(18, VOCALS_RANGE_START + 18, length: RESOLUTION / 2),
-            NewNote(19, VOCALS_RANGE_START + 19, length: RESOLUTION / 2),
-            NewNote(20, VOCALS_RANGE_START + 20, length: RESOLUTION / 2),
-            NewNote(21, VOCALS_RANGE_START + 21, length: RESOLUTION / 2),
-            NewNote(22, VOCALS_RANGE_START + 22, length: RESOLUTION / 2),
-            NewNote(23, VOCALS_RANGE_START + 23, length: RESOLUTION / 2),
+                NewNote(12, VOCALS_RANGE_START + 12, length: RESOLUTION / 2),
+                NewNote(13, VOCALS_RANGE_START + 13, length: RESOLUTION / 2),
+                NewNote(14, VOCALS_RANGE_START + 14, length: RESOLUTION / 2),
+                NewNote(15, VOCALS_RANGE_START + 15, length: RESOLUTION / 2),
+                NewNote(16, VOCALS_RANGE_START + 16, length: RESOLUTION / 2),
+                NewNote(17, VOCALS_RANGE_START + 17, length: RESOLUTION / 2),
+                NewNote(18, VOCALS_RANGE_START + 18, length: RESOLUTION / 2),
+                NewNote(19, VOCALS_RANGE_START + 19, length: RESOLUTION / 2),
+                NewNote(20, VOCALS_RANGE_START + 20, length: RESOLUTION / 2),
+                NewNote(21, VOCALS_RANGE_START + 21, length: RESOLUTION / 2),
+                NewNote(22, VOCALS_RANGE_START + 22, length: RESOLUTION / 2),
+                NewNote(23, VOCALS_RANGE_START + 23, length: RESOLUTION / 2),
 
-            NewSpecial(24, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-            NewSpecial(24, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
-            NewSpecial(24, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
-            NewNote(24, VOCALS_RANGE_START + 24, length: RESOLUTION / 2),
-            NewNote(25, VOCALS_RANGE_START + 25, length: RESOLUTION / 2),
-            NewNote(26, VOCALS_RANGE_START + 26, length: RESOLUTION / 2),
-            NewNote(27, VOCALS_RANGE_START + 27, length: RESOLUTION / 2),
-            NewNote(28, VOCALS_RANGE_START + 28, length: RESOLUTION / 2),
-            NewNote(29, VOCALS_RANGE_START + 29, length: RESOLUTION / 2),
-            NewNote(30, VOCALS_RANGE_START + 30, length: RESOLUTION / 2),
-            NewNote(31, VOCALS_RANGE_START + 31, length: RESOLUTION / 2),
-            NewNote(32, VOCALS_RANGE_START + 32, length: RESOLUTION / 2),
-            NewNote(33, VOCALS_RANGE_START + 33, length: RESOLUTION / 2),
-            NewNote(34, VOCALS_RANGE_START + 34, length: RESOLUTION / 2),
-            NewNote(35, VOCALS_RANGE_START + 35, length: RESOLUTION / 2),
+                NewNote(24, VOCALS_RANGE_START + 24, length: RESOLUTION / 2),
+                NewNote(25, VOCALS_RANGE_START + 25, length: RESOLUTION / 2),
+                NewNote(26, VOCALS_RANGE_START + 26, length: RESOLUTION / 2),
+                NewNote(27, VOCALS_RANGE_START + 27, length: RESOLUTION / 2),
+                NewNote(28, VOCALS_RANGE_START + 28, length: RESOLUTION / 2),
+                NewNote(29, VOCALS_RANGE_START + 29, length: RESOLUTION / 2),
+                NewNote(30, VOCALS_RANGE_START + 30, length: RESOLUTION / 2),
+                NewNote(31, VOCALS_RANGE_START + 31, length: RESOLUTION / 2),
+                NewNote(32, VOCALS_RANGE_START + 32, length: RESOLUTION / 2),
+                NewNote(33, VOCALS_RANGE_START + 33, length: RESOLUTION / 2),
+                NewNote(34, VOCALS_RANGE_START + 34, length: RESOLUTION / 2),
+                NewNote(35, VOCALS_RANGE_START + 35, length: RESOLUTION / 2),
 
-            NewSpecial(36, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
-            NewSpecial(36, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 13),
-            NewNote(36, VOCALS_RANGE_START + 36, length: RESOLUTION / 2),
-            NewNote(37, VOCALS_RANGE_START + 37, length: RESOLUTION / 2),
-            NewNote(38, VOCALS_RANGE_START + 38, length: RESOLUTION / 2),
-            NewNote(39, VOCALS_RANGE_START + 39, length: RESOLUTION / 2),
-            NewNote(40, VOCALS_RANGE_START + 40, length: RESOLUTION / 2),
-            NewNote(41, VOCALS_RANGE_START + 41, length: RESOLUTION / 2),
-            NewNote(42, VOCALS_RANGE_START + 42, length: RESOLUTION / 2),
-            NewNote(43, VOCALS_RANGE_START + 43, length: RESOLUTION / 2),
-            NewNote(44, VOCALS_RANGE_START + 44, length: RESOLUTION / 2),
-            NewNote(45, VOCALS_RANGE_START + 45, length: RESOLUTION / 2),
-            NewNote(46, VOCALS_RANGE_START + 46, length: RESOLUTION / 2),
-            NewNote(47, VOCALS_RANGE_START + 47, length: RESOLUTION / 2),
-            NewNote(48, VOCALS_RANGE_START + 48, length: RESOLUTION / 2),
+                NewNote(36, VOCALS_RANGE_START + 36, length: RESOLUTION / 2),
+                NewNote(37, VOCALS_RANGE_START + 37, length: RESOLUTION / 2),
+                NewNote(38, VOCALS_RANGE_START + 38, length: RESOLUTION / 2),
+                NewNote(39, VOCALS_RANGE_START + 39, length: RESOLUTION / 2),
+                NewNote(40, VOCALS_RANGE_START + 40, length: RESOLUTION / 2),
+                NewNote(41, VOCALS_RANGE_START + 41, length: RESOLUTION / 2),
+                NewNote(42, VOCALS_RANGE_START + 42, length: RESOLUTION / 2),
+                NewNote(43, VOCALS_RANGE_START + 43, length: RESOLUTION / 2),
+                NewNote(44, VOCALS_RANGE_START + 44, length: RESOLUTION / 2),
+                NewNote(45, VOCALS_RANGE_START + 45, length: RESOLUTION / 2),
+                NewNote(46, VOCALS_RANGE_START + 46, length: RESOLUTION / 2),
+                NewNote(47, VOCALS_RANGE_START + 47, length: RESOLUTION / 2),
+                NewNote(48, VOCALS_RANGE_START + 48, length: RESOLUTION / 2),
 
-            NewSpecial(49, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
-            NewSpecial(49, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 1),
-            NewNote(49, 0, flags: Flags.Vocals_Percussion),
-        };
+                NewNote(49, 0, flags: Flags.Vocals_Percussion),
+            };
+
+            public List<SpecialPhrase> Phrases { get; } = new()
+            {
+                NewSpecial(0, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+                NewSpecial(0, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
+                NewSpecial(12, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+                NewSpecial(12, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
+                NewSpecial(12, SpecialPhrase.Type.Starpower, RESOLUTION * 12),
+                NewSpecial(24, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+                NewSpecial(24, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
+                NewSpecial(24, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 12),
+                NewSpecial(36, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
+                NewSpecial(36, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 13),
+                NewSpecial(49, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
+                NewSpecial(49, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 1),
+            };
+        }
+
+        public static readonly ParseBehaviorVocals VocalsNotes = new();
 
         public static MoonSong GenerateSong()
         {
@@ -381,14 +426,14 @@ namespace YARG.Core.UnitTests.Parsing
             PopulateGlobalEvents(song, GlobalEvents);
             foreach (var instrument in EnumExtensions<MoonInstrument>.Values)
             {
-                var gameMode = MoonSong.InstumentToChartGameMode(instrument);
-                var data = GameModeToChartData(gameMode);
-                PopulateInstrument(song, instrument, data);
+                var gameMode = InstumentToChartGameMode(instrument);
+                var track = GameModeToChartData(gameMode);
+                PopulateInstrument(song, instrument, track);
             }
             return song;
         }
 
-        public static List<ChartObject> GameModeToChartData(GameMode gameMode)
+        public static IParseBehavior GameModeToChartData(GameMode gameMode)
         {
             return gameMode switch {
                 GameMode.Guitar => GuitarTrack,
@@ -418,22 +463,22 @@ namespace YARG.Core.UnitTests.Parsing
             song.UpdateCache();
         }
 
-        public static void PopulateInstrument(MoonSong song, MoonInstrument instrument, List<ChartObject> data)
+        public static void PopulateInstrument(MoonSong song, MoonInstrument instrument, IParseBehavior track)
         {
             foreach (var difficulty in EnumExtensions<Difficulty>.Values)
             {
-                PopulateDifficulty(song, instrument, difficulty, data);
+                PopulateDifficulty(song, instrument, difficulty, track);
             }
         }
 
-        public static void PopulateDifficulty(MoonSong song, MoonInstrument instrument, Difficulty difficulty, List<ChartObject> data)
+        public static void PopulateDifficulty(MoonSong song, MoonInstrument instrument, Difficulty difficulty, IParseBehavior track)
         {
             var chart = song.GetChart(instrument, difficulty);
-            foreach (var chartObj in data)
-            {
-                chart.Add(chartObj.Clone(), false);
-            }
-            chart.UpdateCache();
+            foreach (var note in track.Notes)
+                chart.Add(note.Clone());
+
+            foreach (var phrase in track.Phrases)
+                chart.Add(phrase.Clone());
         }
 
         public static void VerifySong(MoonSong sourceSong, MoonSong parsedSong, IEnumerable<GameMode> supportedModes)

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -37,15 +37,20 @@ namespace YARG.Core.UnitTests.Parsing
         private static SpecialPhrase NewSpecial(int index, SpecialPhrase.Type type, uint length = 0)
             => new((uint)(index * RESOLUTION), length, type);
 
-        public interface IParseBehavior
+        public class ParseBehavior
         {
-            public List<MoonNote> Notes { get; }
-            public List<SpecialPhrase> Phrases { get; }
+            public MoonNote[] Notes;
+            public SpecialPhrase[] Phrases;
+
+            public ParseBehavior(MoonNote[] notes, SpecialPhrase[] phrases)
+            {
+                Notes = notes;
+                Phrases = phrases;
+            }
         }
 
-        public class ParseBehaviorGuitar : IParseBehavior
-        {
-            public List<MoonNote> Notes { get; } = new()
+        public static readonly ParseBehavior GuitarTrack = new(
+            new[]
             {
                 NewNote(0, GuitarFret.Green),
                 NewNote(1, GuitarFret.Red),
@@ -88,9 +93,8 @@ namespace YARG.Core.UnitTests.Parsing
                 NewNote(38, GuitarFret.Blue, flags: Flags.Forced),
                 NewNote(39, GuitarFret.Orange, flags: Flags.Forced),
                 NewNote(40, GuitarFret.Open, flags: Flags.Forced),
-            };
-
-            public List<SpecialPhrase> Phrases { get; } = new()
+            },
+            new[]
             {
                 NewSpecial(6, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 6),
                 NewSpecial(12, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 5),
@@ -98,14 +102,11 @@ namespace YARG.Core.UnitTests.Parsing
                 NewSpecial(23, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
                 NewSpecial(29, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
                 NewSpecial(35, SpecialPhrase.Type.Solo, RESOLUTION * 6),
-            };
-        }
+            }
+        );
 
-        public static readonly ParseBehaviorGuitar GuitarTrack = new();
-
-        public class ParseBehaviorGHLGuitar : IParseBehavior
-        {
-            public List<MoonNote> Notes { get; } = new()
+        public static readonly ParseBehavior GhlGuitarTrack = new(
+            new[]
             {
                 NewNote(0, GHLiveGuitarFret.Black1),
                 NewNote(1, GHLiveGuitarFret.Black2),
@@ -145,20 +146,16 @@ namespace YARG.Core.UnitTests.Parsing
                 NewNote(31, GHLiveGuitarFret.White2),
                 NewNote(32, GHLiveGuitarFret.White3),
                 NewNote(33, GHLiveGuitarFret.Open),
-            };
-
-            public List<SpecialPhrase> Phrases { get; } = new()
+            },
+            new[]
             {
                 NewSpecial(20, SpecialPhrase.Type.Starpower, RESOLUTION * 7),
                 NewSpecial(27, SpecialPhrase.Type.Solo, RESOLUTION * 7),
-            };
-        }
+            }
+        );
 
-        public static readonly ParseBehaviorGHLGuitar GhlGuitarTrack = new();
-
-        public class ParseBehaviorProGuitar : IParseBehavior
-        {
-            public List<MoonNote> Notes { get; } = new()
+        public static readonly ParseBehavior ProGuitarTrack = new(
+            new[]
             {
                 NewNote(0, ProGuitarString.Red, 0),
                 NewNote(1, ProGuitarString.Green, 1),
@@ -208,22 +205,18 @@ namespace YARG.Core.UnitTests.Parsing
                 NewNote(39, ProGuitarString.Blue, 3),
                 NewNote(40, ProGuitarString.Yellow, 4),
                 NewNote(41, ProGuitarString.Purple, 5),
-            };
-
-            public List<SpecialPhrase> Phrases { get; } = new()
+            },
+            new[]
             {
                 NewSpecial(18, SpecialPhrase.Type.Starpower, RESOLUTION * 6),
                 NewSpecial(24, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
                 NewSpecial(30, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
                 NewSpecial(36, SpecialPhrase.Type.Solo, RESOLUTION * 6),
-            };
-        }
+            }
+        );
 
-        public static readonly ParseBehaviorProGuitar ProGuitarTrack = new();
-
-        public class ParseBehaviorDrums : IParseBehavior
-        {
-            public List<MoonNote> Notes { get; } = new()
+        public static readonly ParseBehavior DrumsTrack = new(
+            new[]
             {
                 NewNote(0, DrumPad.Kick),
                 NewNote(1, DrumPad.Kick, flags: Flags.DoubleKick),
@@ -313,9 +306,8 @@ namespace YARG.Core.UnitTests.Parsing
                 NewNote(75, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
                 NewNote(76, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
                 NewNote(77, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-            };
-
-            public List<SpecialPhrase> Phrases { get; } = new()
+            },
+            new[]
             {
                 NewSpecial(26, SpecialPhrase.Type.Starpower, RESOLUTION * 8),
                 NewSpecial(34, SpecialPhrase.Type.ProDrums_Activation, RESOLUTION * 5),
@@ -324,16 +316,13 @@ namespace YARG.Core.UnitTests.Parsing
                 NewSpecial(58, SpecialPhrase.Type.TremoloLane, RESOLUTION * 6),
                 NewSpecial(64, SpecialPhrase.Type.TrillLane, RESOLUTION * 6),
                 NewSpecial(70, SpecialPhrase.Type.Solo, RESOLUTION * 8),
-            };
-        }
-
-        public static readonly ParseBehaviorDrums DrumsTrack = new();
+            }
+        );
 
         private const byte VOCALS_RANGE_START = MidIOHelper.VOCALS_RANGE_START;
 
-        public class ParseBehaviorVocals : IParseBehavior
-        {
-            public List<MoonNote> Notes { get; } = new()
+        public static readonly ParseBehavior VocalsNotes = new(
+            new[]
             {
                 NewNote(0, VOCALS_RANGE_START + 0, length: RESOLUTION / 2),
                 NewNote(1, VOCALS_RANGE_START + 1, length: RESOLUTION / 2),
@@ -389,9 +378,8 @@ namespace YARG.Core.UnitTests.Parsing
                 NewNote(48, VOCALS_RANGE_START + 48, length: RESOLUTION / 2),
 
                 NewNote(49, 0, flags: Flags.Vocals_Percussion),
-            };
-
-            public List<SpecialPhrase> Phrases { get; } = new()
+            },
+            new[]
             {
                 NewSpecial(0, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
                 NewSpecial(0, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 12),
@@ -405,10 +393,8 @@ namespace YARG.Core.UnitTests.Parsing
                 NewSpecial(36, SpecialPhrase.Type.Versus_Player2, RESOLUTION * 13),
                 NewSpecial(49, SpecialPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
                 NewSpecial(49, SpecialPhrase.Type.Versus_Player1, RESOLUTION * 1),
-            };
-        }
-
-        public static readonly ParseBehaviorVocals VocalsNotes = new();
+            }
+        );
 
         public static MoonSong GenerateSong()
         {
@@ -427,7 +413,7 @@ namespace YARG.Core.UnitTests.Parsing
             return song;
         }
 
-        public static IParseBehavior GameModeToChartData(GameMode gameMode)
+        public static ParseBehavior GameModeToChartData(GameMode gameMode)
         {
             return gameMode switch {
                 GameMode.Guitar => GuitarTrack,
@@ -453,7 +439,7 @@ namespace YARG.Core.UnitTests.Parsing
             }
         }
 
-        public static void PopulateInstrument(MoonSong song, MoonInstrument instrument, IParseBehavior track)
+        public static void PopulateInstrument(MoonSong song, MoonInstrument instrument, ParseBehavior track)
         {
             foreach (var difficulty in EnumExtensions<Difficulty>.Values)
             {
@@ -461,7 +447,7 @@ namespace YARG.Core.UnitTests.Parsing
             }
         }
 
-        public static void PopulateDifficulty(MoonSong song, MoonInstrument instrument, Difficulty difficulty, IParseBehavior track)
+        public static void PopulateDifficulty(MoonSong song, MoonInstrument instrument, Difficulty difficulty, ParseBehavior track)
         {
             var chart = song.GetChart(instrument, difficulty);
             foreach (var note in track.Notes)

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using MoonscraperChartEditor.Song;
@@ -44,8 +44,8 @@ namespace YARG.Core.Chart
             var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
 
-            return new DrumNote(pad, noteType, drumFlags, generalFlags,
-                moonNote.time, moonNote.tick);
+            double time = _moonSong.TickToTime(moonNote.tick);
+            return new DrumNote(pad, noteType, drumFlags, generalFlags, time, moonNote.tick);
         }
 
         private DrumNote CreateFiveLaneDrumNote(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
@@ -55,8 +55,8 @@ namespace YARG.Core.Chart
             var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
 
-            return new DrumNote(pad, noteType, drumFlags, generalFlags,
-                moonNote.time, moonNote.tick);
+            double time = _moonSong.TickToTime(moonNote.tick);
+            return new DrumNote(pad, noteType, drumFlags, generalFlags, time, moonNote.tick);
         }
 
         private void HandleTextEvent(MoonChartEvent text)
@@ -297,7 +297,7 @@ namespace YARG.Core.Chart
 
             // SP activator
             if (currentPhrases.TryGetValue(SpecialPhrase.Type.ProDrums_Activation, out var activationPhrase) &&
-                IsNoteClosestToEndOfPhrase(moonNote, activationPhrase))
+                IsNoteClosestToEndOfPhrase(_moonSong, moonNote, activationPhrase))
             {
                 flags |= DrumNoteFlags.StarPowerActivator;
             }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using MoonscraperChartEditor.Song;
 
@@ -35,8 +35,8 @@ namespace YARG.Core.Chart
             var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
             var guitarFlags = GetGuitarNoteFlags(moonNote);
 
-            return new GuitarNote(fret, noteType, guitarFlags, generalFlags,
-                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+            double time = _moonSong.TickToTime(moonNote.tick);
+            return new GuitarNote(fret, noteType, guitarFlags, generalFlags, time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
         }
 
         private GuitarNote CreateSixFretGuitarNote(MoonNote moonNote, Dictionary<SpecialPhrase.Type, SpecialPhrase> currentPhrases)
@@ -46,8 +46,8 @@ namespace YARG.Core.Chart
             var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
             var guitarFlags = GetGuitarNoteFlags(moonNote);
 
-            return new GuitarNote(fret, noteType, guitarFlags, generalFlags,
-                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+            double time = _moonSong.TickToTime(moonNote.tick);
+            return new GuitarNote(fret, noteType, guitarFlags, generalFlags, time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
         }
 
         private FiveFretGuitarFret GetFiveFretGuitarFret(MoonNote moonNote)
@@ -81,12 +81,12 @@ namespace YARG.Core.Chart
 
         private GuitarNoteType GetGuitarNoteType(MoonNote moonNote)
         {
-            return moonNote.type switch
+            return moonNote.guitarType switch
             {
                 MoonNote.MoonNoteType.Strum => GuitarNoteType.Strum,
                 MoonNote.MoonNoteType.Hopo  => GuitarNoteType.Hopo,
                 MoonNote.MoonNoteType.Tap   => GuitarNoteType.Tap,
-                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.type}!")
+                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.guitarType}!")
             };
         }
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -81,12 +81,13 @@ namespace YARG.Core.Chart
 
         private GuitarNoteType GetGuitarNoteType(MoonNote moonNote)
         {
-            return moonNote.guitarType switch
+            var type = moonNote.GetGuitarType(_moonSong.hopoThreshold);
+            return type switch
             {
                 MoonNote.MoonNoteType.Strum => GuitarNoteType.Strum,
                 MoonNote.MoonNoteType.Hopo  => GuitarNoteType.Hopo,
                 MoonNote.MoonNoteType.Tap   => GuitarNoteType.Tap,
-                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.guitarType}!")
+                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {type}!")
             };
         }
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProGuitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProGuitar.cs
@@ -54,12 +54,13 @@ namespace YARG.Core.Chart
 
         private ProGuitarNoteType GetProGuitarNoteType(MoonNote moonNote)
         {
-            return moonNote.guitarType switch
+            var type = moonNote.GetGuitarType(_moonSong.hopoThreshold);
+            return type switch
             {
                 MoonNote.MoonNoteType.Strum => ProGuitarNoteType.Strum,
                 MoonNote.MoonNoteType.Hopo  => ProGuitarNoteType.Hopo,
                 MoonNote.MoonNoteType.Tap   => ProGuitarNoteType.Tap,
-                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.guitarType}!")
+                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {type}!")
             };
         }
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProGuitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProGuitar.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using MoonscraperChartEditor.Song;
 
@@ -29,8 +29,8 @@ namespace YARG.Core.Chart
             var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
             var proFlags = GetProGuitarNoteFlags(moonNote);
 
-            return new ProGuitarNote(proString, proFret, noteType, proFlags, generalFlags,
-                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+            double time = _moonSong.TickToTime(moonNote.tick);
+            return new ProGuitarNote(proString, proFret, noteType, proFlags, generalFlags, time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
         }
 
         private ProGuitarString GetProGuitarString(MoonNote moonNote)
@@ -54,12 +54,12 @@ namespace YARG.Core.Chart
 
         private ProGuitarNoteType GetProGuitarNoteType(MoonNote moonNote)
         {
-            return moonNote.type switch
+            return moonNote.guitarType switch
             {
                 MoonNote.MoonNoteType.Strum => ProGuitarNoteType.Strum,
                 MoonNote.MoonNoteType.Hopo  => ProGuitarNoteType.Hopo,
                 MoonNote.MoonNoteType.Tap   => ProGuitarNoteType.Tap,
-                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.type}!")
+                _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {moonNote.guitarType}!")
             };
         }
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Venue.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Venue.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using MoonscraperChartEditor.Song;
 using YARG.Core.Utility;
@@ -152,7 +152,9 @@ namespace YARG.Core.Chart
                     {
                         if (!LightingLookup.TryGetValue(text, out var type))
                             continue;
-                        lightingEvents.Add(new(type, moonVenue.time, moonVenue.tick));
+
+                        double time = _moonSong.TickToTime(moonVenue.tick);
+                        lightingEvents.Add(new(type, time, moonVenue.tick));
                         break;
                     }
 
@@ -160,7 +162,9 @@ namespace YARG.Core.Chart
                     {
                         if (!PostProcessLookup.TryGetValue(text, out var type))
                             continue;
-                        postProcessingEvents.Add(new(type, moonVenue.time, moonVenue.tick));
+
+                        double time = _moonSong.TickToTime(moonVenue.tick);
+                        postProcessingEvents.Add(new(type, time, moonVenue.tick));
                         break;
                     }
 
@@ -182,7 +186,9 @@ namespace YARG.Core.Chart
                     {
                         if (!StageEffectLookup.TryGetValue(text, out var type))
                             continue;
-                        stageEvents.Add(new(type, flags, moonVenue.time, moonVenue.tick));
+
+                        double time = _moonSong.TickToTime(moonVenue.tick);
+                        stageEvents.Add(new(type, flags, time, moonVenue.tick));
                         break;
                     }
 
@@ -213,8 +219,9 @@ namespace YARG.Core.Chart
             // Start of a new event
             else if (currentEvent.tick != moonEvent.tick && performers != Performer.None)
             {
+                double time = _moonSong.TickToTime(currentEvent.tick);
                 // Add tracked event
-                events.Add(new(type, performers, currentEvent.time, GetLengthInTime(currentEvent),
+                events.Add(new(type, performers, time, GetLengthInTime(currentEvent),
                     currentEvent.tick, currentEvent.length));
 
                 // Track new event
@@ -230,7 +237,8 @@ namespace YARG.Core.Chart
 
         private double GetLengthInTime(MoonVenueEvent ev)
         {
-            return GetLengthInTime(ev.time, ev.tick, ev.length);
+            double time = _moonSong.TickToTime(ev.tick);
+            return GetLengthInTime(time, ev.tick, ev.length);
         }
     }
 }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -167,7 +167,8 @@ namespace YARG.Core.Chart
                                 lyricType = LyricType.NonPitched;
                         }
 
-                        lyrics.Add(new(lyric.ToString(), moonEvent.time, moonEvent.tick));
+                        double time = _moonSong.TickToTime(moonEvent.tick);
+                        lyrics.Add(new(lyric.ToString(), time, moonEvent.tick));
                     }
 
                     // Create new note
@@ -201,9 +202,9 @@ namespace YARG.Core.Chart
         {
             var vocalType = GetVocalNoteType(moonNote);
             float pitch = GetVocalNotePitch(moonNote, lyricType);
-
-            return new VocalNote(pitch, harmonyPart, vocalType,
-                moonNote.time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+			
+            double time = _moonSong.TickToTime(moonNote.tick);
+            return new VocalNote(pitch, harmonyPart, vocalType, time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
         }
 
         private float GetVocalNotePitch(MoonNote moonNote, LyricType lyricType)
@@ -247,7 +248,8 @@ namespace YARG.Core.Chart
 
         private Phrase GetVocalsPhraseBounds(SpecialPhrase moonPhrase)
         {
-            return new Phrase(PhraseType.LyricPhrase, moonPhrase.time, GetLengthInTime(moonPhrase),
+            double time = _moonSong.TickToTime(moonPhrase.tick);
+            return new Phrase(PhraseType.LyricPhrase, time, GetLengthInTime(moonPhrase),
                 moonPhrase.tick, moonPhrase.length);
         }
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -202,7 +202,7 @@ namespace YARG.Core.Chart
         {
             var vocalType = GetVocalNoteType(moonNote);
             float pitch = GetVocalNotePitch(moonNote, lyricType);
-			
+            
             double time = _moonSong.TickToTime(moonNote.tick);
             return new VocalNote(pitch, harmonyPart, vocalType, time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
         }

--- a/YARG.Core/MoonscraperChartParser/Events/BPM.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/BPM.cs
@@ -39,7 +39,6 @@ namespace MoonscraperChartEditor.Song
             return new BPM(tick, value, anchor)
             {
                 assignedTime = assignedTime,
-                song = song,
             };
         }
 

--- a/YARG.Core/MoonscraperChartParser/Events/Beat.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/Beat.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -28,10 +28,7 @@ namespace MoonscraperChartEditor.Song
 
         public new Beat Clone()
         {
-            return new Beat(tick, type)
-            {
-                song = song,
-            };
+            return new Beat(tick, type);
         }
 
         public override string ToString()

--- a/YARG.Core/MoonscraperChartParser/Events/ChartEvent.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/ChartEvent.cs
@@ -52,11 +52,7 @@ namespace MoonscraperChartEditor.Song
 
         public new ChartEvent Clone()
         {
-            return new ChartEvent(tick, eventName)
-            {
-                song = song,
-                chart = chart,
-            };
+            return new ChartEvent(tick, eventName);
         }
 
         public override string ToString()

--- a/YARG.Core/MoonscraperChartParser/Events/ChartObject.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/ChartObject.cs
@@ -8,11 +8,7 @@ namespace MoonscraperChartEditor.Song
     [Serializable]
     internal abstract class ChartObject : SongObject
     {
-// Non-nullable field 'chart' must contain a non-null value when exiting constructor
-// 'chart' is assigned externally as part of this object being added to a chart
-#pragma warning disable 8618
         public ChartObject(uint position) : base(position) { }
-#pragma warning restore 8618
 
         // Clone needs to be hideable so it can return a different type in derived classes
         protected override SongObject SongClone() => ChartClone();

--- a/YARG.Core/MoonscraperChartParser/Events/ChartObject.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/ChartObject.cs
@@ -8,9 +8,6 @@ namespace MoonscraperChartEditor.Song
     [Serializable]
     internal abstract class ChartObject : SongObject
     {
-        [NonSerialized]
-        public MoonChart chart;
-
 // Non-nullable field 'chart' must contain a non-null value when exiting constructor
 // 'chart' is assigned externally as part of this object being added to a chart
 #pragma warning disable 8618

--- a/YARG.Core/MoonscraperChartParser/Events/Event.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/Event.cs
@@ -52,10 +52,7 @@ namespace MoonscraperChartEditor.Song
 
         public new Event Clone()
         {
-            return new Event(title, tick)
-            {
-                song = song,
-            };
+            return new Event(title, tick);
         }
 
         public override string ToString()

--- a/YARG.Core/MoonscraperChartParser/Events/Section.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/Section.cs
@@ -19,10 +19,7 @@ namespace MoonscraperChartEditor.Song
 
         public new Section Clone()
         {
-            return new Section(title, tick)
-            {
-                song = song,
-            };
+            return new Section(title, tick);
         }
 
         public override string ToString()

--- a/YARG.Core/MoonscraperChartParser/Events/SongObject.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/SongObject.cs
@@ -9,11 +9,6 @@ namespace MoonscraperChartEditor.Song
     internal abstract class SongObject
     {
         /// <summary>
-        /// The song this object is connected to.
-        /// </summary>
-        [NonSerialized]
-        public MoonSong song;
-        /// <summary>
         /// The tick position of the object
         /// </summary>
         public uint tick;
@@ -28,11 +23,6 @@ namespace MoonscraperChartEditor.Song
             tick = _tick;
         }
 #pragma warning restore 8618
-
-        /// <summary>
-        /// Automatically converts the object's tick position into the time it will appear in the song.
-        /// </summary>
-        public double time => song.TickToTime(tick, song.resolution);
 
         // Clone needs to be hideable so it can return a different type in derived classes
         protected abstract SongObject SongClone();

--- a/YARG.Core/MoonscraperChartParser/Events/SongObject.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/SongObject.cs
@@ -14,15 +14,11 @@ namespace MoonscraperChartEditor.Song
         public uint tick;
 
         public abstract int classID { get; }
-
-// Non-nullable field 'song' must contain a non-null value when exiting constructor
-// 'song' is assigned externally as part of this object being added to a song
-#pragma warning disable 8618
+        
         public SongObject(uint _tick)
         {
             tick = _tick;
         }
-#pragma warning restore 8618
 
         // Clone needs to be hideable so it can return a different type in derived classes
         protected abstract SongObject SongClone();

--- a/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/SpecialPhrase.cs
@@ -72,7 +72,7 @@ namespace MoonscraperChartEditor.Song
                 return base.LessThan(b);
         }
 
-        public uint GetCappedLengthForPos(uint pos)
+        public uint GetCappedLengthForPos(uint pos, MoonChart? chart)
         {
             uint newLength;
             if (pos > tick)
@@ -81,7 +81,7 @@ namespace MoonscraperChartEditor.Song
                 newLength = 0;
 
             SpecialPhrase? nextSp = null;
-            if (song != null && chart != null)
+            if (chart != null)
             {
                 int arrayPos = SongObjectHelper.FindClosestPosition(this, chart.specialPhrases);
                 if (arrayPos == SongObjectHelper.NOTFOUND)
@@ -114,11 +114,7 @@ namespace MoonscraperChartEditor.Song
 
         public new SpecialPhrase Clone()
         {
-            return new SpecialPhrase(tick, length, type)
-            {
-                song = song,
-                chart = chart,
-            };
+            return new SpecialPhrase(tick, length, type);
         }
 
         public override string ToString()

--- a/YARG.Core/MoonscraperChartParser/Events/TimeSignature.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/TimeSignature.cs
@@ -35,7 +35,7 @@ namespace MoonscraperChartEditor.Song
             public BeatInfo quarterBeatLine;
         }
 
-        public MeasureInfo GetMeasureInfo()
+        public MeasureInfo GetMeasureInfo(MoonSong song)
         {
             var measureInfo = new MeasureInfo();
             float resolution = song.resolution;
@@ -68,10 +68,7 @@ namespace MoonscraperChartEditor.Song
 
         public new TimeSignature Clone()
         {
-            return new TimeSignature(tick, numerator, denominator)
-            {
-                song = song,
-            };
+            return new TimeSignature(tick, numerator, denominator);
         }
 
         public override string ToString()

--- a/YARG.Core/MoonscraperChartParser/Events/VenueEvent.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/VenueEvent.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -35,10 +35,7 @@ namespace MoonscraperChartEditor.Song
 
         public new VenueEvent Clone()
         {
-            return new VenueEvent(type, title, tick, length)
-            {
-                song = song,
-            };
+            return new VenueEvent(type, title, tick, length);
         }
 
         public override string ToString()

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartIOHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartIOHelper.cs
@@ -14,8 +14,8 @@ namespace MoonscraperChartEditor.Song.IO
         public const string SECTION_EVENTS = "Events";
 
         // See MidIOHelper for regex details
-		public static readonly Regex TextEventRegex = MidIOHelper.TextEventRegex;
-		public static readonly Regex SectionEventRegex = MidIOHelper.SectionEventRegex;
+        public static readonly Regex TextEventRegex = MidIOHelper.TextEventRegex;
+        public static readonly Regex SectionEventRegex = MidIOHelper.SectionEventRegex;
 
 
         public const int NOTE_OFFSET_PRO_DRUMS = 64;

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.ProcessLists.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.ProcessLists.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 // Chart file format specifications- https://docs.google.com/document/d/1v2v0U-9HQ5qHeccpExDOLJ5CMPZZ3QytPmAG5WF0Kzs/edit?usp=sharing
@@ -210,7 +210,7 @@ namespace MoonscraperChartEditor.Song.IO
         {
             static void AddSolo(MoonChart chart, uint startTick, uint endTick)
             {
-                chart.Add(new SpecialPhrase(startTick, endTick - startTick, SpecialPhrase.Type.Solo), false);
+                chart.Add(new SpecialPhrase(startTick, endTick - startTick, SpecialPhrase.Type.Solo));
             }
 
             static void ProcessSoloMarkers(MoonChart chart, uint currentTick, ref uint? currentStartTick,
@@ -276,20 +276,18 @@ namespace MoonscraperChartEditor.Song.IO
                 // Determine what events are present on the current tick
                 if (text.eventName == TextEventDefinitions.SOLO_START)
                 {
-                    chart.Remove(text, false);
+                    chart.Remove(text);
                     start = true;
                 }
                 else if (text.eventName == TextEventDefinitions.SOLO_END)
                 {
-                    chart.Remove(text, false);
+                    chart.Remove(text);
                     end = true;
                 }
             }
 
             // Handle final set of events
             ProcessSoloMarkers(chart, currentTick, ref currentStartTick, ref start, ref end);
-
-            chart.UpdateCache();
         }
 
         private static void DisambiguateDrumsType(in NoteProcessParams processParams)

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.ProcessLists.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.ProcessLists.cs
@@ -264,8 +264,9 @@ namespace MoonscraperChartEditor.Song.IO
             bool start = false;
             bool end = false;
 
-            foreach (var text in chart.events)
+            for (int i = 0; i < chart.events.Count;)
             {
+                var text = chart.events[i];
                 // Commit found events on next tick
                 if (text.tick != currentTick)
                 {
@@ -276,14 +277,16 @@ namespace MoonscraperChartEditor.Song.IO
                 // Determine what events are present on the current tick
                 if (text.eventName == TextEventDefinitions.SOLO_START)
                 {
-                    chart.Remove(text);
+                    chart.events.RemoveAt(i);
                     start = true;
                 }
                 else if (text.eventName == TextEventDefinitions.SOLO_END)
                 {
-                    chart.Remove(text);
+                    chart.events.RemoveAt(i);
                     end = true;
                 }
+                else
+                    ++i;
             }
 
             // Handle final set of events

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -189,7 +189,7 @@ namespace MoonscraperChartEditor.Song.IO
         private static void ValidateAndApplySettings(MoonSong song, ParseSettings settings)
         {
             // Apply HOPO threshold settings
-            MoonNote.hopoThreshold = ChartIOHelper.GetHopoThreshold(settings, song.resolution);
+            song.hopoThreshold = ChartIOHelper.GetHopoThreshold(settings, song.resolution);
 
             // Sustain cutoff threshold is not verified, sustains are not cut off by default in .chart
             // SP note is not verified, as it is only relevant for .mid

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -189,7 +189,7 @@ namespace MoonscraperChartEditor.Song.IO
         private static void ValidateAndApplySettings(MoonSong song, ParseSettings settings)
         {
             // Apply HOPO threshold settings
-            song.hopoThreshold = ChartIOHelper.GetHopoThreshold(settings, song.resolution);
+            MoonNote.hopoThreshold = ChartIOHelper.GetHopoThreshold(settings, song.resolution);
 
             // Sustain cutoff threshold is not verified, sustains are not cut off by default in .chart
             // SP note is not verified, as it is only relevant for .mid

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -135,8 +135,6 @@ namespace MoonscraperChartEditor.Song.IO
                 var splitter = sectionText.SplitTrimmed('\n');
                 SubmitChartData(settings, song, sectionName, splitter);
             }
-
-            song.UpdateCache();
             return song;
         }
 
@@ -152,7 +150,7 @@ namespace MoonscraperChartEditor.Song.IO
             else if (sectionName.Equals(ChartIOHelper.SECTION_SYNC_TRACK, StringComparison.Ordinal))
             {
                 YargTrace.DebugInfo("Loading sync data");
-                SubmitDataGlobals(song, sectionLines);
+                SubmitDataSync(song, sectionLines);
                 return;
             }
             else if (sectionName.Equals(ChartIOHelper.SECTION_EVENTS, StringComparison.Ordinal))
@@ -198,7 +196,7 @@ namespace MoonscraperChartEditor.Song.IO
             // Note snap threshold is not verified, as the parser doesn't use it
         }
 
-        private static void SubmitDataGlobals(MoonSong song, TrimSplitter sectionLines)
+        private static void SubmitDataSync(MoonSong song, TrimSplitter sectionLines)
         {
             var anchorData = new List<Anchor>();
 
@@ -231,7 +229,7 @@ namespace MoonscraperChartEditor.Song.IO
                             var denominatorText = remaining.GetNextWord(out remaining);
                             uint denominator = denominatorText.IsEmpty ? 2 : (uint)FastInt32Parse(denominatorText);
 
-                            song.Add(new TimeSignature(tick, numerator, (uint)Math.Pow(2, denominator)), false);
+                            song.Add(new TimeSignature(tick, numerator, (uint)Math.Pow(2, denominator)));
                             break;
                         }
 
@@ -241,34 +239,7 @@ namespace MoonscraperChartEditor.Song.IO
                             var tempoText = remaining.GetNextWord(out remaining);
                             uint tempo = (uint)FastInt32Parse(tempoText);
 
-                            song.Add(new BPM(tick, tempo), false);
-                            break;
-                        }
-
-                        case 'E':
-                        {
-                            // Get event text
-                            string eventText = remaining.Trim().Trim('"').ToString();
-
-                            // Strip off brackets and any garbage outside of them
-                            var match = ChartIOHelper.TextEventRegex.Match(eventText);
-                            if (match.Success)
-                            {
-                                eventText = match.Groups[1].Value;
-                            }
-
-                            // Check for section events
-                            var sectionMatch = ChartIOHelper.SectionEventRegex.Match(eventText);
-                            if (sectionMatch.Success)
-                            {
-                                // This is a section, use the text grouped by the regex
-                                string sectionText = sectionMatch.Groups[1].Value;
-                                song.Add(new Section(sectionText, tick), false);
-                            }
-                            else
-                            {
-                                song.Add(new Event(eventText, tick), false);
-                            }
+                            song.Add(new BPM(tick, tempo));
                             break;
                         }
 
@@ -298,24 +269,78 @@ namespace MoonscraperChartEditor.Song.IO
                 }
             }
 
-            var bpms = song.syncTrack.OfType<BPM>().ToArray();        // BPMs are currently uncached
             foreach (var anchor in anchorData)
             {
-                int arrayPos = SongObjectHelper.FindClosestPosition(anchor.tick, bpms);
-                if (bpms[arrayPos].tick == anchor.tick)
+                int arrayPos = SongObjectHelper.FindClosestPosition(anchor.tick, song.bpms);
+                if (song.bpms[arrayPos].tick == anchor.tick)
                 {
-                    bpms[arrayPos].anchor = anchor.anchorTime;
+                    song.bpms[arrayPos].anchor = anchor.anchorTime;
                 }
                 else
                 {
                     // Create a new anchored bpm
                     uint value;
-                    if (bpms[arrayPos].tick > anchor.tick)
-                        value = bpms[arrayPos - 1].value;
+                    if (song.bpms[arrayPos].tick > anchor.tick)
+                        value = song.bpms[arrayPos - 1].value;
                     else
-                        value = bpms[arrayPos].value;
+                        value = song.bpms[arrayPos].value;
 
                     song.Add(new BPM(anchor.tick, value, anchor.anchorTime));
+                }
+            }
+
+            song.UpdateBPMTimeValues();
+        }
+
+        private static void SubmitDataGlobals(MoonSong song, TrimSplitter sectionLines)
+        {
+            foreach (var _line in sectionLines)
+            {
+                var line = _line.Trim();
+                if (line.IsEmpty)
+                    continue;
+
+                try
+                {
+                    // Split on the equals sign
+                    var tickText = line.SplitOnceTrimmed('=', out var remaining);
+
+                    // Get tick
+                    uint tick = (uint) FastInt32Parse(tickText);
+
+                    // Get event type
+                    var typeCodeText = remaining.GetNextWord(out remaining);
+                    if (typeCodeText[0] == 'E')
+                    {
+                        // Get event text
+                        string eventText = remaining.Trim().Trim('"').ToString();
+
+                        // Strip off brackets and any garbage outside of them
+                        var match = ChartIOHelper.TextEventRegex.Match(eventText);
+                        if (match.Success)
+                        {
+                            eventText = match.Groups[1].Value;
+                        }
+
+                        // Check for section events
+                        var sectionMatch = ChartIOHelper.SectionEventRegex.Match(eventText);
+                        if (sectionMatch.Success)
+                        {
+                            // This is a section, use the text grouped by the regex
+                            string sectionText = sectionMatch.Groups[1].Value;
+                            song.Add(new Section(sectionText, tick));
+                        }
+                        else
+                        {
+                            song.Add(new Event(eventText, tick));
+                        }
+                    }
+                    else
+                        YargTrace.LogWarning($"Unrecognized type code '{typeCodeText[0]}'!");
+                }
+                catch (Exception e)
+                {
+                    YargTrace.LogException(e, $"Error parsing .chart line '{line.ToString()}'!");
                 }
             }
         }

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -339,7 +339,7 @@ namespace MoonscraperChartEditor.Song.IO
                 postNotesAddedProcessList = postNotesAddedProcessList
             };
 
-            chart.InitNotesCapacity(5000);
+            chart.notes.Capacity = 5000;
 
             var noteProcessDict = GetNoteProcessDict(gameMode);
             var specialPhraseProcessDict = GetSpecialPhraseProcessDict(gameMode);
@@ -439,6 +439,7 @@ namespace MoonscraperChartEditor.Song.IO
                 {
                     fn(processParams);
                 }
+                chart.notes.TrimExcess();
             }
             catch (Exception e)
             {

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 // Chart file format specifications- https://docs.google.com/document/d/1v2v0U-9HQ5qHeccpExDOLJ5CMPZZ3QytPmAG5WF0Kzs/edit?usp=sharing
@@ -339,6 +339,8 @@ namespace MoonscraperChartEditor.Song.IO
                 postNotesAddedProcessList = postNotesAddedProcessList
             };
 
+            chart.InitNotesCapacity(5000);
+
             var noteProcessDict = GetNoteProcessDict(gameMode);
             var specialPhraseProcessDict = GetSpecialPhraseProcessDict(gameMode);
 
@@ -417,7 +419,7 @@ namespace MoonscraperChartEditor.Song.IO
                                     eventText = match.Groups[1].Value;
                                 }
 
-                                chart.Add(new ChartEvent(tick, eventText), false);
+                                chart.Add(new ChartEvent(tick, eventText));
                                 break;
                             }
 
@@ -432,7 +434,6 @@ namespace MoonscraperChartEditor.Song.IO
                         YargTrace.LogException(e, $"Error parsing .chart line '{line.ToString()}'!");
                     }
                 }
-                chart.UpdateCache();
 
                 foreach (var fn in postNotesAddedProcessList)
                 {
@@ -464,7 +465,7 @@ namespace MoonscraperChartEditor.Song.IO
             uint sus = ApplySustainCutoff(noteProcessParams.settings, noteEvent.length);
 
             var newMoonNote = new MoonNote(tick, ingameFret, sus, defaultFlags);
-            chart.Add(newMoonNote, false);
+            chart.Add(newMoonNote);
         }
 
         private static void ProcessNoteOnEventAsSpecialPhrase(in NoteProcessParams noteProcessParams, SpecialPhrase.Type type)
@@ -476,7 +477,7 @@ namespace MoonscraperChartEditor.Song.IO
             uint sus = noteEvent.length;
 
             var newPhrase = new SpecialPhrase(tick, sus, type);
-            chart.Add(newPhrase, false);
+            chart.Add(newPhrase);
         }
 
         private static void ProcessNoteOnEventAsChordFlag(in NoteProcessParams noteProcessParams, NoteFlagPriority flagData)

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidIOHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidIOHelper.cs
@@ -43,15 +43,15 @@ namespace MoonscraperChartEditor.Song.IO
         public const string HARMONY_3_TRACK_2 = "PART HARM3";
 
         // Regex for text events, matches text inside [brackets] without including the brackets
-		// '[end]' -> 'end'
+        // '[end]' -> 'end'
         // '[section Solo] - "Solo"' -> 'section Solo'
-		public static readonly Regex TextEventRegex = new(@"\[(.*?)\]", RegexOptions.Compiled | RegexOptions.Singleline);
+        public static readonly Regex TextEventRegex = new(@"\[(.*?)\]", RegexOptions.Compiled | RegexOptions.Singleline);
 
         // Regex for section events, assumes the brackets have already been stripped out
         // 'section Practice' -> 'Practice'
         // 'prc_intro' -> 'intro'
         // 'section_outro' -> 'outro'
-		public static readonly Regex SectionEventRegex = new(@"(?:section|prc)[ _](.*)", RegexOptions.Compiled | RegexOptions.Singleline);
+        public static readonly Regex SectionEventRegex = new(@"(?:section|prc)[ _](.*)", RegexOptions.Compiled | RegexOptions.Singleline);
 
         // Matches venue lighting events and groups the text inside (parentheses), not including the parentheses
         // 'lighting (verse)' -> 'verse'

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.ProcessLists.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.ProcessLists.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -303,20 +303,15 @@ namespace MoonscraperChartEditor.Song.IO
             // TODO: HARM2 phrases are used to mark when lyrics shift in static lyrics, this needs to be preserved in some way
             // TODO: Determine if there are any phrases that shouldn't be removed/copied down
             var chart = processParams.song.GetChart(processParams.instrument, MoonSong.Difficulty.Expert);
-            foreach (var phrase in chart.specialPhrases)
-            {
-                chart.Remove(phrase, false);
-            }
+            chart.specialPhrases.Clear();
 
             // Add in phrases from HARM1
             var harm1 = processParams.song.GetChart(MoonSong.MoonInstrument.Harmony1, MoonSong.Difficulty.Expert);
             foreach (var phrase in harm1.specialPhrases)
             {
                 // Make a new copy instead of adding the original reference
-                chart.Add(phrase.Clone(), false);
+                chart.specialPhrases.Add(phrase.Clone());
             }
-
-            chart.UpdateCache();
         }
 
         private static void SwitchToGuitarEnhancedOpensProcessMap(ref EventProcessParams processParams)

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -164,7 +164,7 @@ namespace MoonscraperChartEditor.Song.IO
         private static void ValidateAndApplySettings(MoonSong song, ParseSettings settings)
         {
             // Apply HOPO threshold settings
-            song.hopoThreshold = MidIOHelper.GetHopoThreshold(settings, song.resolution);
+            MoonNote.hopoThreshold = MidIOHelper.GetHopoThreshold(settings, song.resolution);
 
             // Verify sustain cutoff threshold
             if (settings.SustainCutoffThreshold < 0)
@@ -706,7 +706,7 @@ namespace MoonscraperChartEditor.Song.IO
                         break;
 
                     case MoonNote.MoonNoteType.Tap:
-                        if (!note.IsOpenNote())
+                        if (!note.IsOpenNote(MoonChart.GameMode.Guitar))
                         {
                             note.flags |= MoonNote.Flags.Tap;
                             note.flags &= ~MoonNote.Flags.Forced;
@@ -724,7 +724,8 @@ namespace MoonscraperChartEditor.Song.IO
                         continue;
                 }
 
-                YargTrace.Assert(note.type == newType, $"Failed to set forced type! Expected: {newType}  Actual: {note.type}\non {difficulty} {instrument} at tick {note.tick} ({TimeSpan.FromSeconds(note.time):mm':'ss'.'ff})");
+                double time = song.TickToTime(note.tick);
+                YargTrace.Assert(note.guitarType == newType, $"Failed to set forced type! Expected: {newType}  Actual: {note.guitarType}\non {difficulty} {instrument} at tick {note.tick} ({TimeSpan.FromSeconds(time):mm':'ss'.'ff})");
             }
         }
 

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System;
@@ -149,7 +149,6 @@ namespace MoonscraperChartEditor.Song.IO
                             {
                                 var chart = song.GetChart(instrument, difficulty);
                                 chart.Clear();
-                                chart.UpdateCache();
                             }
                         }
 
@@ -437,12 +436,6 @@ namespace MoonscraperChartEditor.Song.IO
             YargTrace.Assert(unpairedNoteQueue.Count == 0, $"Note queue was not fully processed! Remaining event count: {unpairedNoteQueue.Count}");
             YargTrace.Assert(unpairedSysexQueue.Count == 0, $"SysEx event queue was not fully processed! Remaining event count: {unpairedSysexQueue.Count}");
 
-            // Update chart caches
-            foreach (var diff in EnumExtensions<MoonSong.Difficulty>.Values)
-            {
-                song.GetChart(instrument, diff).UpdateCache();
-            }
-
             // Apply SysEx events first
             // These are separate to prevent forcing issues on open notes marked via SysEx
             foreach (var process in processParams.sysexProcessList)
@@ -638,7 +631,7 @@ namespace MoonscraperChartEditor.Song.IO
                 sus = ApplySustainCutoff(eventProcessParams.settings, sus);
 
             var newMoonNote = new MoonNote(tick, ingameFret, sus, defaultFlags);
-            chart.Add(newMoonNote, false);
+            chart.Add(newMoonNote);
         }
 
         private static void ProcessNoteOnEventAsSpecialPhrase(in EventProcessParams eventProcessParams, SpecialPhrase.Type type)
@@ -652,7 +645,7 @@ namespace MoonscraperChartEditor.Song.IO
 
             foreach (var diff in EnumExtensions<MoonSong.Difficulty>.Values)
             {
-                song.GetChart(instrument, diff).Add(new SpecialPhrase(tick, sus, type), false);
+                song.GetChart(instrument, diff).Add(new SpecialPhrase(tick, sus, type));
             }
         }
 
@@ -882,8 +875,6 @@ namespace MoonscraperChartEditor.Song.IO
                         break;
                 }
             }
-
-            chart.UpdateCache();
         }
     }
 }

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -180,14 +180,13 @@ namespace MoonscraperChartEditor.Song.IO
 
             foreach (var tempo in tempoMap.GetTempoChanges())
             {
-                song.Add(new BPM((uint)tempo.Time, (uint)(tempo.Value.BeatsPerMinute * 1000)), false);
+                song.Add(new BPM((uint)tempo.Time, (uint)(tempo.Value.BeatsPerMinute * 1000)));
             }
             foreach (var timesig in tempoMap.GetTimeSignatureChanges())
             {
-                song.Add(new TimeSignature((uint)timesig.Time, (uint)timesig.Value.Numerator, (uint)timesig.Value.Denominator), false);
+                song.Add(new TimeSignature((uint)timesig.Time, (uint)timesig.Value.Numerator, (uint)timesig.Value.Denominator));
             }
-
-            song.UpdateCache();
+            song.UpdateBPMTimeValues();
         }
 
         private static void ReadSongBeats(TrackChunk track, MoonSong song)
@@ -217,7 +216,7 @@ namespace MoonscraperChartEditor.Song.IO
                             continue;
                     }
 
-                    song.Add(new Beat((uint)absoluteTime, beatType), false);
+                    song.Add(new Beat((uint)absoluteTime, beatType));
                 }
             }
         }
@@ -250,16 +249,14 @@ namespace MoonscraperChartEditor.Song.IO
                     {
                         // This is a section, use the text grouped by the regex
                         string sectionText = sectionMatch.Groups[1].Value;
-                        song.Add(new Section(sectionText, (uint)absoluteTime), false);
+                        song.Add(new Section(sectionText, (uint)absoluteTime));
                         continue;
                     }
 
                     // Add the event as-is
-                    song.Add(new Event(eventText, (uint)absoluteTime), false);
+                    song.Add(new Event(eventText, (uint)absoluteTime));
                 }
             }
-
-            song.UpdateCache();
         }
 
         private static void ReadTextEventsIntoGlobalEventsAsLyrics(TrackChunk track, MoonSong song)
@@ -277,18 +274,16 @@ namespace MoonscraperChartEditor.Song.IO
                 if (trackEvent is BaseTextEvent text && !text.Text.Contains('['))
                 {
                     string lyricEvent = TextEventDefinitions.LYRIC_PREFIX_WITH_SPACE + text.Text;
-                    song.Add(new Event(lyricEvent, (uint)absoluteTime), false);
+                    song.Add(new Event(lyricEvent, (uint)absoluteTime));
                 }
                 else if (trackEvent is NoteEvent note && (byte)note.NoteNumber is MidIOHelper.LYRICS_PHRASE_1 or MidIOHelper.LYRICS_PHRASE_2)
                 {
                     if (note.EventType == MidiEventType.NoteOn)
-                        song.Add(new Event(TextEventDefinitions.LYRIC_PHRASE_START, (uint)absoluteTime), false);
+                        song.Add(new Event(TextEventDefinitions.LYRIC_PHRASE_START, (uint)absoluteTime));
                     else if (note.EventType == MidiEventType.NoteOff)
-                        song.Add(new Event(TextEventDefinitions.LYRIC_PHRASE_END, (uint)absoluteTime), false);
+                        song.Add(new Event(TextEventDefinitions.LYRIC_PHRASE_END, (uint)absoluteTime));
                 }
             }
-
-            song.UpdateCache();
         }
 
         private static void ReadVenueEvents(TrackChunk track, MoonSong song)
@@ -331,7 +326,7 @@ namespace MoonscraperChartEditor.Song.IO
                             continue;
 
                         // Add the event
-                        song.Add(new VenueEvent(eventData.type, eventData.text, (uint)startTick, (uint)(startTick - absoluteTime)), false);
+                        song.Add(new VenueEvent(eventData.type, eventData.text, (uint)startTick, (uint)(startTick - absoluteTime)));
                     }
                 }
                 else if (trackEvent is BaseTextEvent text)
@@ -344,7 +339,7 @@ namespace MoonscraperChartEditor.Song.IO
                     // Get new representation of the event
                     if (MidIOHelper.VENUE_TEXT_CONVERSION_LOOKUP.TryGetValue(eventText, out var eventData))
                     {
-                        song.Add(new VenueEvent(eventData.type, eventData.text, (uint)absoluteTime), false);
+                        song.Add(new VenueEvent(eventData.type, eventData.text, (uint)absoluteTime));
                     }
                     else
                     {
@@ -364,18 +359,16 @@ namespace MoonscraperChartEditor.Song.IO
                             }
 
                             matched = true;
-                            song.Add(new VenueEvent(type, converted, (uint)absoluteTime), false);
+                            song.Add(new VenueEvent(type, converted, (uint)absoluteTime));
                             break;
                         }
 
                         // Unknown events
                         if (!matched)
-                            song.Add(new VenueEvent(VenueEvent.Type.Unknown, eventText, (uint)absoluteTime), false);
+                            song.Add(new VenueEvent(VenueEvent.Type.Unknown, eventText, (uint)absoluteTime));
                     }
                 }
             }
-
-            song.UpdateCache();
         }
 
         private static void ReadNotes(ParseSettings settings, TrackChunk track, MoonSong song,

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -455,6 +455,9 @@ namespace MoonscraperChartEditor.Song.IO
             {
                 process(processParams);
             }
+
+            foreach (var difficulty in EnumExtensions<MoonSong.Difficulty>.Values)
+                song.GetChart(instrument, difficulty).notes.TrimExcess();
         }
 
         private static void ProcessNoteEvent(ref EventProcessParams processParams, NoteEventQueue unpairedNotes,
@@ -631,6 +634,8 @@ namespace MoonscraperChartEditor.Song.IO
                 sus = ApplySustainCutoff(eventProcessParams.settings, sus);
 
             var newMoonNote = new MoonNote(tick, ingameFret, sus, defaultFlags);
+            if (chart.notes.Capacity == 0)
+                chart.notes.Capacity = 5000;
             chart.Add(newMoonNote);
         }
 

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -164,7 +164,7 @@ namespace MoonscraperChartEditor.Song.IO
         private static void ValidateAndApplySettings(MoonSong song, ParseSettings settings)
         {
             // Apply HOPO threshold settings
-            MoonNote.hopoThreshold = MidIOHelper.GetHopoThreshold(settings, song.resolution);
+            song.hopoThreshold = MidIOHelper.GetHopoThreshold(settings, song.resolution);
 
             // Verify sustain cutoff threshold
             if (settings.SustainCutoffThreshold < 0)
@@ -693,14 +693,14 @@ namespace MoonscraperChartEditor.Song.IO
                 switch (newType)
                 {
                     case MoonNote.MoonNoteType.Strum:
-                        if (!note.isChord && note.isNaturalHopo)
+                        if (!note.isChord && note.IsNaturalHopo(song.hopoThreshold))
                             note.flags |= MoonNote.Flags.Forced;
                         else
                             note.flags &= ~MoonNote.Flags.Forced;
                         break;
 
                     case MoonNote.MoonNoteType.Hopo:
-                        if (note.isChord || !note.isNaturalHopo)
+                        if (note.isChord || !note.IsNaturalHopo(song.hopoThreshold))
                             note.flags |= MoonNote.Flags.Forced;
                         else
                             note.flags &= ~MoonNote.Flags.Forced;
@@ -726,7 +726,7 @@ namespace MoonscraperChartEditor.Song.IO
                 }
 
                 double time = song.TickToTime(note.tick);
-                YargTrace.Assert(note.guitarType == newType, $"Failed to set forced type! Expected: {newType}  Actual: {note.guitarType}\non {difficulty} {instrument} at tick {note.tick} ({TimeSpan.FromSeconds(time):mm':'ss'.'ff})");
+                YargTrace.Assert(note.GetGuitarType(song.hopoThreshold) == newType, $"Failed to set forced type! Expected: {newType}  Actual: {note.GetGuitarType(song.hopoThreshold)}\non {difficulty} {instrument} at tick {note.tick} ({TimeSpan.FromSeconds(time):mm':'ss'.'ff})");
             }
         }
 

--- a/YARG.Core/MoonscraperChartParser/MoonChart.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonChart.cs
@@ -50,12 +50,6 @@ namespace MoonscraperChartEditor.Song
             specialPhrases.Clear();
         }
 
-        public void InitNotesCapacity(int capcaity)
-        {
-            notes.Capacity = capcaity;
-        }
-
-
         public int Add(MoonNote note)
         {
             note.chart = this;

--- a/YARG.Core/MoonscraperChartParser/MoonChart.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonChart.cs
@@ -7,8 +7,6 @@ namespace MoonscraperChartEditor.Song
 {
     internal class MoonChart
     {
-        private readonly List<ChartObject> _chartObjects = new();
-
         /// <summary>
         /// The song this chart is connected to.
         /// </summary>
@@ -21,20 +19,15 @@ namespace MoonscraperChartEditor.Song
         /// <summary>
         /// Read only list of notes.
         /// </summary>
-        public SongObjectCache<MoonNote> notes { get; private set; } = new();
+        public List<MoonNote> notes { get; private set; } = new();
         /// <summary>
         /// Read only list of special phrases.
         /// </summary>
-        public SongObjectCache<SpecialPhrase> specialPhrases { get; private set; } = new();
+        public List<SpecialPhrase> specialPhrases { get; private set; } = new();
         /// <summary>
         /// Read only list of local events.
         /// </summary>
-        public SongObjectCache<ChartEvent> events { get; private set; } = new();
-
-        /// <summary>
-        /// Read only list containing all chart notes, special phrases, and text events.
-        /// </summary>
-        public ReadOnlyList<ChartObject> chartObjects { get; private set; }
+        public List<ChartEvent> events { get; private set; } = new();
 
         /// <summary>
         /// Creates a new chart object.
@@ -44,63 +37,64 @@ namespace MoonscraperChartEditor.Song
         {
             song = _song;
             gameMode = _gameMode;
-
-            chartObjects = new ReadOnlyList<ChartObject>(_chartObjects);
         }
 
         public MoonChart(MoonSong song, MoonSong.MoonInstrument Instrument) : this(song, MoonSong.InstumentToChartGameMode(Instrument))
         {
         }
 
-        /// <summary>
-        /// Updates all read-only values and the total note count.
-        /// </summary>
-        public void UpdateCache()
-        {
-            MoonSong.UpdateCacheList(notes, _chartObjects);
-            MoonSong.UpdateCacheList(specialPhrases, _chartObjects);
-            MoonSong.UpdateCacheList(events, _chartObjects);
-        }
-
         public void Clear()
         {
-            _chartObjects.Clear();
+            notes.Clear();
+            events.Clear();
+            specialPhrases.Clear();
         }
 
-        /// <summary>
-        /// Adds a chart object (note, special phrase, and/or chart event) into the chart.
-        /// </summary>
-        /// <param name="chartObject">The item to add</param>
-        /// <param name="update">Automatically update all read-only arrays? 
-        /// If set to false, you must manually call the updateArrays() method, but is useful when adding multiple objects as it increases performance dramatically.</param>
-        public int Add(ChartObject chartObject, bool update = true)
+        public void InitNotesCapacity(int capcaity)
         {
-            chartObject.chart = this;
-            chartObject.song = song;
-
-            int pos = SongObjectHelper.Insert(chartObject, _chartObjects);
-
-            if (update)
-                UpdateCache();
-
-            return pos;
+            notes.Capacity = capcaity;
         }
 
-        /// <summary>
-        /// Removes a chart object (note, special phrase, and/or chart event) from the chart.
-        /// </summary>
-        /// <param name="chartObject">Item to add.</param>
-        /// <param name="update">Automatically update all read-only arrays? 
-        /// If set to false, you must manually call the updateArrays() method, but is useful when removing multiple objects as it increases performance dramatically.</param>
-        /// <returns>Returns whether the removal was successful or not (item may not have been found if false).</returns>
-        public bool Remove(ChartObject chartObject, bool update = true)
+
+        public int Add(MoonNote note)
         {
-            bool success = SongObjectHelper.Remove(chartObject, _chartObjects);
+            note.chart = this;
+            note.song = song;
+            return SongObjectHelper.Insert(note, notes);
+        }
 
-            if (update)
-                UpdateCache();
+        public int Add(SpecialPhrase phrase)
+        {
+            phrase.chart = this;
+            phrase.song = song;
+            return SongObjectHelper.Insert(phrase, specialPhrases);
+        }
 
-            return success;
+        public int Add(ChartEvent ev)
+        {
+            ev.chart = this;
+            ev.song = song;
+            return SongObjectHelper.Insert(ev, events);
+        }
+
+        public bool Remove(MoonNote note)
+        {
+            return SongObjectHelper.Remove(note, notes);
+        }
+
+        public bool Remove(SpecialPhrase phrase)
+        {
+            return SongObjectHelper.Remove(phrase, specialPhrases);
+        }
+
+        public bool Remove(ChartEvent ev)
+        {
+            return SongObjectHelper.Remove(ev, events);
+        }
+
+        public bool IsOccupied()
+        {
+            return notes.Count > 0 || specialPhrases.Count > 0 || events.Count > 0;
         }
 
         public enum GameMode

--- a/YARG.Core/MoonscraperChartParser/MoonChart.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonChart.cs
@@ -52,22 +52,16 @@ namespace MoonscraperChartEditor.Song
 
         public int Add(MoonNote note)
         {
-            note.chart = this;
-            note.song = song;
             return SongObjectHelper.Insert(note, notes);
         }
 
         public int Add(SpecialPhrase phrase)
         {
-            phrase.chart = this;
-            phrase.song = song;
             return SongObjectHelper.Insert(phrase, specialPhrases);
         }
 
         public int Add(ChartEvent ev)
         {
-            ev.chart = this;
-            ev.song = song;
             return SongObjectHelper.Insert(ev, events);
         }
 

--- a/YARG.Core/MoonscraperChartParser/MoonSong.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonSong.cs
@@ -22,7 +22,6 @@ namespace MoonscraperChartEditor.Song
         }
 
         public float resolution;
-        public float hopoThreshold;
         public float offset = 0;
 
         public float? manualLength = null;
@@ -181,19 +180,16 @@ namespace MoonscraperChartEditor.Song
 
         public void Add(Beat beat)
         {
-            beat.song = this;
             SongObjectHelper.Insert(beat, beats);
         }
 
         public void Add(TimeSignature timeSig)
         {
-            timeSig.song = this;
             SongObjectHelper.Insert(timeSig, timeSignatures);
         }
 
         public void Add(BPM bpm)
         {
-            bpm.song = this;
             SongObjectHelper.Insert(bpm, bpms);
         }
 
@@ -214,19 +210,16 @@ namespace MoonscraperChartEditor.Song
 
         public void Add(Event ev)
         {
-            ev.song = this;
             SongObjectHelper.Insert(ev, events);
         }
 
         public void Add(Section section)
         {
-            section.song = this;
             SongObjectHelper.Insert(section, sections);
         }
 
         public void Add(VenueEvent venueEvent)
         {
-            venueEvent.song = this;
             SongObjectHelper.Insert(venueEvent, venue);
         }
 

--- a/YARG.Core/MoonscraperChartParser/MoonSong.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonSong.cs
@@ -41,28 +41,28 @@ namespace MoonscraperChartEditor.Song
         /// <summary>
         /// Read only list of song events.
         /// </summary>
-        public SongObjectCache<Event> events { get; private set; } = new();
+        public List<Event> events { get; private set; } = new();
         /// <summary>
         /// Read only list of song sections.
         /// </summary>
-        public SongObjectCache<Section> sections { get; private set; } = new();
+        public List<Section> sections { get; private set; } = new();
         /// <summary>
         /// Read only list of venue events.
         /// </summary>
-        public SongObjectCache<VenueEvent> venue { get; private set; } = new();
+        public List<VenueEvent> venue { get; private set; } = new();
 
         /// <summary>
         /// Read only list of a song's bpm changes.
         /// </summary>
-        public SongObjectCache<BPM> bpms { get; private set; } = new();
+        public List<BPM> bpms { get; private set; } = new();
         /// <summary>
         /// Read only list of a song's time signature changes.
         /// </summary>
-        public SongObjectCache<TimeSignature> timeSignatures { get; private set; } = new();
+        public List<TimeSignature> timeSignatures { get; private set; } = new();
         /// <summary>
         /// Read only list of a song's beats.
         /// </summary>
-        public SongObjectCache<Beat> beats { get; private set; } = new();
+        public List<Beat> beats { get; private set; } = new();
 
         /// <summary>
         /// Default constructor for a new chart. Initialises all lists and adds locked bpm and timesignature objects.
@@ -96,7 +96,7 @@ namespace MoonscraperChartEditor.Song
             foreach (var difficulty in EnumExtensions<Difficulty>.Values)
             {
                 var chart = GetChart(instrument, difficulty);
-                if (chart.chartObjects.Count > 0)
+                if (chart.IsOccupied())
                 {
                     return true;
                 }
@@ -107,7 +107,7 @@ namespace MoonscraperChartEditor.Song
 
         public bool DoesChartExist(MoonInstrument instrument, Difficulty difficulty)
         {
-            return GetChart(instrument, difficulty).chartObjects.Count > 0;
+            return GetChart(instrument, difficulty).IsOccupied();
         }
 
         /// <summary>
@@ -260,18 +260,17 @@ namespace MoonscraperChartEditor.Song
             return success;
         }
 
-        public static void UpdateCacheList<T, U>(SongObjectCache<T> cache, List<U> objectsToCache)
+        public static void UpdateCacheList<T, U>(List<T> cache, List<U> objectsToCache)
             where U : SongObject
             where T : U
         {
-            var cacheObjectList = cache.EditCache();
-            cacheObjectList.Clear();
+            cache.Clear();
 
             foreach (var objectToCache in objectsToCache)
             {
                 if (objectToCache.GetType() == typeof(T))
                 {
-                    cacheObjectList.Add((T) objectToCache);
+                    cache.Add((T) objectToCache);
                 }
             }
         }
@@ -290,12 +289,6 @@ namespace MoonscraperChartEditor.Song
             UpdateCacheList(beats, _syncTrack);
 
             UpdateBPMTimeValues();
-        }
-
-        public void UpdateAllChartCaches()
-        {
-            foreach (var chart in charts)
-                chart.UpdateCache();
         }
 
         /// <summary>
@@ -442,83 +435,6 @@ namespace MoonscraperChartEditor.Song
             Vocals = 8,
             Keys = 9,
             Crowd = 10
-        }
-    }
-
-    internal class SongObjectCache<T> : IList<T>, IEnumerable<T> where T : SongObject
-    {
-        private readonly List<T> cache = new();
-
-        public T this[int index] { get { return cache[index]; } set { cache[index] = value; } }
-
-        public int Count
-        {
-            get { return cache.Count; }
-        }
-
-        public bool IsReadOnly
-        {
-            get { return true; }
-        }
-
-        public void Add(T item)
-        {
-            throw new NotSupportedException();
-        }
-
-        public void Clear()
-        {
-            throw new NotSupportedException();
-        }
-
-        public bool Contains(T item)
-        {
-            return cache.Contains(item);
-        }
-
-        public void CopyTo(T[] array, int arrayIndex)
-        {
-
-        }
-
-        public IEnumerator<T> GetEnumerator()
-        {
-            return cache.GetEnumerator();
-        }
-
-        public int IndexOf(T item)
-        {
-            return cache.IndexOf(item);
-        }
-
-        public void Insert(int index, T item)
-        {
-            throw new NotSupportedException();
-        }
-
-        public bool Remove(T item)
-        {
-            throw new NotSupportedException();
-        }
-
-        public void RemoveAt(int index)
-        {
-            throw new NotSupportedException();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return cache.GetEnumerator();
-        }
-
-        public List<T> EditCache()
-        {
-            return cache;
-        }
-
-        public T[] ToArray()
-        {
-            return cache.ToArray();
         }
     }
 

--- a/YARG.Core/MoonscraperChartParser/MoonSong.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonSong.cs
@@ -22,6 +22,7 @@ namespace MoonscraperChartEditor.Song
         }
 
         public float resolution;
+        public float hopoThreshold;
         public float offset = 0;
 
         public float? manualLength = null;

--- a/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
@@ -255,8 +255,8 @@ namespace MoonscraperChartEditor.Song
 
         /// <summary>
         /// Insert a note into the provided list linearly, with the search starting from the back of the list.
-        /// Ensures correct setting of `previous` & `next` variables.
-        /// Use for handling .mid
+        /// Ensures correct setting of 'previous' and 'next' variables.
+        /// Use for handling .mid note off events
         /// </summary>
         /// <param name="note">The note to be inserted.</param>
         /// <param name="notes">The list in which the note will be inserted.</param>
@@ -287,7 +287,7 @@ namespace MoonscraperChartEditor.Song
 
         /// <summary>
         /// Insert an item into the provided list linearly, with the search starting from the back of the list.
-        /// Use for handling .mid
+        /// Use for handling .mid note off events
         /// </summary>
         /// <param name="item">The item to be inserted.</param>
         /// <param name="list">The list in which the item will be inserted.</param>

--- a/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
@@ -267,18 +267,21 @@ namespace MoonscraperChartEditor.Song
             while (pos > 0 && notes[pos - 1].tick > note.tick)
                 --pos;
 
-            if (pos > 0)
+            if (pos == 0 || notes[pos - 1].tick < note.tick || notes[pos - 1] != note)
             {
-                note.previous = notes[pos - 1];
-                notes[pos - 1].next = note;
-            }
+                if (pos > 0)
+                {
+                    note.previous = notes[pos - 1];
+                    notes[pos - 1].next = note;
+                }
 
-            if (pos < notes.Count)
-            {
-                notes[pos].previous = note;
-                note.next = notes[pos];
+                if (pos < notes.Count)
+                {
+                    notes[pos].previous = note;
+                    note.next = notes[pos];
+                }
+                notes.Insert(pos, note);
             }
-            notes.Insert(pos, note);
             return pos;
         }
 
@@ -292,9 +295,11 @@ namespace MoonscraperChartEditor.Song
         public static int OrderedInsertFromBack<T>(T item, List<T> list) where T : SongObject
         {
             int pos = list.Count;
-            while (pos > 0 && list[pos - 1].tick > item.tick)
+            while (pos > 0 && item.tick < list[pos - 1].tick)
                 --pos;
-            list.Insert(pos, item);
+
+            if (pos == 0 || list[pos - 1].tick < item.tick || list[pos - 1] != item)
+                list.Insert(pos, item);
             return pos;
         }
 

--- a/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
@@ -267,21 +267,29 @@ namespace MoonscraperChartEditor.Song
             while (pos > 0 && notes[pos - 1].tick > note.tick)
                 --pos;
 
-            if (pos == 0 || notes[pos - 1].tick < note.tick || notes[pos - 1] != note)
+            if (pos > 0 && notes[pos - 1].tick == note.tick)
             {
-                if (pos > 0)
+                int check = pos - 1;
+                do
                 {
-                    note.previous = notes[pos - 1];
-                    notes[pos - 1].next = note;
-                }
-
-                if (pos < notes.Count)
-                {
-                    notes[pos].previous = note;
-                    note.next = notes[pos];
-                }
-                notes.Insert(pos, note);
+                    if (notes[check] == note)
+                        return check;
+                    --check;
+                } while (check >= 0 && notes[check].tick == note.tick);
             }
+
+            if (pos > 0)
+            {
+                note.previous = notes[pos - 1];
+                notes[pos - 1].next = note;
+            }
+
+            if (pos < notes.Count)
+            {
+                notes[pos].previous = note;
+                note.next = notes[pos];
+            }
+            notes.Insert(pos, note);
             return pos;
         }
 
@@ -298,8 +306,18 @@ namespace MoonscraperChartEditor.Song
             while (pos > 0 && item.tick < list[pos - 1].tick)
                 --pos;
 
-            if (pos == 0 || list[pos - 1].tick < item.tick || list[pos - 1] != item)
-                list.Insert(pos, item);
+            if (pos > 0 && list[pos - 1].tick == item.tick)
+            {
+                int check = pos - 1;
+                do
+                {
+                    if (list[check] == item)
+                        return check;
+                    --check;
+                } while (check >= 0 && list[check].tick == item.tick);
+            }
+
+            list.Insert(pos, item);
             return pos;
         }
 

--- a/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
@@ -233,6 +233,71 @@ namespace MoonscraperChartEditor.Song
                 return list[pos];
         }
 
+
+        /// <summary>
+        /// Pushes a MoonNote to the back of a list, ensuring correct setting of `previous` & `next` variables.
+        /// </summary>
+        /// <param name="note">The note to be inserted, with assumed correct ordering.</param>
+        /// <param name="notes">The list in which the note will be inserted.</param>
+        /// <returns>Returns the list position it was inserted into,
+        /// which equates to the list size before insertion.</returns>
+        public static int PushNote(MoonNote note, List<MoonNote> notes)
+        {
+            int pos = notes.Count;
+            if (pos > 0)
+            {
+                note.previous = notes[pos - 1];
+                notes[pos - 1].next = note;
+            }
+            notes.Add(note);
+            return pos;
+        }
+
+        /// <summary>
+        /// Insert a note into the provided list linearly, with the search starting from the back of the list.
+        /// Ensures correct setting of `previous` & `next` variables.
+        /// Use for handling .mid
+        /// </summary>
+        /// <param name="note">The note to be inserted.</param>
+        /// <param name="notes">The list in which the note will be inserted.</param>
+        /// <returns>Returns the list position it was inserted into.</returns>
+        public static int OrderedInsertFromBack(MoonNote note, List<MoonNote> notes)
+        {
+            int pos = notes.Count;
+            while (pos > 0 && notes[pos - 1].tick > note.tick)
+                --pos;
+
+            if (pos > 0)
+            {
+                note.previous = notes[pos - 1];
+                notes[pos - 1].next = note;
+            }
+
+            if (pos < notes.Count)
+            {
+                notes[pos].previous = note;
+                note.next = notes[pos];
+            }
+            notes.Insert(pos, note);
+            return pos;
+        }
+
+        /// <summary>
+        /// Insert an item into the provided list linearly, with the search starting from the back of the list.
+        /// Use for handling .mid
+        /// </summary>
+        /// <param name="item">The item to be inserted.</param>
+        /// <param name="list">The list in which the item will be inserted.</param>
+        /// <returns>Returns the list position it was inserted into.</returns>
+        public static int OrderedInsertFromBack<T>(T item, List<T> list) where T : SongObject
+        {
+            int pos = list.Count;
+            while (pos > 0 && list[pos - 1].tick > item.tick)
+                --pos;
+            list.Insert(pos, item);
+            return pos;
+        }
+
         /// <summary>
         /// Adds the item into a sorted position into the specified list and updates the note linked list if a note is inserted. 
         /// </summary>
@@ -240,7 +305,7 @@ namespace MoonscraperChartEditor.Song
         /// <param name="item">The item to be inserted.</param>
         /// <param name="list">The list in which the item will be inserted.</param>
         /// <returns>Returns the list position it was inserted into.</returns>
-        public static int Insert<T>(T item, IList<T> list) where T : SongObject
+        public static int Insert<T>(T item, List<T> list) where T : SongObject
         {
             int insertionPos = NOTFOUND;
             int count = list.Count;

--- a/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/SongObjectHelper.cs
@@ -382,20 +382,21 @@ namespace MoonscraperChartEditor.Song
         /// <param name="item">The item to be remove.</param>
         /// <param name="list">The list in which the item will be removed from.</param>
         /// <returns>Returns whether the item was successfully removed or not (may not be removed if the objects was not found).</returns>
-        public static bool Remove<T>(T item, IList<T> list, bool uniqueData = true) where T : SongObject
+        public static bool Remove(MoonNote item, IList<MoonNote> list, bool uniqueData = true)
         {
             int pos = FindObjectPosition(item, list);
 
             if (pos != NOTFOUND)
             {
-                if (uniqueData && item.GetType() == typeof(MoonNote))
+                if (uniqueData)
                 {
                     // Update linked list
-                    var previous = FindPreviousOfType(item.GetType(), pos, list) as MoonNote;
-                    var next = FindNextOfType(item.GetType(), pos, list) as MoonNote;
+                    var previous = FindPreviousOfType(item.GetType(), pos, list);
+                    var next = FindNextOfType(item.GetType(), pos, list);
 
                     if (previous != null)
                         previous.next = next;
+
                     if (next != null)
                         next.previous = previous;
                 }
@@ -406,6 +407,19 @@ namespace MoonscraperChartEditor.Song
 
             return false;
         }
+
+        public static bool Remove<T>(T item, IList<T> list) where T : SongObject
+        {
+            int pos = FindObjectPosition(item, list);
+            if (pos != NOTFOUND)
+            {
+                list.RemoveAt(pos);
+                return true;
+            }
+            return false;
+        }
+
+
         public static T[] GetRangeCopy<T>(T[] list, uint minPos, uint maxPos) where T : SongObject
         {
             GetRange(list, minPos, maxPos, out int index, out int length);


### PR DESCRIPTION
Simplifies how the parser interacts with moonscraper structures, making parsing less fragile and improving the scaling as chart sizes increase. This includes removing all UpdateCache()s as their existence was flawed.

+ This fixes issues with parsing speed in regards to larger .mid files (ex. Crash Test 5.5 in .mid form going from 6 minutes to 5 seconds)