### PR TITLE
Lyric Censoring [YARG-22]

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -154,7 +154,13 @@ namespace YARG.Core.Chart
                         // Ignore non-lyric events
                         var start = splitter.GetNext();
                         var lyric = splitter.Remaining;
-                        if (!start.Equals(TextEventDefinitions.LYRIC_PREFIX, StringComparison.Ordinal))
+                        bool isExplicit = false;
+                        
+                        if (start.Equals(TextEventDefinitions.LYRIC_PREFIX, StringComparison.Ordinal))
+                            isExplicit = false;
+                        else if (start.Equals(TextEventDefinitions.E_LYRIC_PREFIX, StringComparison.Ordinal))
+                            isExplicit = true;
+                        else
                             continue;
 
                         // Only process note modifiers for lyrics that match the current note
@@ -168,7 +174,11 @@ namespace YARG.Core.Chart
                         }
 
                         double time = _moonSong.TickToTime(moonEvent.tick);
-                        lyrics.Add(new(lyric.ToString(), time, moonEvent.tick));
+                        
+       					if (isExplicit)
+        					lyrics.Add(new(new string('-', lyric.ToString().Length) + " ", time, moonEvent.tick));
+        				else
+           					lyrics.Add(new(lyric.ToString(), time, moonEvent.tick));
                     }
 
                     // Create new note

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -158,7 +158,7 @@ namespace YARG.Core.Chart
                         
                         if (start.Equals(TextEventDefinitions.LYRIC_PREFIX, StringComparison.Ordinal))
                             isExplicit = false;
-                        else if (start.Equals(TextEventDefinitions.E_LYRIC_PREFIX, StringComparison.Ordinal))
+                        else if (start.Equals(TextEventDefinitions.EXPLICIT_LYRIC_PREFIX, StringComparison.Ordinal))
                             isExplicit = true;
                         else
                             continue;

--- a/YARG.Core/MoonscraperChartParser/TextEventDefinitions.cs
+++ b/YARG.Core/MoonscraperChartParser/TextEventDefinitions.cs
@@ -10,7 +10,7 @@ namespace MoonscraperChartEditor.Song
         #region Global lyric events
         public const string
         LYRIC_PREFIX = "lyric",
-        E_LYRIC_PREFIX = "lyric_explicit",
+        EXPLICIT_LYRIC_PREFIX = "lyric_explicit",
         LYRIC_PREFIX_WITH_SPACE = LYRIC_PREFIX + " ",
         LYRIC_PHRASE_START = "phrase_start",
         LYRIC_PHRASE_END = "phrase_end";

--- a/YARG.Core/MoonscraperChartParser/TextEventDefinitions.cs
+++ b/YARG.Core/MoonscraperChartParser/TextEventDefinitions.cs
@@ -10,6 +10,7 @@ namespace MoonscraperChartEditor.Song
         #region Global lyric events
         public const string
         LYRIC_PREFIX = "lyric",
+        E_LYRIC_PREFIX = "lyric_explicit",
         LYRIC_PREFIX_WITH_SPACE = LYRIC_PREFIX + " ",
         LYRIC_PHRASE_START = "phrase_start",
         LYRIC_PHRASE_END = "phrase_end";


### PR DESCRIPTION
Censoring lyrics using `lyric_explicit` prefix. 
Solution to [YARG-22](https://yarg.youtrack.cloud/issue/YARG-22/Censored-vocals).