### PR TITLE
Make MIDI readers choose/auto-detect correct text encoding for lyrics/text events

### DIFF
--- a/YARG.Core/Chart/MidiSettings.cs
+++ b/YARG.Core/Chart/MidiSettings.cs
@@ -27,16 +27,4 @@ namespace YARG.Core.Chart
             TextEncoding = YARGTextContainer.Latin1,
         };
 	}
-
-    public static class MidiSettingsUTF8
-    {
-        public static readonly ReadingSettings Instance = new()
-        {
-            InvalidChunkSizePolicy = InvalidChunkSizePolicy.Ignore,
-            NotEnoughBytesPolicy = NotEnoughBytesPolicy.Ignore,
-            NoHeaderChunkPolicy = NoHeaderChunkPolicy.Ignore,
-            InvalidChannelEventParameterValuePolicy = InvalidChannelEventParameterValuePolicy.ReadValid,
-            TextEncoding = Encoding.UTF8,
-        };
-	}
 }

--- a/YARG.Core/Chart/MidiSettings.cs
+++ b/YARG.Core/Chart/MidiSettings.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using Melanchall.DryWetMidi.Core;
+using YARG.Core.IO;
 
 namespace YARG.Core.Chart
 {
@@ -11,14 +12,31 @@ namespace YARG.Core.Chart
             NotEnoughBytesPolicy = NotEnoughBytesPolicy.Ignore,
             NoHeaderChunkPolicy = NoHeaderChunkPolicy.Ignore,
             InvalidChannelEventParameterValuePolicy = InvalidChannelEventParameterValuePolicy.ReadValid,
-            TextEncoding = Encoding.UTF8,
-            // DecodeTextCallback = DecodeText,
+            TextEncoding = new UTF8Encoding(false, true),
         };
+	}
 
-        // TODO: Use this to detect string encoding
-        // private static string DecodeText(byte[] bytes, ReadingSettings settings)
-        // {
+    public static class MidiSettingsLatin1
+    {
+        public static readonly ReadingSettings Instance = new()
+        {
+            InvalidChunkSizePolicy = InvalidChunkSizePolicy.Ignore,
+            NotEnoughBytesPolicy = NotEnoughBytesPolicy.Ignore,
+            NoHeaderChunkPolicy = NoHeaderChunkPolicy.Ignore,
+            InvalidChannelEventParameterValuePolicy = InvalidChannelEventParameterValuePolicy.ReadValid,
+            TextEncoding = YARGTextContainer.Latin1,
+        };
+	}
 
-        // }
+    public static class MidiSettingsUTF8
+    {
+        public static readonly ReadingSettings Instance = new()
+        {
+            InvalidChunkSizePolicy = InvalidChunkSizePolicy.Ignore,
+            NotEnoughBytesPolicy = NotEnoughBytesPolicy.Ignore,
+            NoHeaderChunkPolicy = NoHeaderChunkPolicy.Ignore,
+            InvalidChannelEventParameterValuePolicy = InvalidChannelEventParameterValuePolicy.ReadValid,
+            TextEncoding = Encoding.UTF8,
+        };
 	}
 }

--- a/YARG.Core/Chart/MidiSettings.cs
+++ b/YARG.Core/Chart/MidiSettings.cs
@@ -12,7 +12,7 @@ namespace YARG.Core.Chart
             NotEnoughBytesPolicy = NotEnoughBytesPolicy.Ignore,
             NoHeaderChunkPolicy = NoHeaderChunkPolicy.Ignore,
             InvalidChannelEventParameterValuePolicy = InvalidChannelEventParameterValuePolicy.ReadValid,
-            TextEncoding = new UTF8Encoding(false, true),
+            TextEncoding = YARGTextContainer.UTF8Strict,
         };
 	}
 

--- a/YARG.Core/Chart/ParsingProperties.cs
+++ b/YARG.Core/Chart/ParsingProperties.cs
@@ -1,6 +1,4 @@
-﻿using System.Text;
-
-namespace YARG.Core.Chart
+﻿namespace YARG.Core.Chart
 {
     /// <summary>
     /// The type of drums contained in the chart.
@@ -30,7 +28,6 @@ namespace YARG.Core.Chart
             NoteSnapThreshold = 0,
 
             StarPowerNote = SETTING_DEFAULT,
-            Encoding = null,
         };
 
         public const int SETTING_DEFAULT = -1;
@@ -44,6 +41,5 @@ namespace YARG.Core.Chart
         public long NoteSnapThreshold;
 
         public int StarPowerNote;
-        public string? Encoding;
     }
 }

--- a/YARG.Core/Chart/ParsingProperties.cs
+++ b/YARG.Core/Chart/ParsingProperties.cs
@@ -1,4 +1,6 @@
-﻿namespace YARG.Core.Chart
+﻿using System.Text;
+
+namespace YARG.Core.Chart
 {
     /// <summary>
     /// The type of drums contained in the chart.
@@ -28,6 +30,7 @@
             NoteSnapThreshold = 0,
 
             StarPowerNote = SETTING_DEFAULT,
+            Encoding = null,
         };
 
         public const int SETTING_DEFAULT = -1;
@@ -41,5 +44,6 @@
         public long NoteSnapThreshold;
 
         public int StarPowerNote;
+        public string? Encoding;
     }
 }

--- a/YARG.Core/IO/TextReader/YARGTextContainer.cs
+++ b/YARG.Core/IO/TextReader/YARGTextContainer.cs
@@ -7,6 +7,7 @@ namespace YARG.Core.IO
     public static class YARGTextContainer
     {
         public static readonly Encoding Latin1 = Encoding.GetEncoding(28591);
+        public static readonly Encoding UTF8Strict = new UTF8Encoding(false, true);
     }
 
     public sealed class YARGTextContainer<TChar>

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -69,28 +69,15 @@ namespace MoonscraperChartEditor.Song.IO
             MidiFile midi;
             try
             {
-                switch (settings.Encoding) {
-                    case "utf8":
-                    case "utf-8":
-                        midi = MidiFile.Read(path, MidiSettingsUTF8.Instance); // Force UTF-8
-                        YargTrace.DebugInfo("Loaded forced UTF-8 midi");
-                        break;
-                    case "latin1":
-                        midi = MidiFile.Read(path, MidiSettingsLatin1.Instance); // Force Latin-1
-                        YargTrace.DebugInfo("Loaded forced Latin-1 midi");
-                        break;
-                    default:
-                        try
-                        {
-                            midi = MidiFile.Read(path, MidiSettings.Instance); // Try UTF-8
-                            YargTrace.DebugInfo("Loaded autodetected UTF-8 midi");
-                        }
-                        catch (DecoderFallbackException)
-                        {
-                            midi = MidiFile.Read(path, MidiSettingsLatin1.Instance); // Force Latin-1 as fallback
-                            YargTrace.DebugInfo("Loaded autodetected Latin-1 midi");
-                        }
-                        break;
+                try
+                {
+                    midi = MidiFile.Read(path, MidiSettings.Instance); // Reading .ini MIDI; Try UTF-8
+                    YargTrace.DebugInfo("Loaded autodetected UTF-8 midi");
+                }
+                catch (DecoderFallbackException)
+                {
+                    midi = MidiFile.Read(path, MidiSettingsLatin1.Instance); // Force Latin-1 as fallback
+                    YargTrace.DebugInfo("Loaded autodetected Latin-1 midi");
                 }
                 // midi = MidiFile.Read(path, MidiSettings.Instance);
             }

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -11,6 +11,7 @@ using YARG.Core.Chart;
 using YARG.Core.Song;
 using YARG.Core.Extensions;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 
 namespace MoonscraperChartEditor.Song.IO
 {
@@ -68,7 +69,30 @@ namespace MoonscraperChartEditor.Song.IO
             MidiFile midi;
             try
             {
-                midi = MidiFile.Read(path, MidiSettings.Instance);
+                switch (settings.Encoding) {
+                    case "utf8":
+                    case "utf-8":
+                        midi = MidiFile.Read(path, MidiSettingsUTF8.Instance); // Force UTF-8
+                        YargTrace.DebugInfo("Loaded forced UTF-8 midi");
+                        break;
+                    case "latin1":
+                        midi = MidiFile.Read(path, MidiSettingsLatin1.Instance); // Force Latin-1
+                        YargTrace.DebugInfo("Loaded forced Latin-1 midi");
+                        break;
+                    default:
+                        try
+                        {
+                            midi = MidiFile.Read(path, MidiSettings.Instance); // Try UTF-8
+                            YargTrace.DebugInfo("Loaded autodetected UTF-8 midi");
+                        }
+                        catch (DecoderFallbackException)
+                        {
+                            midi = MidiFile.Read(path, MidiSettingsLatin1.Instance); // Force Latin-1 as fallback
+                            YargTrace.DebugInfo("Loaded autodetected Latin-1 midi");
+                        }
+                        break;
+                }
+                // midi = MidiFile.Read(path, MidiSettings.Instance);
             }
             catch (Exception e)
             {

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -273,10 +273,6 @@ namespace YARG.Core.Song
 
         private SongMetadata(IRBCONMetadata rbMeta, YARGBinaryReader reader, CategoryCacheStrings strings) : this(reader, strings)
         {
-            if (_parseSettings.Encoding is null)
-            {
-                _parseSettings.Encoding = "latin1";
-            }
             _rbData = rbMeta;
             _directory = rbMeta.SharedMetadata.Directory;
         }
@@ -461,8 +457,7 @@ namespace YARG.Core.Song
                     case "author": _charter = reader.ExtractText(); break;
                     case "guide_pitch_volume": /*GuidePitchVolume = reader.ReadFloat();*/ break;
                     case "encoding":
-                        _parseSettings.Encoding = reader.ExtractText().ToLower();
-                        var encoding = _parseSettings.Encoding switch
+                        var encoding = reader.ExtractText().ToLower() switch
                         {
                             "latin1" => YARGTextContainer.Latin1,
                             "utf-8" or
@@ -728,19 +723,8 @@ namespace YARG.Core.Song
         private SongChart LoadCONChart()
         {
             MidiFile midi;
-            ReadingSettings readingSettings = MidiSettings.Instance;
-            switch (_parseSettings.Encoding) {
-                case "latin1":
-                    readingSettings = MidiSettingsLatin1.Instance;
-                    break;
-                case "utf8":
-                case "utf-8":
-                    readingSettings = MidiSettingsUTF8.Instance;
-                    break;
-                default: break;
-            }
-            YargTrace.DebugInfo("RBCON encoding: " + _parseSettings.Encoding);
-            // Read base MIDI
+            ReadingSettings readingSettings = MidiSettingsLatin1.Instance; // RBCONs are always Latin-1
+            // Read base MIDi
             using (var midiStream = RBData!.GetMidiStream())
             {
                 if (midiStream == null)


### PR DESCRIPTION
Previously, the MIDI readers would assume lyrics/text events are UTF-8 encoding by default. However, that is not true to all MIDIs. The proposed solution goes as thus:

- RBCONs are set to Latin-1 encoding. The `encoding` parameter on the DTA applies only to the DTA itself; RB MIDIs are always Latin-1 encoded.
- .ini MIDIs are read with strict (throws error on invalid character) UTF-8 parsing rules.
  - If that fails, the MIDI is re-read with Latin-1 encoding.
- .chart reading is untouched.

This shouldn't affect performance in any significant way; scanning won't be affected, .charts and RBCONs won't be affected, and most MIDIs will be valid UTF-8 (intentionally or not; english-only Latin-1 is also perfectly valid UTF-8). The only case in which the MIDI would be read twice is old/C3CON Tools converted non-english songs, but the benefit of their lyrics being read correctly more than makes up for the negligible performance loss of reading the MIDI twice (since song loading is near-instant anyway).