### PR TITLE
Auto-generate venue lighting incase it doesn't exist

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Venue.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Venue.cs
@@ -26,7 +26,7 @@ namespace YARG.Core.Chart
             { VENUE_PERFORMER_KEYS,   Performer.Keyboard },
         };
 
-        private static readonly Dictionary<string, LightingType> LightingLookup = new()
+        public static readonly Dictionary<string, LightingType> LightingLookup = new()
         {
             // Keyframed
             { VENUE_LIGHTING_DEFAULT,     LightingType.Default },
@@ -62,7 +62,7 @@ namespace YARG.Core.Chart
             { VENUE_LIGHTING_PREVIOUS, LightingType.Keyframe_Previous },
         };
 
-        private static readonly Dictionary<string, PostProcessingType> PostProcessLookup = new()
+        public static readonly Dictionary<string, PostProcessingType> PostProcessLookup = new()
         {
             { VENUE_POSTPROCESS_DEFAULT, PostProcessingType.Default },
 

--- a/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
+++ b/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace YARG.Core.Chart
 {
@@ -20,6 +21,7 @@ namespace YARG.Core.Chart
             DefaultSectionPreset = new AutogenerationSectionPreset();
             DefaultSectionPreset.AllowedLightPresets.Add(LightingType.Default);
             DefaultSectionPreset.AllowedPostProcs.Add(PostProcessingType.Default);
+            SectionPresets = new List<AutogenerationSectionPreset>();
             if (File.Exists(path))
             {
                 ReadPresetFromFile(path);
@@ -32,7 +34,36 @@ namespace YARG.Core.Chart
 
         private void ReadPresetFromFile(string path)
         {
-            // TODO: read preset from file (JSON) fuction
+            // TODO: ACTUALLY TEST IT!! GOTTA SLEEP
+            try
+            {
+                JObject o = JObject.Parse(File.ReadAllText(path));
+                string cameraPacing = (string)o.SelectToken("camera_pacing");
+                CameraPacing = StringToCameraPacing(cameraPacing);
+                bool defaultSectionRead = false;
+
+                foreach (var sectionPreset in (JObject)o.SelectToken("section_presets")) {
+                    AutogenerationSectionPreset value = JObjectToSectionPreset((JObject)sectionPreset.Value);
+                    value.SectionName = sectionPreset.Key;
+                    if (sectionPreset.Key.ToLower().Trim() == "default")
+                    {
+                        DefaultSectionPreset = value;
+                        if (defaultSectionRead)
+                        {
+                            YargTrace.DebugWarning("Multiple default sections found in preset: " + path);
+                        }
+                        defaultSectionRead = true;
+                    }
+                    else
+                    {
+                        SectionPresets.Add(value);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                YargTrace.LogException(ex, $"Error while loading auto-gen preset {path}");
+            }
         }
 
         public void GenerateLightingEvents(ref SongChart chart) {
@@ -42,8 +73,84 @@ namespace YARG.Core.Chart
         public void GenerateCameraCutEvents(ref SongChart chart) {
             // TODO: camera cut generator function
         }
+
+        private AutogenerationSectionPreset JObjectToSectionPreset(JObject o) {
+            AutogenerationSectionPreset sectionPreset = new AutogenerationSectionPreset();
+            foreach (var parameter in o)
+            {
+                switch (parameter.Key.ToLower().Trim())
+                {
+                    case "allowed_lightpresets":
+                        List<LightingType> allowedLightPresets = new List<LightingType>();
+                        foreach (string key in (JArray)parameter.Value) {
+                            key = key.Trim();
+                            if (VENUE_LIGHTING_CONVERSION_LOOKUP.TryGetValue(key, out eventData))
+                            {
+                                allowedLightPresets.Add(eventData);
+                            }
+                            else
+                            {
+                                YargTrace.DebugWarning("Invalid light preset: " + key);
+                            }
+                        }
+                        sectionPreset.AllowedLightPresets = allowedLightPresets;
+                        break;
+                    case "allowed_postprocs":
+                        List<LightingType> allowedPostProcs = new List<LightingType>();
+                        foreach (string key in (JArray)parameter.Value) {
+                            key = key.Trim();
+                            if (VENUE_TEXT_CONVERSION_LOOKUP.TryGetValue(key, out eventData) && eventData.type == VenueEvent.Type.PostProcessing)
+                            {
+                                allowedPostProcs.Add(eventData.text);
+                            }
+                            else
+                            {
+                                YargTrace.DebugWarning("Invalid post-proc: " + key);
+                            }
+                        }
+                        sectionPreset.AllowedPostProcs = allowedPostProcs;
+                        break;
+                    case "keyframe_rate":
+                        sectionPreset.KeyframeRate = (int)parameter.Value;
+                        break;
+                    case "lightpreset_blendin":
+                        sectionPreset.LightPresetBlendIn = (int)parameter.Value;
+                        break;
+                    case "postproc_blendin":
+                        sectionPreset.PostProcBlendIn = (int)parameter.Value;
+                        break;
+                    /*case "dircut_at_start":
+                        // TODO: add when we have characters / directed camera cuts
+                        break;*/
+                    case "bonusfx_at_start":
+                        sectionPreset.BonusFxAtStart = (bool)parameter.Value;
+                        break;
+                    case "camera_pacing":
+                        sectionPreset.CameraPacing = StringToCameraPacing((string)parameter.Value);
+                        break;
+                }
+            }
+            return sectionPreset;
+        }
         
-       
+        private CameraPacing StringToCameraPacing(string cameraPacing)
+        {
+            switch (cameraPacing.ToLower().Trim()) {
+                case "minimal": 
+                    return CameraPacing.Minimal;
+                case "slow":
+                    return CameraPacing.Slow;
+                case "medium":
+                    return CameraPacing.Medium;
+                case "fast":
+                    return CameraPacing.Fast;
+                case "crazy":
+                    return CameraPacing.Crazy;
+                default:
+                    YargTrace.DebugWarning("Invalid camera pacing in auto-gen preset: " + cameraPacing);
+                    return CameraPacing.Medium;
+            }
+        }
         
     }
 

--- a/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
+++ b/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
@@ -39,7 +39,6 @@ namespace YARG.Core.Chart
 
         private void ReadPresetFromFile(string path)
         {
-            // TODO: ACTUALLY TEST IT!! GOTTA SLEEP
             try
             {
                 JObject o = JObject.Parse(File.ReadAllText(path));
@@ -63,6 +62,10 @@ namespace YARG.Core.Chart
                     {
                         SectionPresets.Add(value);
                     }
+                }
+                if (!defaultSectionRead)
+                {
+                    YargTrace.DebugWarning("Missing default section in preset: " + path);
                 }
             }
             catch (Exception ex)

--- a/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
+++ b/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
@@ -80,6 +80,7 @@ namespace YARG.Core.Chart
             uint resolution = chart.Resolution;
             LightingType latestLighting = LightingType.Intro;
             PostProcessingType latestPostProc = PostProcessingType.Default;
+            bool latestBonusFxState = false;
             // Add initial state
             chart.VenueTrack.Lighting.Add(new LightingEvent(latestLighting, 0, 0));
             chart.VenueTrack.PostProcessing.Add(new PostProcessingEvent(latestPostProc, 0, 0));
@@ -111,6 +112,12 @@ namespace YARG.Core.Chart
                 {
                     YargTrace.DebugInfo("No match found for section " + section.Name + "; using default autogen section");
                 }
+                // BonusFx at start
+                if (sectionPreset.BonusFxAtStart && !latestBonusFxState) // Avoid multiple BonusFx in a row
+                {
+                    chart.VenueTrack.Stage.Add(new StageEffectEvent(StageEffect.BonusFx, VenueEventFlags.None, section.Time, section.Tick));
+                }
+                latestBonusFxState = sectionPreset.BonusFxAtStart;
                 // Actually generate lighting
                 LightingType currentLighting = latestLighting;
                 foreach (LightingType lighting in sectionPreset.AllowedLightPresets)

--- a/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
+++ b/YARG.Core/Chart/Venue/VenueAutogenerationPreset.cs
@@ -1,0 +1,89 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+
+namespace YARG.Core.Chart
+{
+    /// <summary>
+    /// A venue auto-generation preset; to be used incase a given chart does not include manually charted lighting/camera cues.
+    /// </summary>
+    public class VenueAutogenerationPreset
+    {
+        public CameraPacing CameraPacing;
+        public AutogenerationSectionPreset DefaultSectionPreset;
+        public List<AutogenerationSectionPreset> SectionPresets;
+        
+        public VenueAutogenerationPreset(string path)
+        {
+            CameraPacing = CameraPacing.Medium;
+            DefaultSectionPreset = new AutogenerationSectionPreset();
+            DefaultSectionPreset.AllowedLightPresets.Add(LightingType.Default);
+            DefaultSectionPreset.AllowedPostProcs.Add(PostProcessingType.Default);
+            if (File.Exists(path))
+            {
+                ReadPresetFromFile(path);
+            }
+            else
+            {
+                YargTrace.DebugWarning("Auto-generation preset file not found: " + path);
+            }
+        }
+
+        private void ReadPresetFromFile(string path)
+        {
+            // TODO: read preset from file (JSON) fuction
+        }
+
+        public void GenerateLightingEvents(ref SongChart chart) {
+            // TODO: lighting generator function
+        }
+
+        public void GenerateCameraCutEvents(ref SongChart chart) {
+            // TODO: camera cut generator function
+        }
+        
+       
+        
+    }
+
+    public class AutogenerationSectionPreset
+    {
+        public string SectionName; // probably useless
+        public List<string> PracticeSections; // i.e. "*verse*" which applies to "Verse 1", "Verse 2", etc.
+        public List<LightingType> AllowedLightPresets;
+        public List<PostProcessingType> AllowedPostProcs;
+        public int KeyframeRate;
+        public int LightPresetBlendIn;
+        public int PostProcBlendIn;
+        // public DirectedCameraCutType DirectedCutAtStart; // TODO: add when we have characters / directed camera cuts
+        public bool BonusFxAtStart;
+        public CameraPacing? CameraPacingOverride;
+
+        public AutogenerationSectionPreset()
+        {
+            // Default values
+            SectionName = "";
+            PracticeSections = new List<string>();
+            AllowedLightPresets = new List<LightingType>();
+            AllowedPostProcs = new List<PostProcessingType>();
+            KeyframeRate = 2;
+            LightPresetBlendIn = 0;
+            PostProcBlendIn = 0;
+            BonusFxAtStart = false;
+            CameraPacingOverride = null;
+        }
+    }
+
+    /// <summary>
+    /// Possible camera pacing values.
+    /// </summary>
+    public enum CameraPacing
+    {
+        Minimal,
+        Slow,
+        Medium,
+        Fast,
+        Crazy
+    }
+}

--- a/YARG.Core/Song/Metadata/SongMetadata.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.cs
@@ -227,11 +227,11 @@ namespace YARG.Core.Song
         {
             if (IniData != null)
             {
-                return LoadIniChart();
+                return AutogenerateVenue(LoadIniChart());
             }
             else if (RBData != null)
             {
-                return LoadCONChart();
+                return AutogenerateVenue(LoadCONChart());
             }
 
             // This is an invalid state, notify about it
@@ -241,5 +241,27 @@ namespace YARG.Core.Song
         }
 
         public override string ToString() { return _artist + " | " + _name; }
+
+        private SongChart AutogenerateVenue(SongChart chart, bool skip = false) {
+            // Auto-generate venue events if needed - don't do anything if not needed
+            // TODO: possibly move this to YARG itself rather than YARG.Core?
+            if (skip) // useful in case of engine being used only to validate replays and whatnot rather than actually playing the game
+            {
+                return chart; 
+            }
+            // TODO: load from settings rather than hardcoded path
+            VenueAutogenerationPreset autogenerationPreset = new VenueAutogenerationPreset("Z:\\rgces\\Documents\\ArenaRockPreset.json");
+            if (chart.VenueTrack.Lighting.Count == 0)
+            {
+                YargTrace.DebugInfo("Auto-generating venue lighting...");
+                autogenerationPreset.GenerateLightingEvents(ref chart);
+            }
+            // TODO: add when characters and camera events are present ingame
+            /*if (chart.VenueTrack.Camera.Count == 0)
+            {
+                autogenerationPreset.GenerateCameraCutEvents(ref chart);
+            }*/
+            return chart;
+        }
     }
 }

--- a/YARG.Core/Song/Metadata/SongMetadata.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.cs
@@ -245,7 +245,7 @@ namespace YARG.Core.Song
 
         private SongChart AutogenerateVenue(SongChart chart, string? autogenPath = null) {
             // Auto-generate venue events if needed - don't do anything if not needed
-            // TODO: possibly move this to YARG itself rather than YARG.Core?
+            // TODO: possibly move this function to YARG itself rather than YARG.Core?
             if (autogenPath is null || !File.Exists(autogenPath)) // useful in case of engine being used only to validate replays and whatnot rather than actually playing the game
             {
                 return chart; 

--- a/YARG.Core/Song/Metadata/SongMetadata.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Text.RegularExpressions;
 using YARG.Core.Chart;
 
@@ -223,15 +224,15 @@ namespace YARG.Core.Song
 
         public SongMetadata() { }
 
-        public SongChart LoadChart()
+        public SongChart LoadChart(string? autogenPath = null)
         {
             if (IniData != null)
             {
-                return AutogenerateVenue(LoadIniChart());
+                return AutogenerateVenue(LoadIniChart(), autogenPath);
             }
             else if (RBData != null)
             {
-                return AutogenerateVenue(LoadCONChart());
+                return AutogenerateVenue(LoadCONChart(), autogenPath);
             }
 
             // This is an invalid state, notify about it
@@ -242,15 +243,15 @@ namespace YARG.Core.Song
 
         public override string ToString() { return _artist + " | " + _name; }
 
-        private SongChart AutogenerateVenue(SongChart chart, bool skip = false) {
+        private SongChart AutogenerateVenue(SongChart chart, string? autogenPath = null) {
             // Auto-generate venue events if needed - don't do anything if not needed
             // TODO: possibly move this to YARG itself rather than YARG.Core?
-            if (skip) // useful in case of engine being used only to validate replays and whatnot rather than actually playing the game
+            if (autogenPath is null || !File.Exists(autogenPath)) // useful in case of engine being used only to validate replays and whatnot rather than actually playing the game
             {
                 return chart; 
             }
-            // TODO: load from settings rather than hardcoded path
-            VenueAutogenerationPreset autogenerationPreset = new VenueAutogenerationPreset("Z:\\rgces\\Documents\\ArenaRockPreset.json");
+            // Full path sent from YARG expected here
+            VenueAutogenerationPreset autogenerationPreset = new VenueAutogenerationPreset(autogenPath);
             if (chart.VenueTrack.Lighting.Count == 0)
             {
                 YargTrace.DebugInfo("Auto-generating venue lighting...");


### PR DESCRIPTION
This code reads a JSON file containing info on which lighting presets/post-procs to use for which sections, and generates a lighting track based on that info, if the song currently being loaded doesn't have it.
Implementation loosely based on MagmaC3's, detailed in http://docs.c3universe.com/rbndocs/index.php?title=Venue_Autogeneration
This needs implementation on the YARG side as well, but the game should still behave the same without it (i.e. songs loading normally, without venue autogeneration).

Example auto-generation preset JSON file, for testing purposes: [DefaultPreset.json](https://github.com/YARC-Official/YARG.Core/files/13253806/DefaultPreset.json)
Demo video: https://www.youtube.com/watch?v=jd588FNhSOE (for any `[next]` counter that resets to 0 for no reason -- that's the blend-in lighting event, not a `[first]` keyframe)

Suggestion for implementation on the YARG side:
- Have built-in presets in some game folder, like `StreamingAssets/autogen` or similar;
- Read custom presets from `PersistentDataPath/autogen` or similar;
- List them in a dropdown in the settings, either near to other venue-related settings, or on the Presets tab;
- Pass the selected preset as a parameter for the Song.LoadChart() function.

Please let me know if any changes are needed.