### PR TITLE
Introduce Basic Status Validation On Song Load

### DIFF
--- a/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
@@ -1,0 +1,72 @@
+﻿using Melanchall.DryWetMidi.Core;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using YARG.Core.Chart;
+using YARG.Core.Extensions;
+
+namespace YARG.Core.Song
+{
+    public sealed partial class SongMetadata
+    {
+        public SongChart LoadChart()
+        {
+            if (IniData != null)
+            {
+                return LoadIniChart();
+            }
+            else if (RBData != null)
+            {
+                return LoadCONChart();
+            }
+
+            // This is an invalid state, notify about it
+            string errorMessage = $"No chart data available for song {Name} - {Artist}!";
+            YargTrace.Fail(errorMessage);
+            throw new Exception(errorMessage);
+        }
+
+        private SongChart LoadIniChart()
+        {
+            string notesFile = IniData!.chartFile.FullName;
+            YargTrace.LogInfo($"Loading chart file {notesFile}");
+            return SongChart.FromFile(_parseSettings, notesFile);
+        }
+
+        private SongChart LoadCONChart()
+        {
+            MidiFile midi;
+            ReadingSettings readingSettings = MidiSettingsLatin1.Instance; // RBCONs are always Latin-1
+            // Read base MIDI
+            using (var midiStream = RBData!.GetMidiStream())
+            {
+                if (midiStream == null)
+                    throw new Exception("Base MIDI file not present");
+                midi = MidiFile.Read(midiStream, readingSettings);
+            }
+
+            // Merge update MIDI
+            var shared = RBData.SharedMetadata;
+            if (shared.UpdateMidi != null)
+            {
+                using var midiStream = shared.GetMidiUpdateStream();
+                if (midiStream == null)
+                    throw new Exception("Scanned update MIDI file not present");
+                var update = MidiFile.Read(midiStream, readingSettings);
+                midi.Merge(update);
+            }
+
+            // Merge upgrade MIDI
+            if (shared.Upgrade != null)
+            {
+                using var midiStream = shared.Upgrade.GetUpgradeMidiStream();
+                if (midiStream == null)
+                    throw new Exception("Scanned upgrade MIDI file not present");
+                var update = MidiFile.Read(midiStream, readingSettings);
+                midi.Merge(update);
+            }
+
+            return SongChart.FromMidi(_parseSettings, midi);
+        }
+    }
+}

--- a/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
@@ -9,7 +9,7 @@ namespace YARG.Core.Song
 {
     public sealed partial class SongMetadata
     {
-        public SongChart LoadChart()
+        public SongChart? LoadChart()
         {
             if (IniData != null)
             {
@@ -26,14 +26,17 @@ namespace YARG.Core.Song
             throw new Exception(errorMessage);
         }
 
-        private SongChart LoadIniChart()
+        private SongChart? LoadIniChart()
         {
-            string notesFile = IniData!.chartFile.FullName;
+            if (!IniData!.chartFile.IsStillValid())
+                return null;
+
+            string notesFile = IniData.chartFile.FullName;
             YargTrace.LogInfo($"Loading chart file {notesFile}");
             return SongChart.FromFile(_parseSettings, notesFile);
         }
 
-        private SongChart LoadCONChart()
+        private SongChart? LoadCONChart()
         {
             MidiFile midi;
             ReadingSettings readingSettings = MidiSettingsLatin1.Instance; // RBCONs are always Latin-1
@@ -41,7 +44,7 @@ namespace YARG.Core.Song
             using (var midiStream = RBData!.GetMidiStream())
             {
                 if (midiStream == null)
-                    throw new Exception("Base MIDI file not present");
+                    return null;
                 midi = MidiFile.Read(midiStream, readingSettings);
             }
 
@@ -51,7 +54,7 @@ namespace YARG.Core.Song
             {
                 using var midiStream = shared.GetMidiUpdateStream();
                 if (midiStream == null)
-                    throw new Exception("Scanned update MIDI file not present");
+                    return null;
                 var update = MidiFile.Read(midiStream, readingSettings);
                 midi.Merge(update);
             }
@@ -61,7 +64,7 @@ namespace YARG.Core.Song
             {
                 using var midiStream = shared.Upgrade.GetUpgradeMidiStream();
                 if (midiStream == null)
-                    throw new Exception("Scanned upgrade MIDI file not present");
+                    return null;
                 var update = MidiFile.Read(midiStream, readingSettings);
                 midi.Merge(update);
             }

--- a/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
@@ -1,6 +1,7 @@
 ﻿using Melanchall.DryWetMidi.Core;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Text;
 using YARG.Core.Chart;
 using YARG.Core.Extensions;
@@ -52,9 +53,10 @@ namespace YARG.Core.Song
             var shared = RBData.SharedMetadata;
             if (shared.UpdateMidi != null)
             {
-                using var midiStream = shared.GetMidiUpdateStream();
-                if (midiStream == null)
+                if (!shared.UpdateMidi.IsStillValid())
                     return null;
+
+                using var midiStream = new FileStream(shared.UpdateMidi.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
                 var update = MidiFile.Read(midiStream, readingSettings);
                 midi.Merge(update);
             }

--- a/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Loading.cs
@@ -29,7 +29,7 @@ namespace YARG.Core.Song
 
         private SongChart? LoadIniChart()
         {
-            if (!IniData!.chartFile.IsStillValid())
+            if (!IniData!.Validate(_directory))
                 return null;
 
             string notesFile = IniData.chartFile.FullName;

--- a/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
@@ -358,12 +358,5 @@ namespace YARG.Core.Song
                 return DrumsType.Unknown;
             return fivelane ? DrumsType.FiveLane : DrumsType.FourLane;
         }
-
-        private SongChart LoadIniChart()
-        {
-            string notesFile = IniData!.chartFile.FullName;
-            YargTrace.LogInfo($"Loading chart file {notesFile}");
-            return SongChart.FromFile(_parseSettings, notesFile);
-        }
     }
 }

--- a/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongIni.cs
@@ -69,6 +69,17 @@ namespace YARG.Core.Song
                     writer.Write(false);
             }
 
+            public bool Validate(string directory)
+            {
+                if (!chartFile.IsStillValid())
+                    return false;
+
+                if (iniFile == null)
+                    return !File.Exists(Path.Combine(directory, "song.ini"));
+
+                return iniFile.IsStillValid();
+            }
+
             private static readonly string[] SupportedFormats =
             {
                 ".ogg", ".mogg", ".wav", ".mp3", ".aiff", ".opus",

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -719,41 +719,5 @@ namespace YARG.Core.Song
                 return values;
             }
         }
-
-        private SongChart LoadCONChart()
-        {
-            MidiFile midi;
-            ReadingSettings readingSettings = MidiSettingsLatin1.Instance; // RBCONs are always Latin-1
-            // Read base MIDi
-            using (var midiStream = RBData!.GetMidiStream())
-            {
-                if (midiStream == null)
-                    throw new Exception("Base MIDI file not present");
-                midi = MidiFile.Read(midiStream, readingSettings);
-            }
-
-            // Merge update MIDI
-            var shared = RBData.SharedMetadata;
-            if (shared.UpdateMidi != null)
-            {
-                using var midiStream = shared.GetMidiUpdateStream();
-                if (midiStream == null)
-                    throw new Exception("Scanned update MIDI file not present");
-                var update = MidiFile.Read(midiStream, readingSettings);
-                midi.Merge(update);
-            }
-
-            // Merge upgrade MIDI
-            if (shared.Upgrade != null)
-            {
-                using var midiStream = shared.Upgrade.GetUpgradeMidiStream();
-                if (midiStream == null)
-                    throw new Exception("Scanned upgrade MIDI file not present");
-                var update = MidiFile.Read(midiStream, readingSettings);
-                midi.Merge(update);
-            }
-
-            return SongChart.FromMidi(_parseSettings, midi);
-        }
     }
 }

--- a/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.SongRBCON.cs
@@ -209,17 +209,6 @@ namespace YARG.Core.Song
                 }
             }
 
-            public Stream? GetMidiUpdateStream()
-            {
-                if (UpdateMidi == null)
-                    return null;
-
-                FileInfo info = new(UpdateMidi.FullName);
-                if (!info.Exists || info.LastWriteTime != UpdateMidi.LastWriteTime)
-                    return null;
-                return new FileStream(UpdateMidi.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            }
-
             public byte[]? LoadMidiUpdateFile()
             {
                 if (UpdateMidi == null)

--- a/YARG.Core/Song/Metadata/SongMetadata.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.cs
@@ -223,23 +223,6 @@ namespace YARG.Core.Song
 
         public SongMetadata() { }
 
-        public SongChart LoadChart()
-        {
-            if (IniData != null)
-            {
-                return LoadIniChart();
-            }
-            else if (RBData != null)
-            {
-                return LoadCONChart();
-            }
-
-            // This is an invalid state, notify about it
-            string errorMessage = $"No chart data available for song {Name} - {Artist}!";
-            YargTrace.Fail(errorMessage);
-            throw new Exception(errorMessage);
-        }
-
         public override string ToString() { return _artist + " | " + _name; }
     }
 }

--- a/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
+++ b/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
@@ -35,14 +35,14 @@ namespace YARG.Core.Song
 
         public Stream? GetUpgradeMidiStream()
         {
-            if (_midiListing == null || _midiListing.lastWrite != _lastWrite)
+            if (_midiListing == null || !_midiListing.ConFile.IsStillValid())
                 return null;
             return _midiListing.CreateStream();
         }
 
         public byte[]? LoadUpgradeMidi()
         {
-            if (_midiListing == null || _midiListing.lastWrite != _lastWrite)
+            if (_midiListing == null || !_midiListing.ConFile.IsStillValid())
                 return null;
             return _midiListing.LoadAllBytes();
         }


### PR DESCRIPTION
Failed validations will cause the song to not load (resulting in a null value instead of an error). Validation fails signal either missing or updated chart, CON, or ini files.

This should make score tracking a bit easier to manage, though more security *will* still need to be added later for leader board stuff (accursed memory manipulators).

+ Requires a main repo update to handle the null-ability change properly