### PR TITLE
Allow processing inputs and updating to the current time in a single engine update

### DIFF
--- a/ReplayAnalyzer/Analyzer.cs
+++ b/ReplayAnalyzer/Analyzer.cs
@@ -121,11 +121,11 @@ public class Analyzer
                 // Run!
                 if (engine.IsInputQueued)
                 {
-                    engine.UpdateEngine();
+                    engine.UpdateEngineInputs();
                 }
                 else
                 {
-                    engine.UpdateEngine(frameTime);
+                    engine.UpdateEngineToTime(frameTime);
                 }
             }
         }

--- a/ReplayAnalyzer/Analyzer.cs
+++ b/ReplayAnalyzer/Analyzer.cs
@@ -5,6 +5,7 @@ using YARG.Core.Engine.Drums;
 using YARG.Core.Engine.Drums.Engines;
 using YARG.Core.Engine.Guitar;
 using YARG.Core.Engine.Guitar.Engines;
+using YARG.Core.Engine.Logging;
 using YARG.Core.Engine.Vocals;
 using YARG.Core.Engine.Vocals.Engines;
 using YARG.Core.Input;
@@ -19,10 +20,12 @@ public class Analyzer
     private readonly SongChart _chart;
     private readonly Replay    _replay;
 
-    private int                _currentBandScore;
-    private readonly List<int> _bandScores = new();
+    private          int           _currentBandScore;
+    private readonly Dictionary<int, int> _bandScores = new();
 
-    public IReadOnlyList<int> BandScores => _bandScores;
+    public IReadOnlyDictionary<int, int> BandScores => _bandScores;
+
+    public EngineEventLogger EventLog;
 
     public Analyzer(SongChart chart, Replay replay)
     {
@@ -44,23 +47,33 @@ public class Analyzer
 
             // Populate with a fps
             int fps = i * 2 + 1;
-            double secondsPerFrame = 1.0 / fps;
-            double endTime = _chart.GetEndTime();
-            for (double time = 0; time < endTime; time += secondsPerFrame)
-            {
-                // Add a little bit of inconsistency
-                randomValues.Add(time + (random.NextDouble() - 0.5) * secondsPerFrame);
-            }
-
-            // Sort
-            randomValues.Sort();
+            randomValues.AddRange(GenerateFrameTimes(fps));
 
             Console.WriteLine($"> Running at {fps} FPS");
-            RunAnalyzer(randomValues);
+            RunAnalyzer(fps, randomValues);
         }
     }
 
-    private void RunAnalyzer(IReadOnlyList<double> frameUpdates)
+    private List<double> GenerateFrameTimes(int fps)
+    {
+        var random = new Random();
+        var frameTimes = new List<double>();
+        
+        double secondsPerFrame = 1.0 / fps;
+        double endTime = _chart.GetEndTime();
+        for (double time = -2; time < endTime; time += secondsPerFrame)
+        {
+            // Add a little bit of inconsistency
+            frameTimes.Add(time + (random.NextDouble() - 0.5) * secondsPerFrame);
+        }
+
+        // Sort
+        frameTimes.Sort();
+
+        return frameTimes;
+    }
+
+    private void RunAnalyzer(int fps, IReadOnlyList<double> frameUpdates)
     {
         _currentBandScore = 0;
 
@@ -70,12 +83,13 @@ public class Analyzer
             RunFrame(frame, frameUpdates);
         }
 
-        _bandScores.Add(_currentBandScore);
+        _bandScores.Add(fps, _currentBandScore);
     }
 
     private void RunFrame(ReplayFrame replayFrame, IReadOnlyList<double> frameUpdates)
     {
         var engine = CreateEngine(replayFrame);
+        engine.Reset();
 
         Console.WriteLine($"> Running for {replayFrame.PlayerInfo.Profile.Name}...");
 

--- a/ReplayAnalyzer/Analyzer.cs
+++ b/ReplayAnalyzer/Analyzer.cs
@@ -100,7 +100,7 @@ public class Analyzer
             {
                 engine.QueueInput(input);
             }
-            engine.UpdateEngine();
+            engine.UpdateEngineInputs();
         }
         else
         {
@@ -119,14 +119,7 @@ public class Analyzer
                 }
 
                 // Run!
-                if (engine.IsInputQueued)
-                {
-                    engine.UpdateEngineInputs();
-                }
-                else
-                {
-                    engine.UpdateEngineToTime(frameTime);
-                }
+                engine.UpdateEngine(frameTime);
             }
         }
 

--- a/ReplayAnalyzer/Analyzer.cs
+++ b/ReplayAnalyzer/Analyzer.cs
@@ -35,7 +35,7 @@ public class Analyzer
 
     public void Run()
     {
-        RunAnalyzer(null);
+        RunAnalyzer(0, null);
     }
 
     public void RunWithSimulatedUpdates()

--- a/ReplayAnalyzer/Analyzer.cs
+++ b/ReplayAnalyzer/Analyzer.cs
@@ -134,6 +134,8 @@ public class Analyzer
         int score = GetScore(engine, replayFrame);
         Console.WriteLine($"> Done running for {replayFrame.PlayerInfo.Profile.Name}, final score: {score}");
         _currentBandScore += score;
+        
+        EventLog = engine.EventLogger;
     }
 
     private BaseEngine CreateEngine(ReplayFrame replayFrame)

--- a/ReplayAnalyzer/Program.cs
+++ b/ReplayAnalyzer/Program.cs
@@ -159,7 +159,6 @@ LOADING:
 
         if (selectedOption == 1)
         {
-            var bandScore = analyzer.BandScores[0];
             var kp = analyzer.BandScores.First();
             var bandScore = kp.Value;
             if (bandScore != replay.BandScore)

--- a/ReplayAnalyzer/Program.cs
+++ b/ReplayAnalyzer/Program.cs
@@ -210,7 +210,7 @@ LOADING:
 
             foreach (var s in analyzer.BandScores)
             {
-                if (distinctScores.Contains(s.Value)) continue;
+                if (distinctScores.Contains(s.Value) && s.Value == replay.BandScore) continue;
 
                 distinctScores.Add(s.Value);
                 distincts.Add((s.Key, s.Value));

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -96,7 +96,6 @@ namespace YARG.Core.Engine
                 return;
             }
 
-            IsInputUpdate = true;
             ProcessInputs();
         }
 
@@ -129,6 +128,8 @@ namespace YARG.Core.Engine
             while (InputQueue.TryDequeue(out var input))
             {
                 // This will update the engine to the time of the input.
+                // However, it does not use the input for the update.
+                IsInputUpdate = false;
                 UpdateUpToTime(input.Time);
 
                 // Process the input and run hit logic for it.
@@ -237,22 +238,22 @@ namespace YARG.Core.Engine
             var currentTime = State.CurrentTime;
 
             var noteUpdateIndex = State.NoteIndex;
-            
+
             // Get the index of the next note to update to
             while (noteUpdateIndex < Notes.Count && currentTime > Notes[noteUpdateIndex].Time)
             {
                 noteUpdateIndex++;
             }
-            
+
             // Update the engine to the next note
             while(noteUpdateIndex < Notes.Count && Notes[noteUpdateIndex].Time < time)
             {
                 RunHitLogic(Notes[noteUpdateIndex].Time);
-                
+
                 // Move to the next note
                 noteUpdateIndex++;
             }
-            
+
             // Updated to the last note before the given time
             // Now we update the engine to the given time
             RunHitLogic(time);
@@ -269,7 +270,7 @@ namespace YARG.Core.Engine
                 State.LastUpdateTime = State.CurrentTime;
                 State.LastTick = State.CurrentTick;
             }
-            
+
             State.CurrentTime = time;
             State.CurrentTick = GetCurrentTick(time);
 
@@ -293,7 +294,7 @@ namespace YARG.Core.Engine
 
             State.Reset();
             EngineStats.Reset();
-            
+
             EventLogger.Clear();
 
             foreach (var note in Notes)
@@ -422,7 +423,7 @@ namespace YARG.Core.Engine
                 {
                     IsActive = false,
                 });
-                
+
                 EngineStats.StarPowerAmount = 0;
                 EngineStats.IsStarPowerActive = false;
                 UpdateMultiplier();
@@ -436,7 +437,7 @@ namespace YARG.Core.Engine
             {
                 return;
             }
-            
+
             EventLogger.LogEvent(new StarPowerEngineEvent(State.CurrentTime)
             {
                 IsActive = true,
@@ -481,18 +482,18 @@ namespace YARG.Core.Engine
             else
             {
                 double multiplier = Math.Clamp((soloPercentage - 0.6) / 0.4, 0, 1);
-                
+
                 // Old engine says this is 200 *, but I'm not sure that's right?? Isn't it 2x the note's worth, not 4x?
                 double points = 100 * currentSolo.NotesHit * multiplier;
 
                 // Round down to nearest 50 (kinda just makes sense I think?)
                 points -= points % 50;
-                
+
                 currentSolo.SoloBonus = (int) points;
             }
 
             EngineStats.SoloBonuses += currentSolo.SoloBonus;
-            
+
             State.IsSoloActive = false;
 
             OnSoloEnd?.Invoke(Solos[State.CurrentSoloIndex]);
@@ -518,7 +519,7 @@ namespace YARG.Core.Engine
             }
 
             ProcessInputs();
-            
+
             if(lastInputTime < time)
             {
                 UpdateEngineToTime(time);

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -87,7 +87,16 @@ namespace YARG.Core.Engine
         }
 
         /// <summary>
-        /// Updates the engine and processes all inputs currently queued.
+        /// Updates the engine to the given time, processing any queued inputs along the way.
+        /// </summary>
+        public void UpdateEngine(double time)
+        {
+            ProcessInputs();
+            UpdateEngineToTime(time);
+        }
+
+        /// <summary>
+        /// Updates the engine using only the currently queued inputs.
         /// </summary>
         public void UpdateEngineInputs()
         {

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -164,14 +164,6 @@ namespace YARG.Core.Engine
         /// <param name="inputs">List of inputs to execute against.</param>
         /// <returns>The input index that was processed up to.</returns>
         public abstract int ProcessUpToTime(double time, IEnumerable<GameInput> inputs);
-
-        /// <summary>
-        /// Processes the list of inputs from the given start time to the given end time. Does not reset the engine's state.
-        /// </summary>
-        /// <param name="startTime">Time to begin processing from.</param>
-        /// <param name="endTime">Time to process up to.</param>
-        /// <param name="inputs">List of inputs to execute against.</param>
-        public abstract void ProcessFromTimeToTime(double startTime, double endTime, IEnumerable<GameInput> inputs);
     }
 
     public abstract class BaseEngine<TNoteType, TEngineParams, TEngineStats, TEngineState> : BaseEngine
@@ -497,11 +489,6 @@ namespace YARG.Core.Engine
             ProcessInputs();
 
             return inputIndex;
-        }
-
-        public override void ProcessFromTimeToTime(double startTime, double endTime, IEnumerable<GameInput> inputs)
-        {
-            throw new NotImplementedException();
         }
 
         protected abstract int CalculateBaseScore();

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -174,9 +174,8 @@ namespace YARG.Core.Engine
         public abstract void ProcessFromTimeToTime(double startTime, double endTime, IEnumerable<GameInput> inputs);
     }
 
-    public abstract class BaseEngine<TNoteType, TActionType, TEngineParams, TEngineStats, TEngineState> : BaseEngine
+    public abstract class BaseEngine<TNoteType, TEngineParams, TEngineStats, TEngineState> : BaseEngine
         where TNoteType : Note<TNoteType>
-        where TActionType : unmanaged, Enum
         where TEngineParams : BaseEngineParameters
         where TEngineStats : BaseStats, new()
         where TEngineState : BaseEngineState, new()

--- a/YARG.Core/Engine/BaseEngineState.cs
+++ b/YARG.Core/Engine/BaseEngineState.cs
@@ -20,6 +20,7 @@
         public int CurrentStarIndex;
 
         public bool IsSoloActive;
+        public bool IsStarPowerInputActive;
 
         public uint TicksEveryEightMeasures;
 

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -4,7 +4,7 @@ using YARG.Core.Input;
 
 namespace YARG.Core.Engine.Drums
 {
-    public abstract class DrumsEngine : BaseEngine<DrumNote, DrumsAction, DrumsEngineParameters,
+    public abstract class DrumsEngine : BaseEngine<DrumNote, DrumsEngineParameters,
         DrumsStats, DrumsEngineState>
     {
         public delegate void OverhitEvent();

--- a/YARG.Core/Engine/Guitar/Engines/NewYargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/NewYargFiveFretEngine.cs
@@ -1,0 +1,309 @@
+﻿using System;
+using YARG.Core.Chart;
+using YARG.Core.Engine.Logging;
+using YARG.Core.Input;
+
+namespace YARG.Core.Engine.Guitar.Engines
+{
+    public class NewYargFiveFretEngine : GuitarEngine
+    {
+        public NewYargFiveFretEngine(InstrumentDifficulty<GuitarNote> chart, SyncTrack syncTrack, GuitarEngineParameters engineParameters) : base(chart, syncTrack, engineParameters)
+        {
+        }
+
+        protected override bool UpdateHitLogic(double time)
+        {
+            UpdateTimeVariables(time);
+            //UpdateTimers();
+            
+            DepleteStarPower(GetUsedStarPower());
+            
+            UpdateInput();
+            
+            if (State.IsStarPowerInputActive && EngineStats.CanStarPowerActivate)
+            {
+                ActivateStarPower();
+            }
+
+            if (State.ButtonMask != State.TapButtonMask)
+            {
+                State.TapButtonMask = 0;
+            }
+
+            if (State.NoteIndex >= Notes.Count)
+            {
+                UpdateSustains();
+                return false;
+            }
+
+            var note = Notes[State.NoteIndex];
+
+            if (IsInputUpdate && IsFretInput(CurrentInput))
+            {
+                // Check for fret ghosting
+                // We want to run ghost logic regardless of the setting (for the ghost counter)
+                if (note.PreviousNote is not null)
+                {
+                    bool ghostedThisInput = CheckForGhostInput(note);
+
+                    // This variable controls hit logic for ghosting
+                    State.WasNoteGhosted = EngineParameters.AntiGhosting && (ghostedThisInput || State.WasNoteGhosted);
+
+                    // Add ghost inputs to stats regardless of the setting for anti ghosting
+                    if (ghostedThisInput)
+                    {
+                        EngineStats.GhostInputs++;
+                    }
+                }
+            }
+
+            bool isNoteHit = CheckForNoteHit();
+            
+            UpdateSustains();
+            return isNoteHit;
+        }
+
+        protected override bool CheckForNoteHit()
+        {
+            var note = Notes[State.NoteIndex];
+
+            if (note.WasHit || note.WasMissed)
+            {
+                return false;
+            }
+            
+            if (State.CurrentTime < note.Time + EngineParameters.FrontEnd)
+            {
+                return false;
+            }
+
+            if (State.CurrentTime > note.Time + EngineParameters.BackEnd && !note.WasHit)
+            {
+                MissNote(note);
+                return true;
+            }
+
+            if (!CanNoteBeHit(note))
+            {
+                return false;
+            }
+            
+            // Handles hitting hopo/tap notes
+            // If first note is a hopo then it can be hit without combo (for practice mode)
+            bool canHitTap = State.TapButtonMask == 0;// && note.IsTap;
+            bool canHitHopo = note.IsHopo && (EngineStats.Combo > 0 || State.NoteIndex == 0);
+            
+            if ((canHitTap || (canHitHopo && false)) && !State.WasNoteGhosted)
+            {
+                return HitNote(note);
+            }
+
+            return false;
+        }
+
+        protected override bool CanNoteBeHit(GuitarNote note)
+        {
+            byte buttonsMasked = State.ButtonMask;
+            foreach (var sustainNote in ActiveSustains)
+            {
+                // Don't want to mask off the note we're checking otherwise it'll always return false lol
+                if (note == sustainNote)
+                {
+                    continue;
+                }
+
+                // Mask off the disjoint mask if its disjointed or extended disjointed
+                // This removes just the single fret of the disjoint note
+                if ((sustainNote.IsExtendedSustain && sustainNote.IsDisjoint) || sustainNote.IsDisjoint)
+                {
+                    buttonsMasked -= (byte) sustainNote.DisjointMask;
+                }
+                else if (sustainNote.IsExtendedSustain)
+                {
+                    // Remove the entire note mask if its an extended sustain
+                    // Difference between NoteMask and DisjointMask is that DisjointMask is only a single fret
+                    // while NoteMask is the entire chord
+                    buttonsMasked -= (byte) sustainNote.NoteMask;
+                }
+            }
+
+            // Use the DisjointMask for comparison if disjointed and was hit (for sustain logic)
+            int noteMask = (note.IsDisjoint || note.IsExtendedSustain) && note.WasHit
+                ? note.DisjointMask
+                : note.NoteMask;
+
+            // If disjointed and is sustain logic (was hit), can hit if disjoint mask matches
+            if ((note.IsDisjoint || note.IsExtendedSustain) && note.WasHit && (note.DisjointMask & buttonsMasked) != 0)
+            {
+                return true;
+            }
+
+            // If open, must not hold any frets
+            // If not open, must be holding at least 1 fret
+            if (noteMask == 0 && buttonsMasked != 0 || noteMask != 0 && buttonsMasked == 0)
+            {
+                return false;
+            }
+
+            // If holding exact note mask, can hit
+            if (buttonsMasked == noteMask)
+            {
+                return true;
+            }
+
+            // Anchoring
+
+            // XORing the two masks will give the anchor (held frets) around the note.
+            int anchorButtons = buttonsMasked ^ noteMask;
+
+            // Chord logic
+            if (note.IsChord)
+            {
+                if (note.IsStrum)
+                {
+                    // Buttons must match note mask exactly for strum chords
+                    return buttonsMasked == noteMask;
+                }
+
+                // Anchoring hopo/tap chords
+
+                // Gets the lowest fret of the chord.
+                var fretMask = 0;
+                for (var fret = GuitarAction.GreenFret; fret <= GuitarAction.OrangeFret; fret++)
+                {
+                    fretMask = 1 << (int)fret;
+
+                    // If the current fret mask is part of the chord, break
+                    if ((fretMask & note.NoteMask) == fretMask)
+                    {
+                        break;
+                    }
+                }
+
+                // Anchor part:
+                // Lowest fret of chord must be bigger or equal to anchor buttons
+                // (can't hold note higher than the highest fret of chord)
+
+                // Button mask subtract the anchor must equal chord mask (all frets of chord held)
+                return fretMask >= anchorButtons && buttonsMasked - anchorButtons == note.NoteMask;
+            }
+
+            // Anchoring single notes
+
+            // Anchor buttons held are lower than the note mask
+            return anchorButtons < noteMask;
+        }
+
+        protected override bool HitNote(GuitarNote note)
+        {
+            State.TapButtonMask = State.ButtonMask;
+
+            if (note.IsHopo || note.IsTap)
+            {
+                bool strumLeniencyActive = State.StrumLeniencyTimer.IsActive(State.CurrentTime);
+
+                // Disallow hitting if front end timer is not in range of note time and didn't strum
+                // (tried to hit as a hammeron/pulloff)
+                // Also allows first note to be hit without infinite front end
+
+                if (!EngineParameters.InfiniteFrontEnd && State.FrontEndTimer.IsExpired(note.Time) /* && !strumLeniencyActive */ && State.NoteIndex > 0)
+                {
+                    return false;
+                }
+
+                State.TapButtonMask = 0;
+
+                // TODO Everything below here is timer stuff
+            }
+            else
+            {
+                // This line allows for hopos/taps to be hit using infinite front end after strumming
+                State.TapButtonMask = 0;
+                
+                // Does the same thing but ensures it still works when infinite front end is disabled
+                State.FrontEndTimer.Reset();
+
+                State.WasHopoStrummed = false;
+            }
+
+            return base.HitNote(note);
+        }
+        
+        protected override void MissNote(GuitarNote note)
+        {
+            State.TapButtonMask = State.ButtonMask;
+            base.MissNote(note);
+        }
+
+        protected override void UpdateSustains()
+        {
+        }
+        
+        protected void UpdateInput()
+        {
+            if (!IsInputUpdate)
+            {
+                return;
+            }
+
+            if (IsStrumInput(CurrentInput))
+            {
+                State.StrummedThisUpdate = CurrentInput.Button;
+            } else if (IsFretInput(CurrentInput))
+            {
+                State.LastButtonMask = State.ButtonMask;
+                ToggleFret(CurrentInput.Action, CurrentInput.Button);
+                State.FrontEndTimer.Start(State.CurrentTime);
+                
+                EventLogger.LogEvent(new TimerEngineEvent(State.CurrentTime)
+                {
+                    TimerName = "FrontEnd",
+                    TimerStarted = true,
+                    TimerValue = Math.Abs(EngineParameters.FrontEnd),
+                });
+            } else if (CurrentInput.GetAction<GuitarAction>() == GuitarAction.StarPower)
+            {
+                State.IsStarPowerInputActive = CurrentInput.Button;
+            }
+        }
+        
+        protected bool CheckForGhostInput(GuitarNote note)
+        {
+            // First note cannot be ghosted, nor can a note be ghosted if a button is unpressed (pulloff)
+            if (note.PreviousNote is null || !CurrentInput.Button)
+            {
+                return false;
+            }
+
+            // Note can only be ghosted if it's in timing window
+            if (!IsNoteInWindow(note))
+            {
+                return false;
+            }
+
+            // Input is a hammer-on if the highest fret held is higher than the highest fret of the previous mask
+            bool isHammerOn = GetMostSignificantBit(State.ButtonMask) > GetMostSignificantBit(State.LastButtonMask);
+
+            // Input is a hammer-on and the button pressed is not part of the note mask (incorrect fret)
+            if(isHammerOn && (State.ButtonMask & note.NoteMask) == 0)
+            {
+                return true;
+            }
+
+            return false;
+        }
+        
+        private static int GetMostSignificantBit(int mask)
+        {
+            // Gets the most significant bit of the mask
+            var msbIndex = 0;
+            while (mask != 0)
+            {
+                mask >>= 1;
+                msbIndex++;
+            }
+
+            return msbIndex;
+        }
+    }
+}

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -30,7 +30,7 @@ namespace YARG.Core.Engine.Guitar.Engines
 
                 State.ButtonMask = (byte) note.NoteMask;
                 State.StrummedThisUpdate = true;
-                State.FrontEndStartTime = note.Time;
+                //State.FrontEndStartTime = note.Time;
 
                 foreach (var sustainNote in ActiveSustains)
                 {
@@ -82,7 +82,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             {
                 State.LastButtonMask = State.ButtonMask;
                 ToggleFret(CurrentInput.Action, CurrentInput.Button);
-                State.FrontEndStartTime = State.CurrentTime;
+                //State.FrontEndStartTime = State.CurrentTime;
                 
                 EventLogger.LogEvent(new TimerEngineEvent(State.CurrentTime)
                 {
@@ -458,7 +458,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 // Also allows first note to be hit without infinite front end
 
                 double frontEndAbs = Math.Abs(EngineParameters.FrontEnd);
-                bool frontEndExpired = EngineTimer.IsExpired(State.FrontEndStartTime, note.Time, frontEndAbs);
+                bool frontEndExpired = false;//EngineTimer.IsExpired(State.FrontEndStartTime, note.Time, frontEndAbs);
                 if (!EngineParameters.InfiniteFrontEnd && frontEndExpired && !strumLeniencyActive && State.NoteIndex > 0)
                 {
                     return false;
@@ -504,7 +504,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 State.TapButtonMask = 0;
 
                 // Does the same thing but ensures it still works when infinite front end is disabled
-                State.FrontEndStartTime = double.MaxValue;
+                //State.FrontEndStartTime = double.MaxValue;
 
                 State.WasHopoStrummed = false;
 

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -6,8 +6,7 @@ using YARG.Core.Input;
 
 namespace YARG.Core.Engine.Guitar
 {
-    public abstract class GuitarEngine : BaseEngine<GuitarNote, GuitarAction, GuitarEngineParameters,
-        GuitarStats, GuitarEngineState>
+    public abstract class GuitarEngine : BaseEngine<GuitarNote, GuitarEngineParameters, GuitarStats, GuitarEngineState>
     {
         public delegate void OverstrumEvent();
 

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -106,7 +106,7 @@ namespace YARG.Core.Engine.Guitar
                     WasHit = false,
                     WasSkipped = true,
                 });
-                
+
                 prevNote = prevNote.PreviousNote;
             }
 
@@ -174,7 +174,7 @@ namespace YARG.Core.Engine.Guitar
                 WasHit = true,
                 WasSkipped = skipped,
             });
-            
+
             OnNoteHit?.Invoke(State.NoteIndex, note);
             State.NoteIndex++;
             return true;
@@ -214,7 +214,7 @@ namespace YARG.Core.Engine.Guitar
                 WasHit = false,
                 WasSkipped = false,
             });
-            
+
             OnNoteMissed?.Invoke(State.NoteIndex, note);
             State.NoteIndex++;
         }

--- a/YARG.Core/Engine/Guitar/GuitarEngineState.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineState.cs
@@ -1,4 +1,6 @@
-﻿namespace YARG.Core.Engine.Guitar
+﻿using System;
+
+namespace YARG.Core.Engine.Guitar
 {
     public class GuitarEngineState : BaseEngineState
     {
@@ -14,12 +16,13 @@
         public EngineTimer StrumLeniencyTimer;
         public EngineTimer HopoLeniencyTimer;
 
-        public double FrontEndStartTime;
+        public EngineTimer FrontEndTimer;
 
         public void Initialize(GuitarEngineParameters parameters)
         {
             StrumLeniencyTimer = new(parameters.StrumLeniency);
             HopoLeniencyTimer = new(parameters.HopoLeniency);
+            FrontEndTimer = new(Math.Abs(parameters.FrontEnd));
         }
 
         public override void Reset()
@@ -36,8 +39,7 @@
 
             StrumLeniencyTimer.Reset();
             HopoLeniencyTimer.Reset();
-
-            FrontEndStartTime = 0;
+            FrontEndTimer.Reset();
         }
     }
 }

--- a/YARG.Core/Engine/Logging/NoteEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/NoteEngineEvent.cs
@@ -19,10 +19,14 @@ namespace YARG.Core.Engine.Logging
 
         public override void Serialize(BinaryWriter writer)
         {
+            base.Serialize(writer);
+            
             writer.Write(NoteTime);
+            writer.Write(NoteLength);
+            
             writer.Write(NoteIndex);
             writer.Write(NoteMask);
-            writer.Write(NoteLength);
+            
             writer.Write(WasHit);
             writer.Write(WasSkipped);
         }
@@ -32,9 +36,11 @@ namespace YARG.Core.Engine.Logging
             base.Deserialize(reader, version);
             
             NoteTime = reader.ReadDouble();
+            NoteLength = reader.ReadDouble();
+            
             NoteIndex = reader.ReadInt32();
             NoteMask = reader.ReadInt32();
-            NoteLength = reader.ReadInt32();
+            
             WasHit = reader.ReadBoolean();
             WasSkipped = reader.ReadBoolean();
         }

--- a/YARG.Core/Engine/Logging/ScoreEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/ScoreEngineEvent.cs
@@ -13,6 +13,8 @@ namespace YARG.Core.Engine.Logging
 
         public override void Serialize(BinaryWriter writer)
         {
+            base.Serialize(writer);
+            
             writer.Write(Score);
         }
 

--- a/YARG.Core/Engine/Logging/StarPowerEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/StarPowerEngineEvent.cs
@@ -13,6 +13,8 @@ namespace YARG.Core.Engine.Logging
 
         public override void Serialize(BinaryWriter writer)
         {
+            base.Serialize(writer);
+            
             writer.Write(IsActive);
         }
 

--- a/YARG.Core/Engine/Logging/TimerEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/TimerEngineEvent.cs
@@ -19,6 +19,8 @@ namespace YARG.Core.Engine.Logging
 
         public override void Serialize(BinaryWriter writer)
         {
+            base.Serialize(writer);
+            
             writer.Write(TimerName);
             writer.Write(TimerValue);
             writer.Write(TimerStarted);

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -5,7 +5,7 @@ using YARG.Core.Input;
 namespace YARG.Core.Engine.Vocals
 {
     public abstract class VocalsEngine :
-        BaseEngine<VocalNote, VocalsAction, VocalsEngineParameters, VocalsStats, VocalsEngineState>
+        BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats, VocalsEngineState>
     {
         public delegate void TargetNoteChangeEvent(VocalNote targetNote);
 


### PR DESCRIPTION
PR'ing to allow discussion and deliberation before merging. Feeling unsure about this one for some reason lol

This change removes the need to check if inputs are queued before updating the engine, now there's a method which handles both inputs and updating to the given time. The rationale is to ensure there are no discrepancies between where the engine updates to and the actual input update time.

Since the API's changed, this will require a couple changes in the main YARG project.