### PR TITLE
Dynamic Timing Window

### DIFF
--- a/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
@@ -1,13 +1,9 @@
 ﻿using Melanchall.DryWetMidi.Core;
-using MoonscraperChartEditor.Song.IO;
 using NUnit.Framework;
 using YARG.Core.Chart;
+using YARG.Core.Engine;
 using YARG.Core.Engine.Drums;
 using YARG.Core.Engine.Drums.Engines;
-using YARG.Core.Engine.Guitar;
-using YARG.Core.Engine.Guitar.Engines;
-using YARG.Core.Parsing;
-using YARG.Core.Song;
 
 namespace YARG.Core.UnitTests.Engine;
 
@@ -18,7 +14,7 @@ public class DrumEngineTester
         0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.29f
     };
 
-    private readonly DrumsEngineParameters _engineParams = new(0.15, 1, StarMultiplierThresholds,
+    private readonly DrumsEngineParameters _engineParams = new(new HitWindowSettings(0.15, 0.03, 1, false), StarMultiplierThresholds,
         DrumsEngineParameters.DrumMode.ProFourLane);
 
     private string? _chartsDirectory;

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -561,22 +561,20 @@ namespace YARG.Core.Engine
 
         public double GetAverageNoteDistance(TNoteType note)
         {
-            int noteCount = 0;
-            double totalDistance = 0;
+            double currentToNext;
+            double previousToCurrent = currentToNext = EngineParameters.HitWindow.MaxWindow / 2;
 
             if (note.PreviousNote is not null)
             {
-                totalDistance += note.Time - note.PreviousNote.Time;
-                noteCount++;
+                previousToCurrent = (note.Time - note.PreviousNote.Time) / 2;
             }
 
             if (note.NextNote is not null)
             {
-                totalDistance += note.NextNote.Time - note.Time;
-                noteCount++;
+                currentToNext = (note.NextNote.Time - note.Time) / 2;
             }
 
-            return totalDistance / noteCount;
+            return previousToCurrent + currentToNext;
         }
 
         private List<SoloSection> GetSoloSections()

--- a/YARG.Core/Engine/BaseEngineParameters.cs
+++ b/YARG.Core/Engine/BaseEngineParameters.cs
@@ -6,25 +6,7 @@ namespace YARG.Core.Engine
 {
     public abstract class BaseEngineParameters : IBinarySerializable
     {
-        /// <summary>
-        /// The total width of the hit window.
-        /// </summary>
-        public double HitWindow        { get; private set; }
-
-        /// <summary>
-        /// The front to back ratio of the hit window.
-        /// </summary>
-        public double FrontToBackRatio { get; private set; }
-
-        /// <summary>
-        /// How much time ahead of the strikeline can a note be hit. This value is always negative.
-        /// </summary>
-        public double FrontEnd { get; private set; }
-
-        /// <summary>
-        /// How much time behind the strikeline can a note be hit. This value is always positive.
-        /// </summary>
-        public double BackEnd { get; private set; }
+        public HitWindowSettings HitWindow { get; private set;}
 
         public float[] StarMultiplierThresholds { get; private set; }
 
@@ -33,20 +15,15 @@ namespace YARG.Core.Engine
             StarMultiplierThresholds = Array.Empty<float>();
         }
 
-        protected BaseEngineParameters(double hitWindow, double frontBackRatio, float[] starMultiplierThresholds)
+        protected BaseEngineParameters(HitWindowSettings hitWindow, float[] starMultiplierThresholds)
         {
             HitWindow = hitWindow;
-            FrontToBackRatio = frontBackRatio;
             StarMultiplierThresholds = starMultiplierThresholds;
-
-            FrontEnd = -(Math.Abs(HitWindow / 2) * FrontToBackRatio);
-            BackEnd = Math.Abs(HitWindow / 2) * (2 - FrontToBackRatio);
         }
 
         public virtual void Serialize(BinaryWriter writer)
         {
-            writer.Write(FrontEnd);
-            writer.Write(BackEnd);
+            HitWindow.Serialize(writer);
 
             // Write star multiplier thresholds
             writer.Write(StarMultiplierThresholds.Length);
@@ -58,8 +35,8 @@ namespace YARG.Core.Engine
 
         public virtual void Deserialize(BinaryReader reader, int version = 0)
         {
-            FrontEnd = reader.ReadDouble();
-            BackEnd = reader.ReadDouble();
+            HitWindow = new HitWindowSettings();
+            HitWindow.Deserialize(reader, version);
 
             // Read star multiplier thresholds
             StarMultiplierThresholds = new float[reader.ReadInt32()];
@@ -67,9 +44,6 @@ namespace YARG.Core.Engine
             {
                 StarMultiplierThresholds[i] = reader.ReadSingle();
             }
-
-            HitWindow = Math.Abs(FrontEnd) + Math.Abs(BackEnd);
-            FrontToBackRatio = Math.Abs(FrontEnd) / Math.Abs(BackEnd);
         }
     }
 }

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -4,7 +4,7 @@ using YARG.Core.Input;
 
 namespace YARG.Core.Engine.Drums
 {
-    public abstract class DrumsEngine : BaseEngine<DrumNote, DrumsAction, DrumsEngineParameters,
+    public abstract class DrumsEngine : BaseEngine<DrumNote, DrumsEngineParameters,
         DrumsStats, DrumsEngineState>
     {
         public delegate void OverhitEvent();

--- a/YARG.Core/Engine/Drums/DrumsEngineParameters.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngineParameters.cs
@@ -20,9 +20,9 @@ namespace YARG.Core.Engine.Drums
         {
         }
 
-        public DrumsEngineParameters(double hitWindow, double frontBackRatio, float[] starMultiplierThresholds,
+        public DrumsEngineParameters(HitWindowSettings hitWindow, float[] starMultiplierThresholds,
             DrumMode mode)
-            : base(hitWindow, frontBackRatio, starMultiplierThresholds)
+            : base(hitWindow, starMultiplierThresholds)
         {
             Mode = mode;
         }

--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -78,8 +78,10 @@ namespace YARG.Core.Engine.Drums.Engines
 
             var note = Notes[State.NoteIndex];
 
+            double hitWindow = EngineParameters.HitWindow.CalculateHitWindow(GetAverageNoteDistance(note));
+
             // Miss notes (back end)
-            if (State.CurrentTime > note.Time + EngineParameters.BackEnd)
+            if (State.CurrentTime > note.Time + EngineParameters.HitWindow.GetBackEnd(hitWindow))
             {
                 foreach (var chordNote in note.ChordEnumerator())
                 {
@@ -127,7 +129,9 @@ namespace YARG.Core.Engine.Drums.Engines
 
         protected bool CheckForNoteHit(DrumNote note)
         {
-            if (State.CurrentTime < note.Time + EngineParameters.FrontEnd)
+            double hitWindow = EngineParameters.HitWindow.CalculateHitWindow(GetAverageNoteDistance(note));
+
+            if (State.CurrentTime < note.Time + EngineParameters.HitWindow.GetFrontEnd(hitWindow))
             {
                 return false;
             }

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -6,7 +6,7 @@ using YARG.Core.Input;
 
 namespace YARG.Core.Engine.Guitar
 {
-    public abstract class GuitarEngine : BaseEngine<GuitarNote, GuitarAction, GuitarEngineParameters,
+    public abstract class GuitarEngine : BaseEngine<GuitarNote, GuitarEngineParameters,
         GuitarStats, GuitarEngineState>
     {
         public delegate void OverstrumEvent();
@@ -107,7 +107,7 @@ namespace YARG.Core.Engine.Guitar
                     WasHit = false,
                     WasSkipped = true,
                 });
-                
+
                 prevNote = prevNote.PreviousNote;
             }
 
@@ -175,7 +175,7 @@ namespace YARG.Core.Engine.Guitar
                 WasHit = true,
                 WasSkipped = skipped,
             });
-            
+
             OnNoteHit?.Invoke(State.NoteIndex, note);
             State.NoteIndex++;
             return true;
@@ -215,7 +215,7 @@ namespace YARG.Core.Engine.Guitar
                 WasHit = false,
                 WasSkipped = false,
             });
-            
+
             OnNoteMissed?.Invoke(State.NoteIndex, note);
             State.NoteIndex++;
         }

--- a/YARG.Core/Engine/Guitar/GuitarEngineParameters.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineParameters.cs
@@ -16,9 +16,9 @@ namespace YARG.Core.Engine.Guitar
         {
         }
 
-        public GuitarEngineParameters(double hitWindow, double frontBackRatio, float[] starMultiplierThresholds, double hopoLeniency,
+        public GuitarEngineParameters(HitWindowSettings hitWindow, float[] starMultiplierThresholds, double hopoLeniency,
             double strumLeniency, double strumLeniencySmall, bool infiniteFrontEnd, bool antiGhosting)
-            : base(hitWindow, frontBackRatio, starMultiplierThresholds)
+            : base(hitWindow, starMultiplierThresholds)
         {
             HopoLeniency = hopoLeniency;
 

--- a/YARG.Core/Engine/HitWindowSettings.cs
+++ b/YARG.Core/Engine/HitWindowSettings.cs
@@ -1,0 +1,83 @@
+using System;
+using System.IO;
+using YARG.Core.Utility;
+
+namespace YARG.Core.Engine
+{
+    public struct HitWindowSettings : IBinarySerializable
+    {
+        public double MaxWindow { get; private set; }
+        public double MinWindow { get; private set; }
+
+        public bool IsDynamic { get; private set; }
+
+        /// <summary>
+        /// The front to back ratio of the hit window.
+        /// </summary>
+        public double FrontToBackRatio { get; private set; }
+
+        private double _minMaxWindowRatio;
+
+        public HitWindowSettings(double maxWindow, double minWindow, double frontToBackRatio, bool isDynamic)
+        {
+            // Swap max and min if necessary to ensure that max is always larger than min
+            if (maxWindow < minWindow)
+            {
+                (maxWindow, minWindow) = (minWindow, maxWindow);
+            }
+
+            MaxWindow = maxWindow;
+            MinWindow = minWindow;
+            FrontToBackRatio = frontToBackRatio;
+            IsDynamic = isDynamic;
+
+            _minMaxWindowRatio = MinWindow / MaxWindow;
+        }
+
+        public double GetFrontEnd(double fullWindow)
+        {
+            return -(Math.Abs(fullWindow / 2) * FrontToBackRatio);
+        }
+
+        public double GetBackEnd(double fullWindow)
+        {
+            return Math.Abs(fullWindow / 2) * (2 - FrontToBackRatio);
+        }
+
+        public double CalculateHitWindow(double averageTimeDistance)
+        {
+            if (!IsDynamic)
+            {
+                return MaxWindow;
+            }
+
+            averageTimeDistance *= 1000;
+
+            double sqrt = Math.Sqrt(averageTimeDistance + _minMaxWindowRatio);
+            double eighth = 0.125 * averageTimeDistance;
+            double realSize = eighth * sqrt + MinWindow * 1000;
+
+            realSize /= 1000;
+
+            return Math.Max(Math.Min(realSize, MaxWindow), MinWindow);
+        }
+
+        public void Serialize(BinaryWriter writer)
+        {
+            writer.Write(MaxWindow);
+            writer.Write(MinWindow);
+            writer.Write(IsDynamic);
+            writer.Write(FrontToBackRatio);
+        }
+
+        public void Deserialize(BinaryReader reader, int version = 0)
+        {
+            MaxWindow = reader.ReadDouble();
+            MinWindow = reader.ReadDouble();
+            IsDynamic = reader.ReadBoolean();
+            FrontToBackRatio = reader.ReadDouble();
+
+            _minMaxWindowRatio = MinWindow / MaxWindow;
+        }
+    }
+}

--- a/YARG.Core/Engine/HitWindowSettings.cs
+++ b/YARG.Core/Engine/HitWindowSettings.cs
@@ -17,6 +17,7 @@ namespace YARG.Core.Engine
         public double FrontToBackRatio { get; private set; }
 
         private double _minMaxWindowRatio;
+        private double _minOverFive;
 
         public HitWindowSettings(double maxWindow, double minWindow, double frontToBackRatio, bool isDynamic)
         {
@@ -32,6 +33,7 @@ namespace YARG.Core.Engine
             IsDynamic = isDynamic;
 
             _minMaxWindowRatio = MinWindow / MaxWindow;
+            _minOverFive = MinWindow / 5 * 1000;
         }
 
         public double GetFrontEnd(double fullWindow)
@@ -53,13 +55,13 @@ namespace YARG.Core.Engine
 
             averageTimeDistance *= 1000;
 
-            double sqrt = Math.Sqrt(averageTimeDistance + _minMaxWindowRatio);
-            double eighth = 0.125 * averageTimeDistance;
-            double realSize = eighth * sqrt + MinWindow * 1000;
+            double sqrt = _minOverFive * Math.Sqrt(averageTimeDistance * _minMaxWindowRatio);
+            double eighthAverage = 0.125 * averageTimeDistance;
+            double realSize = eighthAverage + sqrt + MinWindow * 1000;
 
             realSize /= 1000;
 
-            return Math.Max(Math.Min(realSize, MaxWindow), MinWindow);
+            return Math.Clamp(realSize, MinWindow, MaxWindow);
         }
 
         public void Serialize(BinaryWriter writer)
@@ -78,6 +80,7 @@ namespace YARG.Core.Engine
             FrontToBackRatio = reader.ReadDouble();
 
             _minMaxWindowRatio = MinWindow / MaxWindow;
+            _minOverFive = MinWindow / 5 * 1000;
         }
     }
 }

--- a/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
@@ -185,7 +185,7 @@ namespace YARG.Core.Engine.Vocals.Engines
             float dist = Math.Abs(singPitch - notePitch);
 
             // Try to check once within the range and...
-            if (true)//dist <= EngineParameters.HitWindow)
+            if (dist <= EngineParameters.HitWindow.MaxWindow)
             {
                 return true;
             }
@@ -193,7 +193,7 @@ namespace YARG.Core.Engine.Vocals.Engines
             // ...try again twelve notes (one octave) away.
             // This effectively allows wrapping in the check. Only subtraction is needed
             // since we take the absolute value before hand and now.
-            //if (Math.Abs(dist - 12f) <= EngineParameters.HitWindow)
+            if (Math.Abs(dist - 12f) <= EngineParameters.HitWindow.MaxWindow)
             {
                 return true;
             }

--- a/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
@@ -185,7 +185,7 @@ namespace YARG.Core.Engine.Vocals.Engines
             float dist = Math.Abs(singPitch - notePitch);
 
             // Try to check once within the range and...
-            if (dist <= EngineParameters.HitWindow)
+            if (true)//dist <= EngineParameters.HitWindow)
             {
                 return true;
             }
@@ -193,7 +193,7 @@ namespace YARG.Core.Engine.Vocals.Engines
             // ...try again twelve notes (one octave) away.
             // This effectively allows wrapping in the check. Only subtraction is needed
             // since we take the absolute value before hand and now.
-            if (Math.Abs(dist - 12f) <= EngineParameters.HitWindow)
+            //if (Math.Abs(dist - 12f) <= EngineParameters.HitWindow)
             {
                 return true;
             }

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -1,11 +1,10 @@
 ﻿using System.Linq;
 using YARG.Core.Chart;
-using YARG.Core.Input;
 
 namespace YARG.Core.Engine.Vocals
 {
     public abstract class VocalsEngine :
-        BaseEngine<VocalNote, VocalsAction, VocalsEngineParameters, VocalsStats, VocalsEngineState>
+        BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats, VocalsEngineState>
     {
         public delegate void TargetNoteChangeEvent(VocalNote targetNote);
 

--- a/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
@@ -23,9 +23,9 @@ namespace YARG.Core.Engine.Vocals
         {
         }
 
-        public VocalsEngineParameters(double hitWindow, double phraseHitPercent, bool singToActivateStarpower,
+        public VocalsEngineParameters(HitWindowSettings hitWindow, double phraseHitPercent, bool singToActivateStarpower,
             double approximateVocalFps, float[] starMultiplierThresholds)
-            : base(hitWindow, 1f, starMultiplierThresholds)
+            : base(hitWindow, starMultiplierThresholds)
         {
             PhraseHitPercent = phraseHitPercent;
             ApproximateVocalFps = approximateVocalFps;


### PR DESCRIPTION
Adds functionality to the engine for a dynamic timing window.
- Changes the engine parameters class, removes the hit window variables (front end, back end etc) and replaces it with a HitWindowSettings struct.
- Specify the minimum and maximum timing window size, as well as if it is dynamic or static
- Front end and back end sizes are no longer a thing and are calculated on demand (as they can change)

The size of the timing window is determined by the average distance between the previous note to the current note, and from the current note to the next note. The average time distance is then put into a function which calculates how large the full window size should be for that average distance.

The dynamic timing window is only intended for usage on guitar engines currently. It should in theory work for drums too however it has not been tested because there currently isn't any intention to give drums a dynamic window. Vocals doesn't support the dynamic timing window and will use the `MaxWindow` variable for its static window (identical to the old `HitWindow` variable)

YARG requires its own PR after this is merged, which I will handle.