### PR TITLE
Rework Star Power drain/whammy gain to be much more deterministic

### DIFF
--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using YARG.Core.Chart;
 using YARG.Core.Engine.Logging;
@@ -292,7 +292,7 @@ namespace YARG.Core.Engine
 
             int previousTimeSigIndex = State.CurrentTimeSigIndex;
             var timeSigs = SyncTrack.TimeSignatures;
-            while (State.NextTimeSigIndex < timeSigs.Count && timeSigs[State.NextTimeSigIndex].Time < time)
+            while (State.NextTimeSigIndex < timeSigs.Count && timeSigs[State.NextTimeSigIndex].Tick <= State.CurrentTick)
             {
                 State.CurrentTimeSigIndex++;
                 State.NextTimeSigIndex++;

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using YARG.Core.Chart;
 using YARG.Core.Engine.Logging;
@@ -300,11 +300,20 @@ namespace YARG.Core.Engine
 
             var currentTimeSig = timeSigs[State.CurrentTimeSigIndex];
 
+            YargTrace.DebugAssert(currentTimeSig.Numerator != 0, "Time signature numerator is 0! Ticks per beat/measure will be 0 after this");
+            YargTrace.DebugAssert(currentTimeSig.Denominator != 0, "Time signature denominator is 0! Ticks per beat/measure will be 0 after this");
+
             // Set ticks per beat/measure if they haven't been set yet
             if (State.TicksEveryBeat == 0)
+            {
                 State.TicksEveryBeat = currentTimeSig.GetTicksPerBeat(SyncTrack);
+                YargTrace.DebugAssert(State.TicksEveryBeat != 0, "Ticks per beat is 0! Star Power will be NaN after this");
+            }
             if (State.TicksEveryMeasure == 0)
+            {
                 State.TicksEveryMeasure = currentTimeSig.GetTicksPerMeasure(SyncTrack);
+                YargTrace.DebugAssert(State.TicksEveryMeasure != 0, "Ticks per measure is 0! Star Power will be NaN after this");
+            }
 
             // Rebase SP on time signature change
             if (previousTimeSigIndex != State.CurrentTimeSigIndex)
@@ -316,6 +325,8 @@ namespace YARG.Core.Engine
                 // Update ticks per beat/measure *after* rebasing, otherwise SP won't update correctly
                 State.TicksEveryBeat = currentTimeSig.GetTicksPerBeat(SyncTrack);
                 State.TicksEveryMeasure = currentTimeSig.GetTicksPerMeasure(SyncTrack);
+                YargTrace.DebugAssert(State.TicksEveryBeat != 0, "Ticks per beat is 0! Star Power will be NaN after this");
+                YargTrace.DebugAssert(State.TicksEveryMeasure != 0, "Ticks per measure is 0! Star Power will be NaN after this");
             }
 
             uint nextTimeSigTick;
@@ -338,6 +349,7 @@ namespace YARG.Core.Engine
                     RebaseStarPower(currentMeasureTick);
                 }
                 State.TicksEveryMeasure = nextTimeSigTick - currentMeasureTick;
+                YargTrace.DebugAssert(State.TicksEveryMeasure != 0, "Ticks per measure is 0! Star Power will be NaN after this");
             }
 
             // Handle the last beat of misaligned time signatures correctly
@@ -351,6 +363,7 @@ namespace YARG.Core.Engine
                 UpdateStarPowerAmount(currentBeatTick);
                 RebaseStarPower(currentBeatTick);
                 State.TicksEveryBeat = nextTimeSigTick - currentBeatTick;
+                YargTrace.DebugAssert(State.TicksEveryBeat != 0, "Ticks per beat is 0! Star Power will be NaN after this");
             }
         }
 
@@ -494,6 +507,11 @@ namespace YARG.Core.Engine
             double gain = CalculateStarPowerGain(tick);
             double drain = CalculateStarPowerDrain(tick);
             EngineStats.StarPowerAmount = Math.Clamp(EngineStats.StarPowerBaseAmount + gain - drain, 0, 1);
+
+            YargTrace.DebugAssert(!double.IsNaN(gain), "SP gain is NaN!");
+            YargTrace.DebugAssert(!double.IsNaN(drain), "SP drain is NaN!");
+            YargTrace.DebugAssert(!double.IsNaN(EngineStats.StarPowerBaseAmount), "SP base is NaN!");
+            YargTrace.DebugAssert(!double.IsNaN(EngineStats.StarPowerAmount), "SP amount is NaN!");
         }
 
         protected void AwardStarPower(TNoteType note)

--- a/YARG.Core/Engine/BaseEngineState.cs
+++ b/YARG.Core/Engine/BaseEngineState.cs
@@ -16,12 +16,15 @@
         public int CurrentTimeSigIndex;
         public int NextTimeSigIndex;
 
+        public uint TicksEveryMeasure;
+
         public int CurrentSoloIndex;
         public int CurrentStarIndex;
 
         public bool IsSoloActive;
 
-        public uint TicksEveryEightMeasures;
+        public bool IsStarPowerInputActive;
+        public uint StarPowerBaseTick;
 
         public virtual void Reset()
         {
@@ -38,12 +41,14 @@
             CurrentTimeSigIndex = 0;
             NextTimeSigIndex = 1;
 
+            TicksEveryMeasure = 0;
+
             CurrentSoloIndex = 0;
             CurrentStarIndex = 0;
 
             IsSoloActive = false;
 
-            TicksEveryEightMeasures = 0;
+            StarPowerBaseTick = 0;
         }
 
     }

--- a/YARG.Core/Engine/BaseEngineState.cs
+++ b/YARG.Core/Engine/BaseEngineState.cs
@@ -16,6 +16,7 @@
         public int CurrentTimeSigIndex;
         public int NextTimeSigIndex;
 
+        public uint TicksEveryBeat;
         public uint TicksEveryMeasure;
 
         public int CurrentSoloIndex;
@@ -41,6 +42,7 @@
             CurrentTimeSigIndex = 0;
             NextTimeSigIndex = 1;
 
+            TicksEveryBeat = 0;
             TicksEveryMeasure = 0;
 
             CurrentSoloIndex = 0;

--- a/YARG.Core/Engine/BaseStats.cs
+++ b/YARG.Core/Engine/BaseStats.cs
@@ -41,6 +41,12 @@ namespace YARG.Core.Engine
         public double StarPowerAmount;
 
         /// <summary>
+        /// Amount of Star Power/Overdrive the player had as of the most recent SP/OD rebase
+        /// (SP activation, time signature change, SP sustain whammy start).
+        /// </summary>
+        public double StarPowerBaseAmount;
+
+        /// <summary>
         /// True if the player currently has Star Power/Overdrive active.
         /// </summary>
         public bool IsStarPowerActive;
@@ -83,8 +89,11 @@ namespace YARG.Core.Engine
             ScoreMultiplier = stats.ScoreMultiplier;
             NotesHit = stats.NotesHit;
             NotesMissed = stats.NotesMissed;
+
             StarPowerAmount = stats.StarPowerAmount;
+            StarPowerBaseAmount = stats.StarPowerBaseAmount;
             IsStarPowerActive = stats.IsStarPowerActive;
+
             PhrasesHit = stats.PhrasesHit;
             PhrasesMissed = stats.PhrasesMissed;
             SoloBonuses = stats.SoloBonuses;
@@ -99,8 +108,11 @@ namespace YARG.Core.Engine
             ScoreMultiplier = 1;
             NotesHit = 0;
             NotesMissed = 0;
+
             StarPowerAmount = 0;
+            StarPowerBaseAmount = 0;
             IsStarPowerActive = false;
+
             PhrasesHit = 0;
             PhrasesMissed = 0;
             SoloBonuses = 0;
@@ -115,8 +127,11 @@ namespace YARG.Core.Engine
             writer.Write(ScoreMultiplier);
             writer.Write(NotesHit);
             writer.Write(NotesMissed);
+
             writer.Write(StarPowerAmount);
+            writer.Write(StarPowerBaseAmount);
             writer.Write(IsStarPowerActive);
+
             writer.Write(PhrasesHit);
             writer.Write(PhrasesMissed);
             writer.Write(SoloBonuses);
@@ -130,8 +145,11 @@ namespace YARG.Core.Engine
             ScoreMultiplier = reader.ReadInt32();
             NotesHit = reader.ReadInt32();
             NotesMissed = reader.ReadInt32();
+
             StarPowerAmount = reader.ReadDouble();
+            StarPowerBaseAmount = reader.ReadDouble();
             IsStarPowerActive = reader.ReadBoolean();
+
             PhrasesHit = reader.ReadInt32();
             PhrasesMissed = reader.ReadInt32();
             SoloBonuses = reader.ReadInt32();

--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -56,7 +56,7 @@ namespace YARG.Core.Engine.Drums.Engines
         {
             UpdateTimeVariables(time);
 
-            DepleteStarPower(GetUsedStarPower());
+            UpdateStarPower();
 
             // Get the pad hit this update
             if (IsInputUpdate && CurrentInput.Button)

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -411,6 +411,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             // No sustains
             if (ActiveSustains.Count == 0)
             {
+                UpdateWhammyStarPower(spSustainsActive: false);
                 return;
             }
 
@@ -419,7 +420,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             {
                 var note = ActiveSustains[i];
 
-                isStarPowerSustainActive = note.IsStarPower || isStarPowerSustainActive;
+                isStarPowerSustainActive |= note.IsStarPower;
                 bool sustainEnded = State.CurrentTick > note.TickEnd;
 
                 if (!CanNoteBeHit(note) || sustainEnded)
@@ -430,15 +431,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 }
             }
 
-            if (isStarPowerSustainActive && CurrentInput.GetAction<GuitarAction>() == GuitarAction.Whammy)
-            {
-                EngineStats.StarPowerAmount += (State.CurrentTick - State.LastTick) /
-                    (double) (State.TicksEveryMeasure * STAR_POWER_MAX_MEASURES);
-                if (EngineStats.StarPowerAmount >= 1)
-                {
-                    EngineStats.StarPowerAmount = 1;
-                }
-            }
+            UpdateWhammyStarPower(isStarPowerSustainActive);
         }
 
         protected override bool HitNote(GuitarNote note)

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -71,7 +71,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 ActivateStarPower();
             }
 
-            DepleteStarPower(GetUsedStarPower());
+            UpdateStarPower();
 
             State.StrummedThisUpdate = (IsInputUpdate && IsStrumInput(CurrentInput) && CurrentInput.Button)
                 || (State.StrummedThisUpdate && IsBotUpdate);
@@ -432,7 +432,8 @@ namespace YARG.Core.Engine.Guitar.Engines
 
             if (isStarPowerSustainActive && CurrentInput.GetAction<GuitarAction>() == GuitarAction.Whammy)
             {
-                EngineStats.StarPowerAmount += (State.CurrentTick - State.LastTick) / (double)State.TicksEveryEightMeasures;
+                EngineStats.StarPowerAmount += (State.CurrentTick - State.LastTick) /
+                    (double) (State.TicksEveryMeasure * STAR_POWER_MAX_MEASURES);
                 if (EngineStats.StarPowerAmount >= 1)
                 {
                     EngineStats.StarPowerAmount = 1;

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -242,6 +242,40 @@ namespace YARG.Core.Engine.Guitar
             }
         }
 
+        protected override void RebaseStarPower(uint baseTick)
+        {
+            base.RebaseStarPower(baseTick);
+
+            State.StarPowerWhammyBaseTick = baseTick;
+        }
+
+        protected override double CalculateStarPowerGain(uint tick)
+            => State.StarPowerWhammyTimer.IsActive(State.CurrentTime) ?
+                CalculateStarPowerProgress(tick, State.StarPowerWhammyBaseTick) : 0;
+
+        protected void UpdateWhammyStarPower(bool spSustainsActive)
+        {
+            if (spSustainsActive)
+            {
+                if (CurrentInput.GetAction<GuitarAction>() == GuitarAction.Whammy)
+                {
+                    // Rebase when beginning to SP whammy
+                    if (!State.StarPowerWhammyTimer.IsActive(State.CurrentTime))
+                    {
+                        RebaseStarPower(State.CurrentTick);
+                    }
+
+                    State.StarPowerWhammyTimer.Start(State.CurrentTime);
+                }
+            }
+            // Rebase after SP whammy ends to commit the final amount to the base
+            else if (State.StarPowerWhammyTimer.IsActive(State.CurrentTime))
+            {
+                RebaseStarPower(State.CurrentTick);
+                State.StarPowerWhammyTimer.Reset();
+            }
+        }
+
         protected sealed override int CalculateBaseScore()
         {
             int score = 0;

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -257,7 +257,7 @@ namespace YARG.Core.Engine.Guitar
         {
             if (spSustainsActive)
             {
-                if (CurrentInput.GetAction<GuitarAction>() == GuitarAction.Whammy)
+                if (IsInputUpdate && CurrentInput.GetAction<GuitarAction>() == GuitarAction.Whammy)
                 {
                     // Rebase when beginning to SP whammy
                     if (!State.StarPowerWhammyTimer.IsActive(State.CurrentTime))
@@ -266,6 +266,18 @@ namespace YARG.Core.Engine.Guitar
                     }
 
                     State.StarPowerWhammyTimer.Start(State.CurrentTime);
+                }
+                else if (State.StarPowerWhammyTimer.IsExpired(State.CurrentTime))
+                {
+                    // Temporarily re-start whammy timer so that whammy gain gets calculated
+                    State.StarPowerWhammyTimer.Start(State.CurrentTime);
+
+                    // Commit final whammy gain amount
+                    UpdateStarPowerAmount(State.CurrentTick);
+                    RebaseStarPower(State.CurrentTick);
+
+                    // Stop whammy gain
+                    State.StarPowerWhammyTimer.Reset();
                 }
             }
             // Rebase after SP whammy ends to commit the final amount to the base

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -251,7 +251,7 @@ namespace YARG.Core.Engine.Guitar
 
         protected override double CalculateStarPowerGain(uint tick)
             => State.StarPowerWhammyTimer.IsActive(State.CurrentTime) ?
-                CalculateStarPowerProgress(tick, State.StarPowerWhammyBaseTick) : 0;
+                CalculateStarPowerBeatProgress(tick, State.StarPowerWhammyBaseTick) : 0;
 
         protected void UpdateWhammyStarPower(bool spSustainsActive)
         {

--- a/YARG.Core/Engine/Guitar/GuitarEngineParameters.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineParameters.cs
@@ -9,6 +9,8 @@ namespace YARG.Core.Engine.Guitar
         public double StrumLeniency      { get; private set; }
         public double StrumLeniencySmall { get; private set; }
 
+        public double StarPowerWhammyBuffer { get; private set; }
+
         public bool InfiniteFrontEnd { get; private set; }
         public bool AntiGhosting     { get; private set; }
 
@@ -16,14 +18,17 @@ namespace YARG.Core.Engine.Guitar
         {
         }
 
-        public GuitarEngineParameters(HitWindowSettings hitWindow, float[] starMultiplierThresholds, double hopoLeniency,
-            double strumLeniency, double strumLeniencySmall, bool infiniteFrontEnd, bool antiGhosting)
+        public GuitarEngineParameters(HitWindowSettings hitWindow, float[] starMultiplierThresholds,
+            double hopoLeniency, double strumLeniency, double strumLeniencySmall, double spWhammyBuffer,
+            bool infiniteFrontEnd, bool antiGhosting)
             : base(hitWindow, starMultiplierThresholds)
         {
             HopoLeniency = hopoLeniency;
 
             StrumLeniency = strumLeniency;
             StrumLeniencySmall = strumLeniencySmall;
+
+            StarPowerWhammyBuffer = spWhammyBuffer;
 
             InfiniteFrontEnd = infiniteFrontEnd;
             AntiGhosting = antiGhosting;
@@ -34,8 +39,12 @@ namespace YARG.Core.Engine.Guitar
             base.Serialize(writer);
 
             writer.Write(HopoLeniency);
+
             writer.Write(StrumLeniency);
             writer.Write(StrumLeniencySmall);
+
+            writer.Write(StarPowerWhammyBuffer);
+
             writer.Write(InfiniteFrontEnd);
             writer.Write(AntiGhosting);
         }
@@ -45,8 +54,12 @@ namespace YARG.Core.Engine.Guitar
             base.Deserialize(reader, version);
 
             HopoLeniency = reader.ReadDouble();
+
             StrumLeniency = reader.ReadDouble();
             StrumLeniencySmall = reader.ReadDouble();
+
+            StarPowerWhammyBuffer = reader.ReadDouble();
+
             InfiniteFrontEnd = reader.ReadBoolean();
             AntiGhosting = reader.ReadBoolean();
         }

--- a/YARG.Core/Engine/Guitar/GuitarEngineState.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineState.cs
@@ -2,8 +2,6 @@
 {
     public class GuitarEngineState : BaseEngineState
     {
-        public const double STAR_POWER_WHAMMY_BUFFER_TIME = 0.1;
-
         public byte ButtonMask;
         public byte LastButtonMask;
         public byte TapButtonMask;
@@ -19,14 +17,13 @@
 
         public double FrontEndStartTime;
 
-
         public uint StarPowerWhammyBaseTick;
 
         public void Initialize(GuitarEngineParameters parameters)
         {
             StrumLeniencyTimer = new(parameters.StrumLeniency);
             HopoLeniencyTimer = new(parameters.HopoLeniency);
-            StarPowerWhammyTimer = new(STAR_POWER_WHAMMY_BUFFER_TIME);
+            StarPowerWhammyTimer = new(parameters.StarPowerWhammyBuffer);
         }
 
         public override void Reset()

--- a/YARG.Core/Engine/Guitar/GuitarEngineState.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineState.cs
@@ -2,6 +2,7 @@
 {
     public class GuitarEngineState : BaseEngineState
     {
+        public const double STAR_POWER_WHAMMY_BUFFER_TIME = 0.1;
 
         public byte ButtonMask;
         public byte LastButtonMask;
@@ -14,12 +15,18 @@
         public EngineTimer StrumLeniencyTimer;
         public EngineTimer HopoLeniencyTimer;
 
+        public EngineTimer StarPowerWhammyTimer;
+
         public double FrontEndStartTime;
+
+
+        public uint StarPowerWhammyBaseTick;
 
         public void Initialize(GuitarEngineParameters parameters)
         {
             StrumLeniencyTimer = new(parameters.StrumLeniency);
             HopoLeniencyTimer = new(parameters.HopoLeniency);
+            StarPowerWhammyTimer = new(STAR_POWER_WHAMMY_BUFFER_TIME);
         }
 
         public override void Reset()
@@ -36,6 +43,7 @@
 
             StrumLeniencyTimer.Reset();
             HopoLeniencyTimer.Reset();
+            StarPowerWhammyTimer.Reset();
 
             FrontEndStartTime = 0;
         }

--- a/YARG.Core/Engine/Guitar/GuitarStats.cs
+++ b/YARG.Core/Engine/Guitar/GuitarStats.cs
@@ -19,6 +19,11 @@ namespace YARG.Core.Engine.Guitar
         /// </summary>
         public int GhostInputs;
 
+        /// <summary>
+        /// Amount of Star Power/Overdrive gained from whammy during the current whammy period.
+        /// </summary>
+        public double StarPowerWhammyGain;
+
         public GuitarStats()
         {
         }
@@ -28,6 +33,7 @@ namespace YARG.Core.Engine.Guitar
             Overstrums = stats.Overstrums;
             HoposStrummed = stats.HoposStrummed;
             GhostInputs = stats.GhostInputs;
+            StarPowerWhammyGain = stats.StarPowerWhammyGain;
         }
 
         public override void Reset()
@@ -36,6 +42,7 @@ namespace YARG.Core.Engine.Guitar
             Overstrums = 0;
             HoposStrummed = 0;
             GhostInputs = 0;
+            StarPowerWhammyGain = 0;
         }
 
         public override void Serialize(BinaryWriter writer)
@@ -45,6 +52,7 @@ namespace YARG.Core.Engine.Guitar
             writer.Write(Overstrums);
             writer.Write(HoposStrummed);
             writer.Write(GhostInputs);
+            writer.Write(StarPowerWhammyGain);
         }
 
         public override void Deserialize(BinaryReader reader, int version = 0)
@@ -54,6 +62,7 @@ namespace YARG.Core.Engine.Guitar
             Overstrums = reader.ReadInt32();
             HoposStrummed = reader.ReadInt32();
             GhostInputs = reader.ReadInt32();
+            StarPowerWhammyGain = reader.ReadDouble();
         }
     }
 }

--- a/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
@@ -80,7 +80,7 @@ namespace YARG.Core.Engine.Vocals.Engines
                 ActivateStarPower();
             }
 
-            DepleteStarPower(GetUsedStarPower());
+            UpdateStarPower();
 
             // Get the pitch this update
             if (IsInputUpdate && CurrentInput.GetAction<VocalsAction>() == VocalsAction.Pitch)


### PR DESCRIPTION
Star Power amount is now based on direct tick differences recalculated every update, rather than being accumulated over updates. This makes things fully consistent and prevents imprecision issues from messing with the value over time (particularly when lots of inputs are happening).

SP whammy also now has a leniency timer where it'll stay active without a whammy input before stopping. This makes it possible to use keyboard whammy without having to absolutely smash it to pieces just to get a usable amount of SP lol

This will require a couple changes in main YARG, to add a value for the SP whammy leniency timer parameter (I suggest between 0.1 to 0.2, i.e. 5 to 10 whammy inputs per second needed), and adjust the debug text for the new ticks per beat/measure variables. It will also break existing replays, since a couple new values need to be serialized.