### PR TITLE
Utilize Generics to Consolidate YARGBinaryReader & StreamExtension Read Functions

### DIFF
--- a/YARG.Core/Extensions/StreamExtensions.cs
+++ b/YARG.Core/Extensions/StreamExtensions.cs
@@ -1,408 +1,56 @@
 ﻿using System;
-using System.Buffers.Binary;
 using System.IO;
+using YARG.Core.IO;
 
 namespace YARG.Core.Extensions
 {
     public static class StreamExtensions
     {
-        #region Stream
-        public static short ReadInt16LE(this Stream stream)
+        public static TType Read<TType>(this Stream stream, Endianness endianness = Endianness.LittleEndian)
+            where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            if (stream.Read(buffer) != sizeof(short))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
+            TType value = default;
+            unsafe
+            {
+                byte* buffer = (byte*)&value;
+                if (stream.Read(new Span<byte>(buffer, sizeof(TType))) != sizeof(TType))
+                    throw new EndOfStreamException($"Not enough data in the stream to read {typeof(TType)} ({sizeof(TType)} bytes)!");
 
-            return BinaryPrimitives.ReadInt16LittleEndian(buffer);
-        }
-
-        public static short ReadInt16BE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            if (stream.Read(buffer) != sizeof(short))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
-
-            return BinaryPrimitives.ReadInt16BigEndian(buffer);
-        }
-
-        public static ushort ReadUInt16LE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            if (stream.Read(buffer) != sizeof(ushort))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
-
-            return BinaryPrimitives.ReadUInt16LittleEndian(buffer);
-        }
-
-        public static ushort ReadUInt16BE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            if (stream.Read(buffer) != sizeof(ushort))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
-
-            return BinaryPrimitives.ReadUInt16BigEndian(buffer);
-        }
-
-        public static int ReadInt32LE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            if (stream.Read(buffer) != sizeof(int))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
-
-            return BinaryPrimitives.ReadInt32LittleEndian(buffer);
-        }
-
-        public static int ReadInt32BE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            if (stream.Read(buffer) != sizeof(int))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
-
-            return BinaryPrimitives.ReadInt32BigEndian(buffer);
-        }
-
-        public static uint ReadUInt32LE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            if (stream.Read(buffer) != sizeof(uint))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
-
-            return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        }
-
-        public static uint ReadUInt32BE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            if (stream.Read(buffer) != sizeof(uint))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
-
-            return BinaryPrimitives.ReadUInt32BigEndian(buffer);
-        }
-
-        public static long ReadInt64LE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            if (stream.Read(buffer) != sizeof(long))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
-
-            return BinaryPrimitives.ReadInt64LittleEndian(buffer);
-        }
-
-        public static long ReadInt64BE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            if (stream.Read(buffer) != sizeof(long))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
-
-            return BinaryPrimitives.ReadInt64BigEndian(buffer);
-        }
-
-        public static ulong ReadUInt64LE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            if (stream.Read(buffer) != sizeof(ulong))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
-
-            return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
-        }
-
-        public static ulong ReadUInt64BE(this Stream stream)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            if (stream.Read(buffer) != sizeof(ulong))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
-
-            return BinaryPrimitives.ReadUInt64BigEndian(buffer);
+                // Have to flip bits if the OS uses the opposite Endian
+                if ((endianness == Endianness.LittleEndian) != BitConverter.IsLittleEndian)
+                {
+                    int half = sizeof(TType) >> 1;
+                    for (int i = 0, j = sizeof(TType) - 1; i < half; ++i, --j)
+                        (buffer[j], buffer[i]) = (buffer[i], buffer[j]);
+                }
+            }
+            return value;
         }
 
         public static byte[] ReadBytes(this Stream stream, int length)
         {
             byte[] buffer = new byte[length];
             if (stream.Read(buffer, 0, length) != length)
-                throw new EndOfStreamException($"Not enough data in the buffer to read {length} bytes!");
+                throw new EndOfStreamException($"Not enough data in the stream to read {length} bytes!");
 
             return buffer;
         }
 
-        public static void WriteInt16LE(this Stream stream, short value)
+        public static void Write<TType>(this Stream stream, TType value, Endianness endianness = Endianness.LittleEndian)
+            where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
-            stream.Write(buffer);
+            unsafe
+            {
+                byte* buffer = (byte*) &value;
+                // Have to flip bits if the OS uses the opposite Endian
+                if ((endianness == Endianness.LittleEndian) != BitConverter.IsLittleEndian)
+                {
+                    int half = sizeof(TType) >> 1;
+                    for (int i = 0, j = sizeof(TType) - 1; i < half; ++i, --j)
+                        (buffer[j], buffer[i]) = (buffer[i], buffer[j]);
+                }
+                stream.Write(new Span<byte>(buffer, sizeof(TType)));
+            }
         }
-
-        public static void WriteInt16BE(this Stream stream, short value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            BinaryPrimitives.WriteInt16BigEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteUInt16LE(this Stream stream, ushort value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteUInt16BE(this Stream stream, ushort value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            BinaryPrimitives.WriteUInt16BigEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteInt32LE(this Stream stream, int value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteInt32BE(this Stream stream, int value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            BinaryPrimitives.WriteInt32BigEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteUInt32LE(this Stream stream, uint value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteUInt32BE(this Stream stream, uint value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteInt64LE(this Stream stream, long value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteInt64BE(this Stream stream, long value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            BinaryPrimitives.WriteInt64BigEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteUInt64LE(this Stream stream, ulong value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
-            stream.Write(buffer);
-        }
-
-        public static void WriteUInt64BE(this Stream stream, ulong value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            BinaryPrimitives.WriteUInt64BigEndian(buffer, value);
-            stream.Write(buffer);
-        }
-        #endregion
-
-        #region BinaryReader
-        public static short ReadInt16LE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            if (reader.Read(buffer) != sizeof(short))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
-
-            return BinaryPrimitives.ReadInt16LittleEndian(buffer);
-        }
-
-        public static short ReadInt16BE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            if (reader.Read(buffer) != sizeof(short))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int16!");
-
-            return BinaryPrimitives.ReadInt16BigEndian(buffer);
-        }
-
-        public static ushort ReadUInt16LE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            if (reader.Read(buffer) != sizeof(ushort))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
-
-            return BinaryPrimitives.ReadUInt16LittleEndian(buffer);
-        }
-
-        public static ushort ReadUInt16BE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            if (reader.Read(buffer) != sizeof(ushort))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt16!");
-
-            return BinaryPrimitives.ReadUInt16BigEndian(buffer);
-        }
-
-        public static int ReadInt32LE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            if (reader.Read(buffer) != sizeof(int))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
-
-            return BinaryPrimitives.ReadInt32LittleEndian(buffer);
-        }
-
-        public static int ReadInt32BE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            if (reader.Read(buffer) != sizeof(int))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int32!");
-
-            return BinaryPrimitives.ReadInt32BigEndian(buffer);
-        }
-
-        public static uint ReadUInt32LE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            if (reader.Read(buffer) != sizeof(uint))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
-
-            return BinaryPrimitives.ReadUInt32LittleEndian(buffer);
-        }
-
-        public static uint ReadUInt32BE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            if (reader.Read(buffer) != sizeof(uint))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt32!");
-
-            return BinaryPrimitives.ReadUInt32BigEndian(buffer);
-        }
-
-        public static long ReadInt64LE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            if (reader.Read(buffer) != sizeof(long))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
-
-            return BinaryPrimitives.ReadInt64LittleEndian(buffer);
-        }
-
-        public static long ReadInt64BE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            if (reader.Read(buffer) != sizeof(long))
-                throw new EndOfStreamException("Not enough data in the buffer to read an Int64!");
-
-            return BinaryPrimitives.ReadInt64BigEndian(buffer);
-        }
-
-        public static ulong ReadUInt64LE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            if (reader.Read(buffer) != sizeof(ulong))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
-
-            return BinaryPrimitives.ReadUInt64LittleEndian(buffer);
-        }
-
-        public static ulong ReadUInt64BE(this BinaryReader reader)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            if (reader.Read(buffer) != sizeof(ulong))
-                throw new EndOfStreamException("Not enough data in the buffer to read a UInt64!");
-
-            return BinaryPrimitives.ReadUInt64BigEndian(buffer);
-        }
-        #endregion
-
-        #region BinaryWriter
-        public static void WriteInt16LE(this BinaryWriter writer, short value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            BinaryPrimitives.WriteInt16LittleEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteInt16BE(this BinaryWriter writer, short value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(short)];
-            BinaryPrimitives.WriteInt16BigEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteUInt16LE(this BinaryWriter writer, ushort value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            BinaryPrimitives.WriteUInt16LittleEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteUInt16BE(this BinaryWriter writer, ushort value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ushort)];
-            BinaryPrimitives.WriteUInt16BigEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteInt32LE(this BinaryWriter writer, int value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            BinaryPrimitives.WriteInt32LittleEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteInt32BE(this BinaryWriter writer, int value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(int)];
-            BinaryPrimitives.WriteInt32BigEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteUInt32LE(this BinaryWriter writer, uint value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            BinaryPrimitives.WriteUInt32LittleEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteUInt32BE(this BinaryWriter writer, uint value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(uint)];
-            BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteInt64LE(this BinaryWriter writer, long value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            BinaryPrimitives.WriteInt64LittleEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteInt64BE(this BinaryWriter writer, long value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(long)];
-            BinaryPrimitives.WriteInt64BigEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteUInt64LE(this BinaryWriter writer, ulong value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            BinaryPrimitives.WriteUInt64LittleEndian(buffer, value);
-            writer.Write(buffer);
-        }
-
-        public static void WriteUInt64BE(this BinaryWriter writer, ulong value)
-        {
-            Span<byte> buffer = stackalloc byte[sizeof(ulong)];
-            BinaryPrimitives.WriteUInt64BigEndian(buffer, value);
-            writer.Write(buffer);
-        }
-        #endregion
     }
 }

--- a/YARG.Core/Extensions/StreamExtensions.cs
+++ b/YARG.Core/Extensions/StreamExtensions.cs
@@ -6,7 +6,7 @@ namespace YARG.Core.Extensions
 {
     public static class StreamExtensions
     {
-        public static TType Read<TType>(this Stream stream, Endianness endianness = Endianness.Little)
+        public static TType Read<TType>(this Stream stream, Endianness endianness)
             where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
             TType value = default;
@@ -32,7 +32,7 @@ namespace YARG.Core.Extensions
             return buffer;
         }
 
-        public static void Write<TType>(this Stream stream, TType value, Endianness endianness = Endianness.Little)
+        public static void Write<TType>(this Stream stream, TType value, Endianness endianness)
             where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
             unsafe

--- a/YARG.Core/Extensions/StreamExtensions.cs
+++ b/YARG.Core/Extensions/StreamExtensions.cs
@@ -6,7 +6,7 @@ namespace YARG.Core.Extensions
 {
     public static class StreamExtensions
     {
-        public static TType Read<TType>(this Stream stream, Endianness endianness = Endianness.LittleEndian)
+        public static TType Read<TType>(this Stream stream, Endianness endianness = Endianness.Little)
             where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
             TType value = default;
@@ -17,7 +17,7 @@ namespace YARG.Core.Extensions
                     throw new EndOfStreamException($"Not enough data in the stream to read {typeof(TType)} ({sizeof(TType)} bytes)!");
 
                 // Have to flip bits if the OS uses the opposite Endian
-                if ((endianness == Endianness.LittleEndian) != BitConverter.IsLittleEndian)
+                if ((endianness == Endianness.Little) != BitConverter.IsLittleEndian)
                 {
                     int half = sizeof(TType) >> 1;
                     for (int i = 0, j = sizeof(TType) - 1; i < half; ++i, --j)
@@ -36,14 +36,14 @@ namespace YARG.Core.Extensions
             return buffer;
         }
 
-        public static void Write<TType>(this Stream stream, TType value, Endianness endianness = Endianness.LittleEndian)
+        public static void Write<TType>(this Stream stream, TType value, Endianness endianness = Endianness.Little)
             where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
             unsafe
             {
                 byte* buffer = (byte*) &value;
                 // Have to flip bits if the OS uses the opposite Endian
-                if ((endianness == Endianness.LittleEndian) != BitConverter.IsLittleEndian)
+                if ((endianness == Endianness.Little) != BitConverter.IsLittleEndian)
                 {
                     int half = sizeof(TType) >> 1;
                     for (int i = 0, j = sizeof(TType) - 1; i < half; ++i, --j)

--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -18,7 +18,7 @@ namespace YARG.Core.IO
         public AbridgedFileInfo(YARGBinaryReader reader)
         {
             FullName = reader.ReadLEBString();
-            LastWriteTime = DateTime.FromBinary(reader.ReadInt64());
+            LastWriteTime = DateTime.FromBinary(reader.Read<long>());
         }
 
         public AbridgedFileInfo(string fullname, DateTime lastWrite)
@@ -55,7 +55,7 @@ namespace YARG.Core.IO
         public static AbridgedFileInfo? TryParseInfo(string file, YARGBinaryReader reader)
         {
             FileInfo midiInfo = new(file);
-            if (!midiInfo.Exists || midiInfo.LastWriteTime != DateTime.FromBinary(reader.ReadInt64()))
+            if (!midiInfo.Exists || midiInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>()))
                 return null;
             return midiInfo;
         }

--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -18,7 +18,7 @@ namespace YARG.Core.IO
         public AbridgedFileInfo(YARGBinaryReader reader)
         {
             FullName = reader.ReadLEBString();
-            LastWriteTime = DateTime.FromBinary(reader.Read<long>());
+            LastWriteTime = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
         }
 
         public AbridgedFileInfo(string fullname, DateTime lastWrite)
@@ -55,7 +55,7 @@ namespace YARG.Core.IO
         public static AbridgedFileInfo? TryParseInfo(string file, YARGBinaryReader reader)
         {
             FileInfo midiInfo = new(file);
-            if (!midiInfo.Exists || midiInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>()))
+            if (!midiInfo.Exists || midiInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>(Endianness.Little)))
                 return null;
             return midiInfo;
         }

--- a/YARG.Core/IO/CharacterCodes.cs
+++ b/YARG.Core/IO/CharacterCodes.cs
@@ -36,13 +36,13 @@ namespace YARG.Core.IO
             _code = BinaryPrimitives.ReadUInt32BigEndian(data);
         }
 
-        public static FourCC Read(Stream stream) => new(stream.Read<uint>(Endianness.BigEndian));
-        public static FourCC Read(BinaryReader reader) => new(reader.BaseStream.Read<uint>(Endianness.BigEndian));
-        public static FourCC Read(YARGBinaryReader reader) => new(reader.Read<uint>(Endianness.BigEndian));
+        public static FourCC Read(Stream stream) => new(stream.Read<uint>(Endianness.Big));
+        public static FourCC Read(BinaryReader reader) => new(reader.BaseStream.Read<uint>(Endianness.Big));
+        public static FourCC Read(YARGBinaryReader reader) => new(reader.Read<uint>(Endianness.Big));
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.BaseStream.Write(_code, Endianness.BigEndian);
+            writer.BaseStream.Write(_code, Endianness.Big);
         }
 
         [Obsolete("FourCC is a readonly struct, use the Read static method instead.", true)]
@@ -99,13 +99,13 @@ namespace YARG.Core.IO
             _code = BinaryPrimitives.ReadUInt64BigEndian(data);
         }
 
-        public static EightCC Read(Stream stream) => new(stream.Read<ulong>(Endianness.BigEndian));
-        public static EightCC Read(BinaryReader reader) => new(reader.BaseStream.Read<ulong>(Endianness.BigEndian));
-        public static EightCC Read(YARGBinaryReader reader) => new(reader.Read<ulong>(Endianness.BigEndian));
+        public static EightCC Read(Stream stream) => new(stream.Read<ulong>(Endianness.Big));
+        public static EightCC Read(BinaryReader reader) => new(reader.BaseStream.Read<ulong>(Endianness.Big));
+        public static EightCC Read(YARGBinaryReader reader) => new(reader.Read<ulong>(Endianness.Big));
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.BaseStream.Write(_code, Endianness.BigEndian);
+            writer.BaseStream.Write(_code, Endianness.Big);
         }
 
         [Obsolete("EightCC is a readonly struct, use the Read static method instead.", true)]

--- a/YARG.Core/IO/CharacterCodes.cs
+++ b/YARG.Core/IO/CharacterCodes.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers.Binary;
 using System.IO;
 using System.Runtime.CompilerServices;
@@ -36,13 +36,13 @@ namespace YARG.Core.IO
             _code = BinaryPrimitives.ReadUInt32BigEndian(data);
         }
 
-        public static FourCC Read(Stream stream) => new(stream.ReadUInt32BE());
-        public static FourCC Read(BinaryReader reader) => new(reader.ReadUInt32BE());
-        public static FourCC Read(YARGBinaryReader reader) => new(reader.ReadUInt32(Endianness.BigEndian));
+        public static FourCC Read(Stream stream) => new(stream.Read<uint>(Endianness.BigEndian));
+        public static FourCC Read(BinaryReader reader) => new(reader.BaseStream.Read<uint>(Endianness.BigEndian));
+        public static FourCC Read(YARGBinaryReader reader) => new(reader.Read<uint>(Endianness.BigEndian));
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.WriteUInt32BE(_code);
+            writer.BaseStream.Write(_code, Endianness.BigEndian);
         }
 
         [Obsolete("FourCC is a readonly struct, use the Read static method instead.", true)]
@@ -99,13 +99,13 @@ namespace YARG.Core.IO
             _code = BinaryPrimitives.ReadUInt64BigEndian(data);
         }
 
-        public static EightCC Read(Stream stream) => new(stream.ReadUInt64BE());
-        public static EightCC Read(BinaryReader reader) => new(reader.ReadUInt64BE());
-        public static EightCC Read(YARGBinaryReader reader) => new(reader.ReadUInt64(Endianness.BigEndian));
+        public static EightCC Read(Stream stream) => new(stream.Read<ulong>(Endianness.BigEndian));
+        public static EightCC Read(BinaryReader reader) => new(reader.BaseStream.Read<ulong>(Endianness.BigEndian));
+        public static EightCC Read(YARGBinaryReader reader) => new(reader.Read<ulong>(Endianness.BigEndian));
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.WriteUInt64BE(_code);
+            writer.BaseStream.Write(_code, Endianness.BigEndian);
         }
 
         [Obsolete("EightCC is a readonly struct, use the Read static method instead.", true)]

--- a/YARG.Core/IO/Midi/YARGMidiFile.cs
+++ b/YARG.Core/IO/Midi/YARGMidiFile.cs
@@ -26,14 +26,14 @@ namespace YARG.Core.IO
             if (FourCC.Read(stream) != HEADER_TAG)
                 throw new Exception("Midi Header Chunk Tag 'MThd' not found");
 
-            int length = stream.ReadInt32BE();
+            int length = stream.Read<int>(Endianness.BigEndian);
             if (length < SIZEOF_HEADER)
                 throw new Exception("Midi Header not of sufficient length");
 
             YARGBinaryReader reader = new(stream, length);
-            _format = reader.ReadUInt16(Endianness.BigEndian);
-            _numTracks = reader.ReadUInt16(Endianness.BigEndian);
-            _tickRate = reader.ReadUInt16(Endianness.BigEndian);
+            _format = reader.Read<ushort>(Endianness.BigEndian);
+            _numTracks = reader.Read<ushort>(Endianness.BigEndian);
+            _tickRate = reader.Read<ushort>(Endianness.BigEndian);
         }
 
         public YARGMidiFile(byte[] data) : this(new MemoryStream(data, 0, data.Length, false, true)) { }

--- a/YARG.Core/IO/Midi/YARGMidiFile.cs
+++ b/YARG.Core/IO/Midi/YARGMidiFile.cs
@@ -26,14 +26,14 @@ namespace YARG.Core.IO
             if (FourCC.Read(stream) != HEADER_TAG)
                 throw new Exception("Midi Header Chunk Tag 'MThd' not found");
 
-            int length = stream.Read<int>(Endianness.BigEndian);
+            int length = stream.Read<int>(Endianness.Big);
             if (length < SIZEOF_HEADER)
                 throw new Exception("Midi Header not of sufficient length");
 
             YARGBinaryReader reader = new(stream, length);
-            _format = reader.Read<ushort>(Endianness.BigEndian);
-            _numTracks = reader.Read<ushort>(Endianness.BigEndian);
-            _tickRate = reader.Read<ushort>(Endianness.BigEndian);
+            _format = reader.Read<ushort>(Endianness.Big);
+            _numTracks = reader.Read<ushort>(Endianness.Big);
+            _tickRate = reader.Read<ushort>(Endianness.Big);
         }
 
         public YARGMidiFile(byte[] data) : this(new MemoryStream(data, 0, data.Length, false, true)) { }

--- a/YARG.Core/IO/Midi/YARGMidiTrack.cs
+++ b/YARG.Core/IO/Midi/YARGMidiTrack.cs
@@ -60,7 +60,7 @@ namespace YARG.Core.IO
 
         public YARGMidiTrack(Stream stream)
         {
-            int count = stream.ReadInt32BE();
+            int count = stream.Read<int>(Endianness.BigEndian);
             if (stream is MemoryStream mem)
             {
                 _data = new ReadOnlyMemory<byte>(mem.GetBuffer(), (int) mem.Position, count);

--- a/YARG.Core/IO/Midi/YARGMidiTrack.cs
+++ b/YARG.Core/IO/Midi/YARGMidiTrack.cs
@@ -60,7 +60,7 @@ namespace YARG.Core.IO
 
         public YARGMidiTrack(Stream stream)
         {
-            int count = stream.Read<int>(Endianness.BigEndian);
+            int count = stream.Read<int>(Endianness.Big);
             if (stream is MemoryStream mem)
             {
                 _data = new ReadOnlyMemory<byte>(mem.GetBuffer(), (int) mem.Position, count);

--- a/YARG.Core/IO/SngHandler/SngFile.cs
+++ b/YARG.Core/IO/SngHandler/SngFile.cs
@@ -71,7 +71,7 @@ namespace YARG.Core.IO
 
             try
             {
-                uint version = stream.Read<uint>();
+                uint version = stream.Read<uint>(Endianness.Little);
                 var xorMask = stream.ReadBytes(XORMASK_SIZE);
                 var metadata = ReadMetadata(stream);
                 var listings = ReadListings(stream);
@@ -100,8 +100,8 @@ namespace YARG.Core.IO
         private static IniSection ReadMetadata(FileStream stream)
         {
             Dictionary<string, List<IniModifier>> modifiers = new();
-            ulong length = stream.Read<ulong>() - sizeof(ulong);
-            ulong numPairs = stream.Read<ulong>();
+            ulong length = stream.Read<ulong>(Endianness.Little) - sizeof(ulong);
+            ulong numPairs = stream.Read<ulong>(Endianness.Little);
 
             var validNodes = SongIniHandler.SONG_INI_DICTIONARY["[song]"];
             YARGTextContainer<byte> text = new(stream.ReadBytes((int)length), 0);
@@ -132,8 +132,8 @@ namespace YARG.Core.IO
 
         private static Dictionary<string, SngFileListing> ReadListings(FileStream stream)
         {
-            ulong length = stream.Read<ulong>() - sizeof(ulong);
-            ulong numListings = stream.Read<ulong>();
+            ulong length = stream.Read<ulong>(Endianness.Little) - sizeof(ulong);
+            ulong numListings = stream.Read<ulong>(Endianness.Little);
 
             Dictionary<string, SngFileListing> listings = new((int)numListings);
 

--- a/YARG.Core/IO/SngHandler/SngFile.cs
+++ b/YARG.Core/IO/SngHandler/SngFile.cs
@@ -71,7 +71,7 @@ namespace YARG.Core.IO
 
             try
             {
-                uint version = stream.ReadUInt32LE();
+                uint version = stream.Read<uint>();
                 var xorMask = stream.ReadBytes(XORMASK_SIZE);
                 var metadata = ReadMetadata(stream);
                 var listings = ReadListings(stream);
@@ -100,8 +100,8 @@ namespace YARG.Core.IO
         private static IniSection ReadMetadata(FileStream stream)
         {
             Dictionary<string, List<IniModifier>> modifiers = new();
-            ulong length = stream.ReadUInt64LE() - sizeof(ulong);
-            ulong numPairs = stream.ReadUInt64LE();
+            ulong length = stream.Read<ulong>() - sizeof(ulong);
+            ulong numPairs = stream.Read<ulong>();
 
             var validNodes = SongIniHandler.SONG_INI_DICTIONARY["[song]"];
             YARGTextContainer<byte> text = new(stream.ReadBytes((int)length), 0);
@@ -132,8 +132,8 @@ namespace YARG.Core.IO
 
         private static Dictionary<string, SngFileListing> ReadListings(FileStream stream)
         {
-            ulong length = stream.ReadUInt64LE() - sizeof(ulong);
-            ulong numListings = stream.ReadUInt64LE();
+            ulong length = stream.Read<ulong>() - sizeof(ulong);
+            ulong numListings = stream.Read<ulong>();
 
             Dictionary<string, SngFileListing> listings = new((int)numListings);
 

--- a/YARG.Core/IO/SngHandler/SngFileListing.cs
+++ b/YARG.Core/IO/SngHandler/SngFileListing.cs
@@ -14,8 +14,8 @@ namespace YARG.Core.IO
 
         public SngFileListing(YARGBinaryReader reader)
         {
-            Length = reader.ReadInt64();
-            Position = reader.ReadInt64();
+            Length = reader.Read<long>();
+            Position = reader.Read<long>();
         }
 
         public byte[] LoadAllBytes(string filename, SngMask mask)

--- a/YARG.Core/IO/SngHandler/SngFileListing.cs
+++ b/YARG.Core/IO/SngHandler/SngFileListing.cs
@@ -14,8 +14,8 @@ namespace YARG.Core.IO
 
         public SngFileListing(YARGBinaryReader reader)
         {
-            Length = reader.Read<long>();
-            Position = reader.Read<long>();
+            Length = reader.Read<long>(Endianness.Little);
+            Position = reader.Read<long>(Endianness.Little);
         }
 
         public byte[] LoadAllBytes(string filename, SngMask mask)

--- a/YARG.Core/IO/YARGBinaryReader.cs
+++ b/YARG.Core/IO/YARGBinaryReader.cs
@@ -61,7 +61,7 @@ namespace YARG.Core.IO
             return ReadByte() > 0;
         }
 
-        public TType Read<TType>(Endianness endianness = Endianness.Little)
+        public TType Read<TType>(Endianness endianness)
             where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
             unsafe

--- a/YARG.Core/IO/YARGBinaryReader.cs
+++ b/YARG.Core/IO/YARGBinaryReader.cs
@@ -12,8 +12,8 @@ namespace YARG.Core.IO
 {
     public enum Endianness
     {
-        LittleEndian = 0,
-        BigEndian = 1,
+        Little = 0,
+        Big = 1,
     };
 
     public sealed class YARGBinaryReader
@@ -61,7 +61,7 @@ namespace YARG.Core.IO
             return ReadByte() > 0;
         }
 
-        public TType Read<TType>(Endianness endianness = Endianness.LittleEndian)
+        public TType Read<TType>(Endianness endianness = Endianness.Little)
             where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
             unsafe
@@ -74,7 +74,7 @@ namespace YARG.Core.IO
                 {
                     // If the memory layout of the host system matches the layout of
                     // the value to be parsed from the file, we only require a cast
-                    if ((endianness == Endianness.LittleEndian) == BitConverter.IsLittleEndian)
+                    if ((endianness == Endianness.Little) == BitConverter.IsLittleEndian)
                         return *(TType*) (buf + pos);
 
                     // Reminder: _position moved

--- a/YARG.Core/IO/YARGBinaryReader.cs
+++ b/YARG.Core/IO/YARGBinaryReader.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Xml.Linq;
 using YARG.Core.Extensions;
 
 namespace YARG.Core.IO
@@ -60,90 +61,33 @@ namespace YARG.Core.IO
             return ReadByte() > 0;
         }
 
-        public short ReadInt16(Endianness endianness = Endianness.LittleEndian)
+        public TType Read<TType>(Endianness endianness = Endianness.LittleEndian)
+            where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
-            short value;
-            var span = data.Span.Slice(_position, sizeof(short));
-            if (endianness == Endianness.LittleEndian)
-                value = BinaryPrimitives.ReadInt16LittleEndian(span);
-            else
-                value = BinaryPrimitives.ReadInt16BigEndian(span);
-            _position += sizeof(short);
-            return value;
-        }
+            unsafe
+            {
+                long pos = _position;
+                // Will throw if invalid
+                Move(sizeof(TType));
 
-        public ushort ReadUInt16(Endianness endianness = Endianness.LittleEndian)
-        {
-            ushort value;
-            var span = data.Span.Slice(_position, sizeof(ushort));
-            if (endianness == Endianness.LittleEndian)
-                value = BinaryPrimitives.ReadUInt16LittleEndian(span);
-            else
-                value = BinaryPrimitives.ReadUInt16BigEndian(span);
-            _position += sizeof(ushort);
-            return value;
-        }
+                fixed (byte* buf = data.Span)
+                {
+                    // If the memory layout of the host system matches the layout of
+                    // the value to be parsed from the file, we only require a cast
+                    if ((endianness == Endianness.LittleEndian) == BitConverter.IsLittleEndian)
+                        return *(TType*) (buf + pos);
 
-        public int ReadInt32(Endianness endianness = Endianness.LittleEndian)
-        {
-            int value;
-            var span = data.Span.Slice(_position, sizeof(int));
-            if (endianness == Endianness.LittleEndian)
-                value = BinaryPrimitives.ReadInt32LittleEndian(span);
-            else
-                value = BinaryPrimitives.ReadInt32BigEndian(span);
-            _position += sizeof(int);
-            return value;
-        }
+                    // Reminder: _position moved
+                    pos = _position;
 
-        public uint ReadUInt32(Endianness endianness = Endianness.LittleEndian)
-        {
-            uint value;
-            var span = data.Span.Slice(_position, sizeof(uint));
-            if (endianness == Endianness.LittleEndian)
-                value = BinaryPrimitives.ReadUInt32LittleEndian(span);
-            else
-                value = BinaryPrimitives.ReadUInt32BigEndian(span);
-            _position += sizeof(uint);
-            return value;
-        }
-
-        public long ReadInt64(Endianness endianness = Endianness.LittleEndian)
-        {
-            long value;
-            var span = data.Span.Slice(_position, sizeof(long));
-            if (endianness == Endianness.LittleEndian)
-                value = BinaryPrimitives.ReadInt64LittleEndian(span);
-            else
-                value = BinaryPrimitives.ReadInt64BigEndian(span);
-            _position += sizeof(long);
-            return value;
-        }
-
-        public ulong ReadUInt64(Endianness endianness = Endianness.LittleEndian)
-        {
-            ulong value;
-            var span = data.Span.Slice(_position, sizeof(ulong));
-            if (endianness == Endianness.LittleEndian)
-                value = BinaryPrimitives.ReadUInt64LittleEndian(span);
-            else
-                value = BinaryPrimitives.ReadUInt64BigEndian(span);
-            _position += sizeof(ulong);
-            return value;
-        }
-
-        public float ReadFloat(Endianness endianness = Endianness.LittleEndian)
-        {
-            uint memory = ReadUInt32(endianness);
-            float value = Unsafe.As<uint, float>(ref memory);
-            return value;
-        }
-
-        public double ReadDouble(Endianness endianness = Endianness.LittleEndian)
-        {
-            ulong memory = ReadUInt64(endianness);
-            double value = Unsafe.As<ulong, double>(ref memory);
-            return value;
+                    // Otherwise, we have to flip the bytes
+                    TType value = default;
+                    byte* bytes = (byte*)&value;
+                    for (int i = 0; i < sizeof(TType); ++i)
+                        bytes[i] = buf[--pos];
+                    return value;
+                }
+            }
         }
 
         public bool ReadBytes(Span<byte> bytes)

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -140,10 +140,10 @@ namespace YARG.Core.Song.Cache
                 return;
             }
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {
@@ -166,12 +166,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.Read<int>();
-                int length = reader.Read<int>();
+                int index = reader.Read<int>(Endianness.Little);
+                int length = reader.Read<int>(Endianness.Little);
                 if (invalidSongsInCache.Contains(name))
                 {
                     reader.Move(length);
@@ -201,12 +201,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.Read<int>();
-                int length = reader.Read<int>();
+                int index = reader.Read<int>(Endianness.Little);
+                int length = reader.Read<int>(Endianness.Little);
 
                 if (invalidSongsInCache.Contains(name))
                 {
@@ -234,10 +234,10 @@ namespace YARG.Core.Song.Cache
         private void QuickReadIniGroup_Parallel(YARGBinaryReader reader, List<Task> entryTasks, CategoryCacheStrings strings, ParallelExceptionTracker tracker)
         {
             string directory = reader.ReadLEBString();
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {
@@ -260,14 +260,14 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {
@@ -288,14 +288,14 @@ namespace YARG.Core.Song.Cache
         {
             var dta = QuickReadExtractedCONGroupHeader(reader);
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -140,10 +140,10 @@ namespace YARG.Core.Song.Cache
                 return;
             }
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {
@@ -166,12 +166,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.ReadInt32();
-                int length = reader.ReadInt32();
+                int index = reader.Read<int>();
+                int length = reader.Read<int>();
                 if (invalidSongsInCache.Contains(name))
                 {
                     reader.Move(length);
@@ -201,12 +201,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.ReadInt32();
-                int length = reader.ReadInt32();
+                int index = reader.Read<int>();
+                int length = reader.Read<int>();
 
                 if (invalidSongsInCache.Contains(name))
                 {
@@ -234,10 +234,10 @@ namespace YARG.Core.Song.Cache
         private void QuickReadIniGroup_Parallel(YARGBinaryReader reader, List<Task> entryTasks, CategoryCacheStrings strings, ParallelExceptionTracker tracker)
         {
             string directory = reader.ReadLEBString();
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {
@@ -260,14 +260,14 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {
@@ -288,14 +288,14 @@ namespace YARG.Core.Song.Cache
         {
             var dta = QuickReadExtractedCONGroupHeader(reader);
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 entryTasks.Add(Task.Run(() =>
                 {

--- a/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
@@ -110,10 +110,10 @@ namespace YARG.Core.Song.Cache
                 return;
             }
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count; ++i)
             {
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 ReadIniEntry(directory, group, entryReader, strings);
             }
@@ -125,12 +125,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.ReadInt32();
-                int length = reader.ReadInt32();
+                int index = reader.Read<int>();
+                int length = reader.Read<int>();
                 if (invalidSongsInCache.Contains(name))
                 {
                     reader.Move(length);
@@ -149,12 +149,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.ReadInt32();
-                int length = reader.ReadInt32();
+                int index = reader.Read<int>();
+                int length = reader.Read<int>();
 
                 if (invalidSongsInCache.Contains(name))
                 {
@@ -171,10 +171,10 @@ namespace YARG.Core.Song.Cache
         private void QuickReadIniGroup(YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             string directory = reader.ReadLEBString();
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count; ++i)
             {
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 QuickReadIniEntry(directory, entryReader, strings);
             }
@@ -186,14 +186,14 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 AddEntry(SongMetadata.PackedRBCONFromCache_Quick(group.CONFile, name, upgrades, entryReader, strings));
             }
@@ -204,14 +204,14 @@ namespace YARG.Core.Song.Cache
             var dta = QuickReadExtractedCONGroupHeader(reader);
             // Lack of null check by design
 
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 var entryReader = reader.Slice(length);
                 AddEntry(SongMetadata.UnpackedRBCONFromCache_Quick(dta, name, upgrades, entryReader, strings));
             }

--- a/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
@@ -110,10 +110,10 @@ namespace YARG.Core.Song.Cache
                 return;
             }
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 ReadIniEntry(directory, group, entryReader, strings);
             }
@@ -125,12 +125,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.Read<int>();
-                int length = reader.Read<int>();
+                int index = reader.Read<int>(Endianness.Little);
+                int length = reader.Read<int>(Endianness.Little);
                 if (invalidSongsInCache.Contains(name))
                 {
                     reader.Move(length);
@@ -149,12 +149,12 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
-                int index = reader.Read<int>();
-                int length = reader.Read<int>();
+                int index = reader.Read<int>(Endianness.Little);
+                int length = reader.Read<int>(Endianness.Little);
 
                 if (invalidSongsInCache.Contains(name))
                 {
@@ -171,10 +171,10 @@ namespace YARG.Core.Song.Cache
         private void QuickReadIniGroup(YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             string directory = reader.ReadLEBString();
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 QuickReadIniEntry(directory, entryReader, strings);
             }
@@ -186,14 +186,14 @@ namespace YARG.Core.Song.Cache
             if (group == null)
                 return;
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 AddEntry(SongMetadata.PackedRBCONFromCache_Quick(group.CONFile, name, upgrades, entryReader, strings));
             }
@@ -204,14 +204,14 @@ namespace YARG.Core.Song.Cache
             var dta = QuickReadExtractedCONGroupHeader(reader);
             // Lack of null check by design
 
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
                 string name = reader.ReadLEBString();
                 // index
                 reader.Move(4);
 
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 var entryReader = reader.Slice(length);
                 AddEntry(SongMetadata.UnpackedRBCONFromCache_Quick(dta, name, upgrades, entryReader, strings));
             }

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -13,10 +13,10 @@ namespace YARG.Core.Song.Cache
 
         private static void RunCONTasks(FileStream stream, Action<YARGBinaryReader> func)
         {
-            int count = stream.Read<int>();
+            int count = stream.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
-                int length = stream.Read<int>();
+                int length = stream.Read<int>(Endianness.Little);
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 func(reader);
             }
@@ -24,10 +24,10 @@ namespace YARG.Core.Song.Cache
 
         private static void RunEntryTasks(FileStream stream, CategoryCacheStrings strings, Action<YARGBinaryReader, CategoryCacheStrings> func)
         {
-            int count = stream.Read<int>();
+            int count = stream.Read<int>(Endianness.Little);
             for (int i = 0; i < count; ++i)
             {
-                int length = stream.Read<int>();
+                int length = stream.Read<int>(Endianness.Little);
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 func(reader, strings);
             }
@@ -35,10 +35,10 @@ namespace YARG.Core.Song.Cache
 
         private static void AddParallelCONTasks(FileStream stream, ref List<Task> conTasks, Action<YARGBinaryReader> func, ParallelExceptionTracker tracker)
         {
-            int count = stream.Read<int>();
+            int count = stream.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = stream.Read<int>();
+                int length = stream.Read<int>(Endianness.Little);
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 conTasks.Add(Task.Run(() =>
                 {
@@ -56,10 +56,10 @@ namespace YARG.Core.Song.Cache
 
         private static void AddParallelEntryTasks(FileStream stream, ref List<Task> entryTasks, CategoryCacheStrings strings, Action<YARGBinaryReader, List<Task>, CategoryCacheStrings, ParallelExceptionTracker> func, ParallelExceptionTracker tracker)
         {
-            int count = stream.Read<int>();
+            int count = stream.Read<int>(Endianness.Little);
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = stream.Read<int>();
+                int length = stream.Read<int>(Endianness.Little);
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 entryTasks.Add(Task.Run(() => {
                     List<Task> tasks = new();
@@ -95,7 +95,7 @@ namespace YARG.Core.Song.Cache
             }
 
             FileStream fs = new(cacheLocation, FileMode.Open, FileAccess.Read);
-            if (fs.Read<int>() != CACHE_VERSION)
+            if (fs.Read<int>(Endianness.Little) != CACHE_VERSION)
             {
                 YargTrace.DebugInfo($"Cache outdated");
                 fs.Dispose();
@@ -171,10 +171,10 @@ namespace YARG.Core.Song.Cache
                 {
                     AddParallelEntryTasks(stream, ref entryTasks, strings, QuickReadIniGroup_Parallel, tracker);
 
-                    int count = stream.Read<int>();
+                    int count = stream.Read<int>(Endianness.Little);
                     for (int i = 0; i < count; ++i)
                     {
-                        int length = stream.Read<int>();
+                        int length = stream.Read<int>(Endianness.Little);
                         stream.Position += length;
                     }
 
@@ -197,10 +197,10 @@ namespace YARG.Core.Song.Cache
                 RunEntryTasks(stream, strings, QuickReadIniGroup);
                 YargTrace.DebugInfo($"Ini Entries quick read: {_progress.Count}");
 
-                int count = stream.Read<int>();
+                int count = stream.Read<int>(Endianness.Little);
                 for (int i = 0; i < count; ++i)
                 {
-                    int length = stream.Read<int>();
+                    int length = stream.Read<int>(Endianness.Little);
                     stream.Position += length;
                 }
 
@@ -273,8 +273,8 @@ namespace YARG.Core.Song.Cache
         private void ReadUpdateDirectory(YARGBinaryReader reader)
         {
             string directory = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
-            int count = reader.Read<int>();
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
+            int count = reader.Read<int>(Endianness.Little);
 
             // Functions as a "check base directory" call
             if (GetBaseIniGroup(directory) != null)
@@ -298,8 +298,8 @@ namespace YARG.Core.Song.Cache
         private void ReadUpgradeDirectory(YARGBinaryReader reader)
         {
             string directory = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
-            int count = reader.Read<int>();
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
+            int count = reader.Read<int>(Endianness.Little);
 
             // Functions as a "check base directory" call
             if (GetBaseIniGroup(directory) != null)
@@ -316,7 +316,7 @@ namespace YARG.Core.Song.Cache
                         for (int i = 0; i < count; i++)
                         {
                             string name = reader.ReadLEBString();
-                            var lastWrite = DateTime.FromBinary(reader.Read<long>());
+                            var lastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
                             if (!group.upgrades.TryGetValue(name, out var upgrade) || upgrade!.LastWrite != lastWrite)
                                 AddInvalidSong(name);
                         }
@@ -335,9 +335,9 @@ namespace YARG.Core.Song.Cache
         private void ReadUpgradeCON(YARGBinaryReader cacheReader)
         {
             string filename = cacheReader.ReadLEBString();
-            var conLastWrite = DateTime.FromBinary(cacheReader.Read<long>());
-            var dtaLastWrite = DateTime.FromBinary(cacheReader.Read<long>());
-            int count = cacheReader.Read<int>();
+            var conLastWrite = DateTime.FromBinary(cacheReader.Read<long>(Endianness.Little));
+            var dtaLastWrite = DateTime.FromBinary(cacheReader.Read<long>(Endianness.Little));
+            int count = cacheReader.Read<int>(Endianness.Little);
 
             // Functions as a "check base directory" call
             if (GetBaseIniGroup(filename) != null && CreateCONGroup(filename, out var group))
@@ -352,7 +352,7 @@ namespace YARG.Core.Song.Cache
                         for (int i = 0; i < count; i++)
                         {
                             string name = cacheReader.ReadLEBString();
-                            var lastWrite = DateTime.FromBinary(cacheReader.Read<long>());
+                            var lastWrite = DateTime.FromBinary(cacheReader.Read<long>(Endianness.Little));
                             if (group.Upgrades[name].LastWrite != lastWrite)
                                 AddInvalidSong(name);
                         }
@@ -378,7 +378,7 @@ namespace YARG.Core.Song.Cache
                 return null;
             }
 
-            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
             if (!FindCONGroup(filename, out var group))
             {
                 FileInfo info = new(filename);
@@ -432,7 +432,7 @@ namespace YARG.Core.Song.Cache
             MarkDirectory(directory);
             extractedConGroups.Add(directory, group!);
 
-            if (dtaInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>()))
+            if (dtaInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>(Endianness.Little)))
             {
                 YargTrace.DebugInfo($"EXCON dta updated, needs rescan");
                 return null;
@@ -455,8 +455,8 @@ namespace YARG.Core.Song.Cache
         private void QuickReadUpgradeDirectory(YARGBinaryReader reader)
         {
             string directory = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
-            int count = reader.Read<int>();
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
+            int count = reader.Read<int>(Endianness.Little);
 
             UpgradeGroup group = new(dtaLastWrite);
             upgradeGroups.Add(directory, group);
@@ -464,7 +464,7 @@ namespace YARG.Core.Song.Cache
             for (int i = 0; i < count; i++)
             {
                 string name = reader.ReadLEBString();
-                var lastWrite = DateTime.FromBinary(reader.Read<long>());
+                var lastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
                 string filename = Path.Combine(directory, $"{name}_plus.mid");
 
                 IRBProUpgrade upgrade = new UnpackedRBProUpgrade(filename, lastWrite);
@@ -477,7 +477,7 @@ namespace YARG.Core.Song.Cache
         {
             string filename = reader.ReadLEBString();
             reader.Move(2 * SongMetadata.SIZEOF_DATETIME);
-            int count = reader.Read<int>();
+            int count = reader.Read<int>(Endianness.Little);
 
             if (CreateCONGroup(filename, out var group))
             {
@@ -486,7 +486,7 @@ namespace YARG.Core.Song.Cache
                 for (int i = 0; i < count; i++)
                 {
                     string name = reader.ReadLEBString();
-                    var lastWrite = DateTime.FromBinary(reader.Read<long>());
+                    var lastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
                     var listing = group!.CONFile.TryGetListing($"songs_upgrades/{name}_plus.mid");
 
                     IRBProUpgrade upgrade = new PackedRBProUpgrade(listing, lastWrite);
@@ -498,7 +498,7 @@ namespace YARG.Core.Song.Cache
                 for (int i = 0; i < count; i++)
                 {
                     string name = reader.ReadLEBString();
-                    var lastWrite = DateTime.FromBinary(reader.Read<long>());
+                    var lastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
 
                     IRBProUpgrade upgrade = new PackedRBProUpgrade(null, lastWrite);
                     AddUpgrade(name, null, upgrade);
@@ -509,7 +509,7 @@ namespace YARG.Core.Song.Cache
         private PackedCONGroup? QuickReadCONGroupHeader(YARGBinaryReader reader)
         {
             string filename = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
             if (!FindCONGroup(filename, out var group))
             {
                 if (!CreateCONGroup(filename, out group))
@@ -532,7 +532,7 @@ namespace YARG.Core.Song.Cache
         {
             string directory = reader.ReadLEBString();
             FileInfo dtaInfo = new(Path.Combine(directory, "songs.dta"));
-            if (!dtaInfo.Exists || dtaInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>()))
+            if (!dtaInfo.Exists || dtaInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>(Endianness.Little)))
             {
                 YargTrace.DebugInfo($"EXCON dta missing");
                 return null;

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -13,10 +13,10 @@ namespace YARG.Core.Song.Cache
 
         private static void RunCONTasks(FileStream stream, Action<YARGBinaryReader> func)
         {
-            int count = stream.ReadInt32LE();
+            int count = stream.Read<int>();
             for (int i = 0; i < count; ++i)
             {
-                int length = stream.ReadInt32LE();
+                int length = stream.Read<int>();
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 func(reader);
             }
@@ -24,10 +24,10 @@ namespace YARG.Core.Song.Cache
 
         private static void RunEntryTasks(FileStream stream, CategoryCacheStrings strings, Action<YARGBinaryReader, CategoryCacheStrings> func)
         {
-            int count = stream.ReadInt32LE();
+            int count = stream.Read<int>();
             for (int i = 0; i < count; ++i)
             {
-                int length = stream.ReadInt32LE();
+                int length = stream.Read<int>();
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 func(reader, strings);
             }
@@ -35,10 +35,10 @@ namespace YARG.Core.Song.Cache
 
         private static void AddParallelCONTasks(FileStream stream, ref List<Task> conTasks, Action<YARGBinaryReader> func, ParallelExceptionTracker tracker)
         {
-            int count = stream.ReadInt32LE();
+            int count = stream.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = stream.ReadInt32LE();
+                int length = stream.Read<int>();
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 conTasks.Add(Task.Run(() =>
                 {
@@ -56,10 +56,10 @@ namespace YARG.Core.Song.Cache
 
         private static void AddParallelEntryTasks(FileStream stream, ref List<Task> entryTasks, CategoryCacheStrings strings, Action<YARGBinaryReader, List<Task>, CategoryCacheStrings, ParallelExceptionTracker> func, ParallelExceptionTracker tracker)
         {
-            int count = stream.ReadInt32LE();
+            int count = stream.Read<int>();
             for (int i = 0; i < count && !tracker.IsSet(); ++i)
             {
-                int length = stream.ReadInt32LE();
+                int length = stream.Read<int>();
                 YARGBinaryReader reader = new(stream.ReadBytes(length));
                 entryTasks.Add(Task.Run(() => {
                     List<Task> tasks = new();
@@ -95,7 +95,7 @@ namespace YARG.Core.Song.Cache
             }
 
             FileStream fs = new(cacheLocation, FileMode.Open, FileAccess.Read);
-            if (fs.ReadInt32LE() != CACHE_VERSION)
+            if (fs.Read<int>() != CACHE_VERSION)
             {
                 YargTrace.DebugInfo($"Cache outdated");
                 fs.Dispose();
@@ -171,10 +171,10 @@ namespace YARG.Core.Song.Cache
                 {
                     AddParallelEntryTasks(stream, ref entryTasks, strings, QuickReadIniGroup_Parallel, tracker);
 
-                    int count = stream.ReadInt32LE();
+                    int count = stream.Read<int>();
                     for (int i = 0; i < count; ++i)
                     {
-                        int length = stream.ReadInt32LE();
+                        int length = stream.Read<int>();
                         stream.Position += length;
                     }
 
@@ -197,10 +197,10 @@ namespace YARG.Core.Song.Cache
                 RunEntryTasks(stream, strings, QuickReadIniGroup);
                 YargTrace.DebugInfo($"Ini Entries quick read: {_progress.Count}");
 
-                int count = stream.ReadInt32LE();
+                int count = stream.Read<int>();
                 for (int i = 0; i < count; ++i)
                 {
-                    int length = stream.ReadInt32LE();
+                    int length = stream.Read<int>();
                     stream.Position += length;
                 }
 
@@ -273,8 +273,8 @@ namespace YARG.Core.Song.Cache
         private void ReadUpdateDirectory(YARGBinaryReader reader)
         {
             string directory = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.ReadInt64());
-            int count = reader.ReadInt32();
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
+            int count = reader.Read<int>();
 
             // Functions as a "check base directory" call
             if (GetBaseIniGroup(directory) != null)
@@ -298,8 +298,8 @@ namespace YARG.Core.Song.Cache
         private void ReadUpgradeDirectory(YARGBinaryReader reader)
         {
             string directory = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.ReadInt64());
-            int count = reader.ReadInt32();
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
+            int count = reader.Read<int>();
 
             // Functions as a "check base directory" call
             if (GetBaseIniGroup(directory) != null)
@@ -316,7 +316,7 @@ namespace YARG.Core.Song.Cache
                         for (int i = 0; i < count; i++)
                         {
                             string name = reader.ReadLEBString();
-                            var lastWrite = DateTime.FromBinary(reader.ReadInt64());
+                            var lastWrite = DateTime.FromBinary(reader.Read<long>());
                             if (!group.upgrades.TryGetValue(name, out var upgrade) || upgrade!.LastWrite != lastWrite)
                                 AddInvalidSong(name);
                         }
@@ -335,9 +335,9 @@ namespace YARG.Core.Song.Cache
         private void ReadUpgradeCON(YARGBinaryReader cacheReader)
         {
             string filename = cacheReader.ReadLEBString();
-            var conLastWrite = DateTime.FromBinary(cacheReader.ReadInt64());
-            var dtaLastWrite = DateTime.FromBinary(cacheReader.ReadInt64());
-            int count = cacheReader.ReadInt32();
+            var conLastWrite = DateTime.FromBinary(cacheReader.Read<long>());
+            var dtaLastWrite = DateTime.FromBinary(cacheReader.Read<long>());
+            int count = cacheReader.Read<int>();
 
             // Functions as a "check base directory" call
             if (GetBaseIniGroup(filename) != null && CreateCONGroup(filename, out var group))
@@ -352,7 +352,7 @@ namespace YARG.Core.Song.Cache
                         for (int i = 0; i < count; i++)
                         {
                             string name = cacheReader.ReadLEBString();
-                            var lastWrite = DateTime.FromBinary(cacheReader.ReadInt64());
+                            var lastWrite = DateTime.FromBinary(cacheReader.Read<long>());
                             if (group.Upgrades[name].LastWrite != lastWrite)
                                 AddInvalidSong(name);
                         }
@@ -378,7 +378,7 @@ namespace YARG.Core.Song.Cache
                 return null;
             }
 
-            var dtaLastWrite = DateTime.FromBinary(reader.ReadInt64());
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
             if (!FindCONGroup(filename, out var group))
             {
                 FileInfo info = new(filename);
@@ -432,7 +432,7 @@ namespace YARG.Core.Song.Cache
             MarkDirectory(directory);
             extractedConGroups.Add(directory, group!);
 
-            if (dtaInfo.LastWriteTime != DateTime.FromBinary(reader.ReadInt64()))
+            if (dtaInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>()))
             {
                 YargTrace.DebugInfo($"EXCON dta updated, needs rescan");
                 return null;
@@ -455,8 +455,8 @@ namespace YARG.Core.Song.Cache
         private void QuickReadUpgradeDirectory(YARGBinaryReader reader)
         {
             string directory = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.ReadInt64());
-            int count = reader.ReadInt32();
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
+            int count = reader.Read<int>();
 
             UpgradeGroup group = new(dtaLastWrite);
             upgradeGroups.Add(directory, group);
@@ -464,7 +464,7 @@ namespace YARG.Core.Song.Cache
             for (int i = 0; i < count; i++)
             {
                 string name = reader.ReadLEBString();
-                var lastWrite = DateTime.FromBinary(reader.ReadInt64());
+                var lastWrite = DateTime.FromBinary(reader.Read<long>());
                 string filename = Path.Combine(directory, $"{name}_plus.mid");
 
                 IRBProUpgrade upgrade = new UnpackedRBProUpgrade(filename, lastWrite);
@@ -477,7 +477,7 @@ namespace YARG.Core.Song.Cache
         {
             string filename = reader.ReadLEBString();
             reader.Move(2 * SongMetadata.SIZEOF_DATETIME);
-            int count = reader.ReadInt32();
+            int count = reader.Read<int>();
 
             if (CreateCONGroup(filename, out var group))
             {
@@ -486,7 +486,7 @@ namespace YARG.Core.Song.Cache
                 for (int i = 0; i < count; i++)
                 {
                     string name = reader.ReadLEBString();
-                    var lastWrite = DateTime.FromBinary(reader.ReadInt64());
+                    var lastWrite = DateTime.FromBinary(reader.Read<long>());
                     var listing = group!.CONFile.TryGetListing($"songs_upgrades/{name}_plus.mid");
 
                     IRBProUpgrade upgrade = new PackedRBProUpgrade(listing, lastWrite);
@@ -498,7 +498,7 @@ namespace YARG.Core.Song.Cache
                 for (int i = 0; i < count; i++)
                 {
                     string name = reader.ReadLEBString();
-                    var lastWrite = DateTime.FromBinary(reader.ReadInt64());
+                    var lastWrite = DateTime.FromBinary(reader.Read<long>());
 
                     IRBProUpgrade upgrade = new PackedRBProUpgrade(null, lastWrite);
                     AddUpgrade(name, null, upgrade);
@@ -509,7 +509,7 @@ namespace YARG.Core.Song.Cache
         private PackedCONGroup? QuickReadCONGroupHeader(YARGBinaryReader reader)
         {
             string filename = reader.ReadLEBString();
-            var dtaLastWrite = DateTime.FromBinary(reader.ReadInt64());
+            var dtaLastWrite = DateTime.FromBinary(reader.Read<long>());
             if (!FindCONGroup(filename, out var group))
             {
                 if (!CreateCONGroup(filename, out group))
@@ -532,7 +532,7 @@ namespace YARG.Core.Song.Cache
         {
             string directory = reader.ReadLEBString();
             FileInfo dtaInfo = new(Path.Combine(directory, "songs.dta"));
-            if (!dtaInfo.Exists || dtaInfo.LastWriteTime != DateTime.FromBinary(reader.ReadInt64()))
+            if (!dtaInfo.Exists || dtaInfo.LastWriteTime != DateTime.FromBinary(reader.Read<long>()))
             {
                 YargTrace.DebugInfo($"EXCON dta missing");
                 return null;

--- a/YARG.Core/Song/Cache/CacheNodes.cs
+++ b/YARG.Core/Song/Cache/CacheNodes.cs
@@ -37,7 +37,7 @@ namespace YARG.Core.Song.Cache
                 var tasks = new Task[NUM_CATEGORIES];
                 for (int i = 0; i < NUM_CATEGORIES; ++i)
                 {
-                    int length = stream.ReadInt32LE();
+                    int length = stream.Read<int>();
                     byte[] section = stream.ReadBytes(length);
 
                     int strIndex = i;
@@ -49,7 +49,7 @@ namespace YARG.Core.Song.Cache
             {
                 for (int i = 0; i < NUM_CATEGORIES; ++i)
                 {
-                    int length = stream.ReadInt32LE();
+                    int length = stream.Read<int>();
                     GetArray(i) = ReadStrings(stream.ReadBytes(length));
                 }
             }
@@ -57,7 +57,7 @@ namespace YARG.Core.Song.Cache
             static string[] ReadStrings(byte[] section)
             {
                 YARGBinaryReader reader = new(section);
-                int count = reader.ReadInt32();
+                int count = reader.Read<int>();
                 string[] strings = new string[count];
                 for (int i = 0; i < count; ++i)
                     strings[i] = reader.ReadLEBString();

--- a/YARG.Core/Song/Cache/CacheNodes.cs
+++ b/YARG.Core/Song/Cache/CacheNodes.cs
@@ -37,7 +37,7 @@ namespace YARG.Core.Song.Cache
                 var tasks = new Task[NUM_CATEGORIES];
                 for (int i = 0; i < NUM_CATEGORIES; ++i)
                 {
-                    int length = stream.Read<int>();
+                    int length = stream.Read<int>(Endianness.Little);
                     byte[] section = stream.ReadBytes(length);
 
                     int strIndex = i;
@@ -49,7 +49,7 @@ namespace YARG.Core.Song.Cache
             {
                 for (int i = 0; i < NUM_CATEGORIES; ++i)
                 {
-                    int length = stream.Read<int>();
+                    int length = stream.Read<int>(Endianness.Little);
                     GetArray(i) = ReadStrings(stream.ReadBytes(length));
                 }
             }
@@ -57,7 +57,7 @@ namespace YARG.Core.Song.Cache
             static string[] ReadStrings(byte[] section)
             {
                 YARGBinaryReader reader = new(section);
-                int count = reader.Read<int>();
+                int count = reader.Read<int>(Endianness.Little);
                 string[] strings = new string[count];
                 for (int i = 0; i < count; ++i)
                     strings[i] = reader.ReadLEBString();

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
@@ -227,13 +227,13 @@ namespace YARG.Core.Song
                 return null;
 
             var chart = IIniMetadata.CHART_FILE_TYPES[chartTypeIndex];
-            var lastWrite = DateTime.FromBinary(reader.ReadInt64());
+            var lastWrite = DateTime.FromBinary(reader.Read<long>());
 
             AbridgedFileInfo chartInfo = new(Path.Combine(directory, chart.File), lastWrite);
             AbridgedFileInfo? iniInfo = null;
             if (reader.ReadBoolean())
             {
-                lastWrite = DateTime.FromBinary(reader.ReadInt64());
+                lastWrite = DateTime.FromBinary(reader.Read<long>());
                 iniInfo = new(Path.Combine(directory, "song.ini"), lastWrite);
             }
 

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
@@ -227,13 +227,13 @@ namespace YARG.Core.Song
                 return null;
 
             var chart = IIniMetadata.CHART_FILE_TYPES[chartTypeIndex];
-            var lastWrite = DateTime.FromBinary(reader.Read<long>());
+            var lastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
 
             AbridgedFileInfo chartInfo = new(Path.Combine(directory, chart.File), lastWrite);
             AbridgedFileInfo? iniInfo = null;
             if (reader.ReadBoolean())
             {
-                lastWrite = DateTime.FromBinary(reader.Read<long>());
+                lastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
                 iniInfo = new(Path.Combine(directory, "song.ini"), lastWrite);
             }
 

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
@@ -163,7 +163,7 @@ namespace YARG.Core.Song
         public static SongMetadata? SngFromCache(string baseDirectory, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             // Implement proper versioning in the future 
-            uint version = reader.ReadUInt32();
+            uint version = reader.Read<uint>();
 
             string sngPath = Path.Combine(baseDirectory, reader.ReadLEBString());
             var sngInfo = AbridgedFileInfo.TryParseInfo(sngPath, reader);
@@ -189,10 +189,10 @@ namespace YARG.Core.Song
         public static SongMetadata? SngFromCache_Quick(string baseDirectory, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             // Implement proper versioning in the future 
-            uint version = reader.ReadUInt32();
+            uint version = reader.Read<uint>();
 
             string sngPath = Path.Combine(baseDirectory, reader.ReadLEBString());
-            AbridgedFileInfo sngInfo = new(sngPath, DateTime.FromBinary(reader.ReadInt64()));
+            AbridgedFileInfo sngInfo = new(sngPath, DateTime.FromBinary(reader.Read<long>()));
 
             byte chartTypeIndex = reader.ReadByte();
             if (chartTypeIndex >= IIniMetadata.CHART_FILE_TYPES.Length)

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
@@ -163,7 +163,7 @@ namespace YARG.Core.Song
         public static SongMetadata? SngFromCache(string baseDirectory, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             // Implement proper versioning in the future 
-            uint version = reader.Read<uint>();
+            uint version = reader.Read<uint>(Endianness.Little);
 
             string sngPath = Path.Combine(baseDirectory, reader.ReadLEBString());
             var sngInfo = AbridgedFileInfo.TryParseInfo(sngPath, reader);
@@ -189,10 +189,10 @@ namespace YARG.Core.Song
         public static SongMetadata? SngFromCache_Quick(string baseDirectory, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             // Implement proper versioning in the future 
-            uint version = reader.Read<uint>();
+            uint version = reader.Read<uint>(Endianness.Little);
 
             string sngPath = Path.Combine(baseDirectory, reader.ReadLEBString());
-            AbridgedFileInfo sngInfo = new(sngPath, DateTime.FromBinary(reader.Read<long>()));
+            AbridgedFileInfo sngInfo = new(sngPath, DateTime.FromBinary(reader.Read<long>(Endianness.Little)));
 
             byte chartTypeIndex = reader.ReadByte();
             if (chartTypeIndex >= IIniMetadata.CHART_FILE_TYPES.Length)

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
@@ -183,7 +183,7 @@ namespace YARG.Core.Song
                 using var stream = _metadata.GetMoggStream();
                 if (stream != null)
                 {
-                    int version = stream.ReadInt32LE();
+                    int version = stream.Read<int>();
                     return version == 0x0A || version == 0xf0;
                 }
                 else if (moggListing != null)
@@ -228,7 +228,7 @@ namespace YARG.Core.Song
         public static SongMetadata? PackedRBCONFromCache(CONFile file, string nodeName, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             var midiListing = file.TryGetListing(reader.ReadLEBString());
-            var midiLastWrite = DateTime.FromBinary(reader.ReadInt64());
+            var midiLastWrite = DateTime.FromBinary(reader.Read<long>());
             if (midiListing == null || midiListing.lastWrite != midiLastWrite)
                 return null;
 
@@ -237,7 +237,7 @@ namespace YARG.Core.Song
             if (reader.ReadBoolean())
             {
                 moggListing = file.TryGetListing(reader.ReadLEBString());
-                if (moggListing == null || moggListing.lastWrite != DateTime.FromBinary(reader.ReadInt64()))
+                if (moggListing == null || moggListing.lastWrite != DateTime.FromBinary(reader.Read<long>()))
                     return null;
             }
             else
@@ -264,7 +264,7 @@ namespace YARG.Core.Song
         public static SongMetadata PackedRBCONFromCache_Quick(CONFile file, string nodeName, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             var midiListing = file.TryGetListing(reader.ReadLEBString());
-            var midiLastWrite = DateTime.FromBinary(reader.ReadInt64());
+            var midiLastWrite = DateTime.FromBinary(reader.Read<long>());
 
             CONFileListing? moggListing = null;
             AbridgedFileInfo? moggInfo = null;

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
@@ -183,7 +183,7 @@ namespace YARG.Core.Song
                 using var stream = _metadata.GetMoggStream();
                 if (stream != null)
                 {
-                    int version = stream.Read<int>();
+                    int version = stream.Read<int>(Endianness.Little);
                     return version == 0x0A || version == 0xf0;
                 }
                 else if (moggListing != null)
@@ -228,7 +228,7 @@ namespace YARG.Core.Song
         public static SongMetadata? PackedRBCONFromCache(CONFile file, string nodeName, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             var midiListing = file.TryGetListing(reader.ReadLEBString());
-            var midiLastWrite = DateTime.FromBinary(reader.Read<long>());
+            var midiLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
             if (midiListing == null || midiListing.lastWrite != midiLastWrite)
                 return null;
 
@@ -237,7 +237,7 @@ namespace YARG.Core.Song
             if (reader.ReadBoolean())
             {
                 moggListing = file.TryGetListing(reader.ReadLEBString());
-                if (moggListing == null || moggListing.lastWrite != DateTime.FromBinary(reader.Read<long>()))
+                if (moggListing == null || moggListing.lastWrite != DateTime.FromBinary(reader.Read<long>(Endianness.Little)))
                     return null;
             }
             else
@@ -264,7 +264,7 @@ namespace YARG.Core.Song
         public static SongMetadata PackedRBCONFromCache_Quick(CONFile file, string nodeName, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             var midiListing = file.TryGetListing(reader.ReadLEBString());
-            var midiLastWrite = DateTime.FromBinary(reader.Read<long>());
+            var midiLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
 
             CONFileListing? moggListing = null;
             AbridgedFileInfo? moggInfo = null;

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -69,16 +69,16 @@ namespace YARG.Core.Song
             {
                 RBDifficulties = new(reader);
                 Directory = reader.ReadLEBString();
-                AnimTempo = reader.Read<uint>();
+                AnimTempo = reader.Read<uint>(Endianness.Little);
                 SongID = reader.ReadLEBString();
                 VocalPercussionBank = reader.ReadLEBString();
-                VocalSongScrollSpeed = reader.Read<uint>();
-                SongRating = reader.Read<uint>();
+                VocalSongScrollSpeed = reader.Read<uint>(Endianness.Little);
+                SongRating = reader.Read<uint>(Endianness.Little);
                 VocalGender = reader.ReadBoolean();
-                VocalTonicNote = reader.Read<uint>();
+                VocalTonicNote = reader.Read<uint>(Endianness.Little);
                 SongTonality = reader.ReadBoolean();
-                TuningOffsetCents = reader.Read<int>();
-                VenueVersion = reader.Read<uint>();
+                TuningOffsetCents = reader.Read<int>(Endianness.Little);
+                VenueVersion = reader.Read<uint>(Endianness.Little);
 
                 RealGuitarTuning = ReadIntArray(reader);
                 RealBassTuning = ReadIntArray(reader);
@@ -137,25 +137,25 @@ namespace YARG.Core.Song
 
             private static int[] ReadIntArray(YARGBinaryReader reader)
             {
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 if (length == 0)
                     return Array.Empty<int>();
 
                 int[] values = new int[length];
                 for (int i = 0; i < length; ++i)
-                    values[i] = reader.Read<int>();
+                    values[i] = reader.Read<int>(Endianness.Little);
                 return values;
             }
 
             private static float[] ReadFloatArray(YARGBinaryReader reader)
             {
-                int length = reader.Read<int>();
+                int length = reader.Read<int>(Endianness.Little);
                 if (length == 0)
                     return Array.Empty<float>();
 
                 float[] values = new float[length];
                 for (int i = 0; i < length; ++i)
-                    values[i] = reader.Read<float>();
+                    values[i] = reader.Read<float>(Endianness.Little);
                 return values;
             }
 

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -69,16 +69,16 @@ namespace YARG.Core.Song
             {
                 RBDifficulties = new(reader);
                 Directory = reader.ReadLEBString();
-                AnimTempo = reader.ReadUInt32();
+                AnimTempo = reader.Read<uint>();
                 SongID = reader.ReadLEBString();
                 VocalPercussionBank = reader.ReadLEBString();
-                VocalSongScrollSpeed = reader.ReadUInt32();
-                SongRating = reader.ReadUInt32();
+                VocalSongScrollSpeed = reader.Read<uint>();
+                SongRating = reader.Read<uint>();
                 VocalGender = reader.ReadBoolean();
-                VocalTonicNote = reader.ReadUInt32();
+                VocalTonicNote = reader.Read<uint>();
                 SongTonality = reader.ReadBoolean();
-                TuningOffsetCents = reader.ReadInt32();
-                VenueVersion = reader.ReadUInt32();
+                TuningOffsetCents = reader.Read<int>();
+                VenueVersion = reader.Read<uint>();
 
                 RealGuitarTuning = ReadIntArray(reader);
                 RealBassTuning = ReadIntArray(reader);
@@ -137,25 +137,25 @@ namespace YARG.Core.Song
 
             private static int[] ReadIntArray(YARGBinaryReader reader)
             {
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 if (length == 0)
                     return Array.Empty<int>();
 
                 int[] values = new int[length];
                 for (int i = 0; i < length; ++i)
-                    values[i] = reader.ReadInt32();
+                    values[i] = reader.Read<int>();
                 return values;
             }
 
             private static float[] ReadFloatArray(YARGBinaryReader reader)
             {
-                int length = reader.ReadInt32();
+                int length = reader.Read<int>();
                 if (length == 0)
                     return Array.Empty<float>();
 
                 float[] values = new float[length];
                 for (int i = 0; i < length; ++i)
-                    values[i] = reader.ReadFloat();
+                    values[i] = reader.Read<float>();
                 return values;
             }
 
@@ -396,7 +396,7 @@ namespace YARG.Core.Song
                     case "name": _name = reader.ExtractText(); break;
                     case "artist": _artist = reader.ExtractText(); break;
                     case "master": _isMaster = reader.ExtractBoolean(); break;
-                    case "context": /*Context = reader.ReadUInt32();*/ break;
+                    case "context": /*Context = reader.Read<uint>();*/ break;
                     case "song": SongLoop(rbConMetadata, result, reader); break;
                     case "song_vocals": while (reader.StartNode()) reader.EndNode(); break;
                     case "song_scroll_speed": rbConMetadata.VocalSongScrollSpeed = reader.ExtractUInt32(); break;
@@ -423,7 +423,7 @@ namespace YARG.Core.Song
                     case "genre": _genre = reader.ExtractText(); break;
                     case "decade": /*Decade = reader.ExtractText();*/ break;
                     case "vocal_gender": rbConMetadata.VocalGender = reader.ExtractText() == "male"; break;
-                    case "format": /*Format = reader.ReadUInt32();*/ break;
+                    case "format": /*Format = reader.Read<uint>();*/ break;
                     case "version": rbConMetadata.VenueVersion = reader.ExtractUInt32(); break;
                     case "fake": /*IsFake = reader.ExtractText();*/ break;
                     case "downloaded": /*Downloaded = reader.ExtractText();*/ break;
@@ -451,14 +451,14 @@ namespace YARG.Core.Song
                         }
                     case "song_id": rbConMetadata.SongID = reader.ExtractText(); break;
                     case "rating": rbConMetadata.SongRating = reader.ExtractUInt32(); break;
-                    case "short_version": /*ShortVersion = reader.ReadUInt32();*/ break;
+                    case "short_version": /*ShortVersion = reader.Read<uint>();*/ break;
                     case "album_art": rbConMetadata.HasAlbumArt = reader.ExtractBoolean(); break;
                     case "year_released":
                     case "year_recorded": YearAsNumber = reader.ExtractInt32(); break;
                     case "album_name": _album = reader.ExtractText(); break;
                     case "album_track_number": _albumTrack = reader.ExtractUInt16(); break;
                     case "pack_name": _playlist = reader.ExtractText(); break;
-                    case "base_points": /*BasePoints = reader.ReadUInt32();*/ break;
+                    case "base_points": /*BasePoints = reader.Read<uint>();*/ break;
                     case "band_fail_cue": /*BandFailCue = reader.ExtractText();*/ break;
                     case "drum_bank": rbConMetadata.DrumBank = reader.ExtractText(); break;
                     case "song_length": _songLength = reader.ExtractUInt64(); break;
@@ -582,7 +582,7 @@ namespace YARG.Core.Song
                     case "name": result.location = reader.ExtractText(); break;
                     case "tracks": TracksLoop(rbConMetadata, reader); break;
                     case "crowd_channels": rbConMetadata.CrowdIndices = reader.ExtractList_Int().ToArray(); break;
-                    //case "vocal_parts": rbConMetadata.VocalParts = reader.ReadUInt16(); break;
+                    //case "vocal_parts": rbConMetadata.VocalParts = reader.Read<ushort>(); break;
                     case "pans":
                         if (reader.StartNode())
                         {

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
@@ -133,7 +133,7 @@ namespace YARG.Core.Song
                 if (stream == null)
                     return false;
 
-                int version = stream.Read<int>();
+                int version = stream.Read<int>(Endianness.Little);
                 return version == 0x0A || version == 0xf0;
             }
         }

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
@@ -133,7 +133,7 @@ namespace YARG.Core.Song
                 if (stream == null)
                     return false;
 
-                int version = stream.ReadInt32LE();
+                int version = stream.Read<int>();
                 return version == 0x0A || version == 0xf0;
             }
         }

--- a/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
@@ -10,38 +10,38 @@ namespace YARG.Core.Song
     {
         public SongMetadata(YARGBinaryReader reader, CategoryCacheStrings strings)
         {
-            _name.Str = strings.titles[reader.Read<int>()];
-            _artist.Str = strings.artists[reader.Read<int>()];
-            _album.Str = strings.albums[reader.Read<int>()];
-            _genre.Str = strings.genres[reader.Read<int>()];
-            Year = strings.years[reader.Read<int>()];
-            _charter.Str = strings.charters[reader.Read<int>()];
-            _playlist.Str = strings.playlists[reader.Read<int>()];
-            _source.Str = strings.sources[reader.Read<int>()];
+            _name.Str = strings.titles[reader.Read<int>(Endianness.Little)];
+            _artist.Str = strings.artists[reader.Read<int>(Endianness.Little)];
+            _album.Str = strings.albums[reader.Read<int>(Endianness.Little)];
+            _genre.Str = strings.genres[reader.Read<int>(Endianness.Little)];
+            Year = strings.years[reader.Read<int>(Endianness.Little)];
+            _charter.Str = strings.charters[reader.Read<int>(Endianness.Little)];
+            _playlist.Str = strings.playlists[reader.Read<int>(Endianness.Little)];
+            _source.Str = strings.sources[reader.Read<int>(Endianness.Little)];
 
             _isMaster = reader.ReadBoolean();
 
-            _albumTrack = reader.Read<int>();
-            _playlistTrack = reader.Read<int>();
+            _albumTrack = reader.Read<int>(Endianness.Little);
+            _playlistTrack = reader.Read<int>(Endianness.Little);
 
-            _songLength = reader.Read<ulong>();
-            _songOffset = reader.Read<long>();
+            _songLength = reader.Read<ulong>(Endianness.Little);
+            _songOffset = reader.Read<long>(Endianness.Little);
 
-            _previewStart = reader.Read<ulong>();
-            _previewEnd = reader.Read<ulong>();
+            _previewStart = reader.Read<ulong>(Endianness.Little);
+            _previewEnd = reader.Read<ulong>(Endianness.Little);
 
-            VideoStartTimeSeconds = reader.Read<double>();
-            VideoEndTimeSeconds = reader.Read<double>();
+            VideoStartTimeSeconds = reader.Read<double>(Endianness.Little);
+            VideoEndTimeSeconds = reader.Read<double>(Endianness.Little);
 
             _loadingPhrase = reader.ReadLEBString();
 
-            _parseSettings.HopoThreshold = reader.Read<long>();
-            _parseSettings.HopoFreq_FoF = reader.Read<int>();
+            _parseSettings.HopoThreshold = reader.Read<long>(Endianness.Little);
+            _parseSettings.HopoFreq_FoF = reader.Read<int>(Endianness.Little);
             _parseSettings.EighthNoteHopo = reader.ReadBoolean();
-            _parseSettings.SustainCutoffThreshold = reader.Read<long>();
-            _parseSettings.NoteSnapThreshold = reader.Read<long>();
-            _parseSettings.StarPowerNote = reader.Read<int>();
-            _parseSettings.DrumsType = (DrumsType)reader.Read<int>();
+            _parseSettings.SustainCutoffThreshold = reader.Read<long>(Endianness.Little);
+            _parseSettings.NoteSnapThreshold = reader.Read<long>(Endianness.Little);
+            _parseSettings.StarPowerNote = reader.Read<int>(Endianness.Little);
+            _parseSettings.DrumsType = (DrumsType)reader.Read<int>(Endianness.Little);
 
             _parts = new(reader);
             _hash = new(reader);

--- a/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
@@ -10,38 +10,38 @@ namespace YARG.Core.Song
     {
         public SongMetadata(YARGBinaryReader reader, CategoryCacheStrings strings)
         {
-            _name.Str = strings.titles[reader.ReadInt32()];
-            _artist.Str = strings.artists[reader.ReadInt32()];
-            _album.Str = strings.albums[reader.ReadInt32()];
-            _genre.Str = strings.genres[reader.ReadInt32()];
-            Year = strings.years[reader.ReadInt32()];
-            _charter.Str = strings.charters[reader.ReadInt32()];
-            _playlist.Str = strings.playlists[reader.ReadInt32()];
-            _source.Str = strings.sources[reader.ReadInt32()];
+            _name.Str = strings.titles[reader.Read<int>()];
+            _artist.Str = strings.artists[reader.Read<int>()];
+            _album.Str = strings.albums[reader.Read<int>()];
+            _genre.Str = strings.genres[reader.Read<int>()];
+            Year = strings.years[reader.Read<int>()];
+            _charter.Str = strings.charters[reader.Read<int>()];
+            _playlist.Str = strings.playlists[reader.Read<int>()];
+            _source.Str = strings.sources[reader.Read<int>()];
 
             _isMaster = reader.ReadBoolean();
 
-            _albumTrack = reader.ReadInt32();
-            _playlistTrack = reader.ReadInt32();
+            _albumTrack = reader.Read<int>();
+            _playlistTrack = reader.Read<int>();
 
-            _songLength = reader.ReadUInt64();
-            _songOffset = reader.ReadInt64();
+            _songLength = reader.Read<ulong>();
+            _songOffset = reader.Read<long>();
 
-            _previewStart = reader.ReadUInt64();
-            _previewEnd = reader.ReadUInt64();
+            _previewStart = reader.Read<ulong>();
+            _previewEnd = reader.Read<ulong>();
 
-            VideoStartTimeSeconds = reader.ReadDouble();
-            VideoEndTimeSeconds = reader.ReadDouble();
+            VideoStartTimeSeconds = reader.Read<double>();
+            VideoEndTimeSeconds = reader.Read<double>();
 
             _loadingPhrase = reader.ReadLEBString();
 
-            _parseSettings.HopoThreshold = reader.ReadInt64();
-            _parseSettings.HopoFreq_FoF = reader.ReadInt32();
+            _parseSettings.HopoThreshold = reader.Read<long>();
+            _parseSettings.HopoFreq_FoF = reader.Read<int>();
             _parseSettings.EighthNoteHopo = reader.ReadBoolean();
-            _parseSettings.SustainCutoffThreshold = reader.ReadInt64();
-            _parseSettings.NoteSnapThreshold = reader.ReadInt64();
-            _parseSettings.StarPowerNote = reader.ReadInt32();
-            _parseSettings.DrumsType = (DrumsType)reader.ReadInt32();
+            _parseSettings.SustainCutoffThreshold = reader.Read<long>();
+            _parseSettings.NoteSnapThreshold = reader.Read<long>();
+            _parseSettings.StarPowerNote = reader.Read<int>();
+            _parseSettings.DrumsType = (DrumsType)reader.Read<int>();
 
             _parts = new(reader);
             _hash = new(reader);

--- a/YARG.Core/Song/Metadata/Types/RBCONDifficulties.cs
+++ b/YARG.Core/Song/Metadata/Types/RBCONDifficulties.cs
@@ -26,19 +26,19 @@ namespace YARG.Core.Song
         public RBCONDifficulties() { }
         public RBCONDifficulties(YARGBinaryReader reader)
         {
-            band = reader.ReadInt16();
-            FiveFretGuitar = reader.ReadInt16();
-            FiveFretBass = reader.ReadInt16();
-            FiveFretRhythm = reader.ReadInt16();
-            FiveFretCoop = reader.ReadInt16();
-            Keys = reader.ReadInt16();
-            FourLaneDrums = reader.ReadInt16();
-            ProDrums = reader.ReadInt16();
-            ProGuitar = reader.ReadInt16();
-            ProBass = reader.ReadInt16();
-            ProKeys = reader.ReadInt16();
-            LeadVocals = reader.ReadInt16();
-            HarmonyVocals = reader.ReadInt16();
+            band = reader.Read<short>();
+            FiveFretGuitar = reader.Read<short>();
+            FiveFretBass = reader.Read<short>();
+            FiveFretRhythm = reader.Read<short>();
+            FiveFretCoop = reader.Read<short>();
+            Keys = reader.Read<short>();
+            FourLaneDrums = reader.Read<short>();
+            ProDrums = reader.Read<short>();
+            ProGuitar = reader.Read<short>();
+            ProBass = reader.Read<short>();
+            ProKeys = reader.Read<short>();
+            LeadVocals = reader.Read<short>();
+            HarmonyVocals = reader.Read<short>();
         }
 
         public void Serialize(BinaryWriter writer)

--- a/YARG.Core/Song/Metadata/Types/RBCONDifficulties.cs
+++ b/YARG.Core/Song/Metadata/Types/RBCONDifficulties.cs
@@ -26,19 +26,19 @@ namespace YARG.Core.Song
         public RBCONDifficulties() { }
         public RBCONDifficulties(YARGBinaryReader reader)
         {
-            band = reader.Read<short>();
-            FiveFretGuitar = reader.Read<short>();
-            FiveFretBass = reader.Read<short>();
-            FiveFretRhythm = reader.Read<short>();
-            FiveFretCoop = reader.Read<short>();
-            Keys = reader.Read<short>();
-            FourLaneDrums = reader.Read<short>();
-            ProDrums = reader.Read<short>();
-            ProGuitar = reader.Read<short>();
-            ProBass = reader.Read<short>();
-            ProKeys = reader.Read<short>();
-            LeadVocals = reader.Read<short>();
-            HarmonyVocals = reader.Read<short>();
+            band = reader.Read<short>(Endianness.Little);
+            FiveFretGuitar = reader.Read<short>(Endianness.Little);
+            FiveFretBass = reader.Read<short>(Endianness.Little);
+            FiveFretRhythm = reader.Read<short>(Endianness.Little);
+            FiveFretCoop = reader.Read<short>(Endianness.Little);
+            Keys = reader.Read<short>(Endianness.Little);
+            FourLaneDrums = reader.Read<short>(Endianness.Little);
+            ProDrums = reader.Read<short>(Endianness.Little);
+            ProGuitar = reader.Read<short>(Endianness.Little);
+            ProBass = reader.Read<short>(Endianness.Little);
+            ProKeys = reader.Read<short>(Endianness.Little);
+            LeadVocals = reader.Read<short>(Endianness.Little);
+            HarmonyVocals = reader.Read<short>(Endianness.Little);
         }
 
         public void Serialize(BinaryWriter writer)


### PR DESCRIPTION
+ Removes BinaryReader & BinaryWriter non-color extensions

+ Requires Main repo update due to yarg_mogg file version & length reads