### PR TITLE
Auto-Generate Sections When Songs Don't Have Any

### DIFF
--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -163,7 +163,10 @@ namespace YARG.Core.Chart
                     double startTime = SyncTrack.TickToTime(startTick);
                     double endTime   = SyncTrack.TickToTime(endTick);
 
-                    var section = new Section($"Section {i + 1}", startTime, startTick)
+                    // 10%, 20%, 30%, etc.
+                    var sectionName = $"{100f / AUTO_GEN_SECTION_COUNT * (i + 1):N0}%";
+
+                    var section = new Section(sectionName, startTime, startTick)
                     {
                         TickLength = endTick - startTick,
                         TimeLength = endTime - startTime,

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -155,16 +155,18 @@ namespace YARG.Core.Chart
             // This prevents issues with songs with no sections, such as in practice mode.
             if (Sections.Count <= 0)
             {
-                for (uint i = 0; i < AUTO_GEN_SECTION_COUNT; i++)
+                uint startTick = 0;
+                double startTime = SyncTrack.TickToTime(startTick);
+
+                // `i` is effectively the "ending index" since start tick and time is
+                // always one index behind.
+                for (uint i = 1; i <= AUTO_GEN_SECTION_COUNT; i++)
                 {
-                    uint startTick = lastTick / AUTO_GEN_SECTION_COUNT * i;
-                    uint endTick   = lastTick / AUTO_GEN_SECTION_COUNT * (i + 1);
+                    uint endTick = lastTick / AUTO_GEN_SECTION_COUNT * i;
+                    double endTime = SyncTrack.TickToTime(endTick);
 
-                    double startTime = SyncTrack.TickToTime(startTick);
-                    double endTime   = SyncTrack.TickToTime(endTick);
-
-                    // 10%, 20%, 30%, etc.
-                    var sectionName = $"{100f / AUTO_GEN_SECTION_COUNT * (i + 1):N0}%";
+                    // 10%, 20%, 30%, etc. (the ending percent)
+                    var sectionName = $"{100f / AUTO_GEN_SECTION_COUNT * i:N0}%";
 
                     var section = new Section(sectionName, startTime, startTick)
                     {
@@ -173,6 +175,10 @@ namespace YARG.Core.Chart
                     };
 
                     Sections.Add(section);
+
+                    // Set the start of the next section to the end of this one
+                    startTick = endTick;
+                    startTime = endTime;
                 }
             }
             else

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -165,7 +165,7 @@ namespace YARG.Core.Chart
                     uint endTick = lastTick / AUTO_GEN_SECTION_COUNT * i;
                     double endTime = SyncTrack.TickToTime(endTick);
 
-                    // "0% to 10%", "10% to 20%", etc.
+                    // "0% - 10%", "10% - 20%", etc.
                     var sectionName =
                         $"{100f / AUTO_GEN_SECTION_COUNT * (i - 1):N0}% - {100f / AUTO_GEN_SECTION_COUNT * i:N0}%";
 

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -176,8 +176,8 @@ namespace YARG.Core.Chart
             {
                 // Otherwise make sure the length of the last section is correct
                 var lastSection = Sections[^1];
-                lastSection.TickLength = lastSection.Tick - lastTick;
-                lastSection.TimeLength = lastSection.Time - SyncTrack.TickToTime(lastTick);
+                lastSection.TickLength = lastTick - lastSection.Tick;
+                lastSection.TimeLength = SyncTrack.TickToTime(lastTick) - lastSection.Time;
             }
         }
 

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -165,8 +165,9 @@ namespace YARG.Core.Chart
                     uint endTick = lastTick / AUTO_GEN_SECTION_COUNT * i;
                     double endTime = SyncTrack.TickToTime(endTick);
 
-                    // 10%, 20%, 30%, etc. (the ending percent)
-                    var sectionName = $"{100f / AUTO_GEN_SECTION_COUNT * i:N0}%";
+                    // "0% to 10%", "10% to 20%", etc.
+                    var sectionName =
+                        $"{100f / AUTO_GEN_SECTION_COUNT * (i - 1):N0}% - {100f / AUTO_GEN_SECTION_COUNT * i:N0}%";
 
                     var section = new Section(sectionName, startTime, startTick)
                     {


### PR DESCRIPTION
When a song is loaded without any sections, 10 equal sections are created for the song automatically. I wasn't too sure exactly where to put this, since we need the last tick of the chart, so I just made a  `PostProcessSections` method in `SongChart`, and called it at the end of the constructor where everything is loaded. Not sure if that's the best place, let me know if there's a better one.

Also moved the code ensuring that the last section extends to the end of the chart from YARG to here. Small YARG change required when this is merged because of it.