### PR TITLE
Refactored Replay Preset Serialization

### DIFF
--- a/YARG.Core/Extensions/BinaryReaderWriterExtensions.cs
+++ b/YARG.Core/Extensions/BinaryReaderWriterExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 using System.IO;
 
@@ -14,6 +15,28 @@ namespace YARG.Core.Extensions
         {
             int argb = reader.ReadInt32();
             return Color.FromArgb(argb);
+        }
+
+        public static void Write(this BinaryWriter writer, Guid guid)
+        {
+            Span<byte> span = stackalloc byte[16];
+            if (!guid.TryWriteBytes(span))
+            {
+                throw new InvalidOperationException("Failed to write GUID bytes.");
+            }
+
+            writer.Write(span);
+        }
+
+        public static Guid ReadGuid(this BinaryReader reader)
+        {
+            Span<byte> span = stackalloc byte[16];
+            if (reader.Read(span) != span.Length)
+            {
+                throw new EndOfStreamException("Failed to read GUID, ran out of bytes!");
+            }
+
+            return new Guid(span);
         }
     }
 }

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -3,6 +3,7 @@ using System.IO;
 using Newtonsoft.Json;
 using YARG.Core.Chart;
 using YARG.Core.Utility;
+using YARG.Core.Extensions;
 
 namespace YARG.Core.Game
 {
@@ -152,6 +153,12 @@ namespace YARG.Core.Game
 
             writer.Write(Name);
 
+            writer.Write(EnginePreset);
+
+            writer.Write(ThemePreset);
+            writer.Write(ColorProfile);
+            writer.Write(CameraPreset);
+
             writer.Write((byte) CurrentInstrument);
             writer.Write((byte) CurrentDifficulty);
             writer.Write((ulong) CurrentModifiers);
@@ -167,6 +174,12 @@ namespace YARG.Core.Game
             version = reader.ReadInt32();
 
             Name = reader.ReadString();
+
+            EnginePreset = reader.ReadGuid();
+
+            ThemePreset = reader.ReadGuid();
+            ColorProfile = reader.ReadGuid();
+            CameraPreset = reader.ReadGuid();
 
             CurrentInstrument = (Instrument) reader.ReadByte();
             CurrentDifficulty = (Difficulty) reader.ReadByte();

--- a/YARG.Core/Replays/Replay.cs
+++ b/YARG.Core/Replays/Replay.cs
@@ -44,8 +44,7 @@ namespace YARG.Core.Replays
         public DateTime    Date;
         public HashWrapper SongChecksum;
 
-        public int            ColorProfileCount;
-        public ColorProfile[] ColorProfiles;
+        public ReplayPresetContainer ReplayPresetContainer;
 
         public int      PlayerCount;
         public string[] PlayerNames;
@@ -58,7 +57,7 @@ namespace YARG.Core.Replays
             ArtistName = string.Empty;
             CharterName = string.Empty;
 
-            ColorProfiles = Array.Empty<ColorProfile>();
+            ReplayPresetContainer = new ReplayPresetContainer();
             PlayerNames = Array.Empty<string>();
             Frames = Array.Empty<ReplayFrame>();
         }
@@ -80,11 +79,7 @@ namespace YARG.Core.Replays
 
             SongChecksum.Serialize(writer);
 
-            writer.Write(ColorProfileCount);
-            for (int i = 0; i < ColorProfileCount; i++)
-            {
-                ColorProfiles[i].Serialize(writer);
-            }
+            ReplayPresetContainer.Serialize(writer);
 
             writer.Write(PlayerCount);
             for (int i = 0; i < PlayerCount; i++)
@@ -101,7 +96,7 @@ namespace YARG.Core.Replays
         [MemberNotNull(nameof(SongName))]
         [MemberNotNull(nameof(ArtistName))]
         [MemberNotNull(nameof(CharterName))]
-        [MemberNotNull(nameof(ColorProfiles))]
+        [MemberNotNull(nameof(ReplayPresetContainer))]
         [MemberNotNull(nameof(PlayerNames))]
         [MemberNotNull(nameof(Frames))]
         public void Deserialize(BinaryReader reader, int version = 0)
@@ -115,14 +110,9 @@ namespace YARG.Core.Replays
             Date = DateTime.FromBinary(reader.ReadInt64());
             SongChecksum = new HashWrapper(reader);
 
-            ColorProfileCount = reader.ReadInt32();
-            ColorProfiles = new ColorProfile[ColorProfileCount];
-
-            for (int i = 0; i < ColorProfileCount; i++)
-            {
-                ColorProfiles[i] = new ColorProfile("");
-                ColorProfiles[i].Deserialize(reader, version);
-            }
+            // TODO: Find a way to skip this step when analyzing replays
+            ReplayPresetContainer = new ReplayPresetContainer();
+            ReplayPresetContainer.Deserialize(reader, version);
 
             PlayerCount = reader.ReadInt32();
             PlayerNames = new string[PlayerCount];

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using YARG.Core.IO;

--- a/YARG.Core/Replays/ReplayPresetContainer.cs
+++ b/YARG.Core/Replays/ReplayPresetContainer.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Bson;
+using YARG.Core.Extensions;
+using YARG.Core.Game;
+using YARG.Core.Utility;
+
+namespace YARG.Core.Replays
+{
+    /// <summary>
+    /// A container that stores the presets used in a replay, and allows for easy access of
+    /// said presets. The container has separate versioning from the replay itself.
+    /// </summary>
+    public class ReplayPresetContainer : IBinarySerializable
+    {
+        private const int CONTAINER_VERSION = 0;
+
+        private readonly Dictionary<Guid, ColorProfile> _colorProfiles = new();
+        private readonly Dictionary<Guid, CameraPreset> _cameraPresets = new();
+
+        /// <returns>
+        /// The color profile if it's in this container, otherwise, <c>null</c>.
+        /// </returns>
+        public ColorProfile? GetColorProfile(Guid guid)
+        {
+            return _colorProfiles.GetValueOrDefault(guid);
+        }
+
+        /// <summary>
+        /// Stores the specified color profile into this container. If the color profile
+        /// is a default one, nothing is stored.
+        /// </summary>
+        public void StoreColorProfile(ColorProfile colorProfile)
+        {
+            if (colorProfile.DefaultPreset)
+            {
+                return;
+            }
+
+            _colorProfiles[colorProfile.Id] = colorProfile;
+        }
+
+        /// <returns>
+        /// The camera preset if it's in this container, otherwise, <c>null</c>.
+        /// </returns>
+        public CameraPreset? GetCameraPreset(Guid guid)
+        {
+            return _cameraPresets.GetValueOrDefault(guid);
+        }
+
+        /// <summary>
+        /// Stores the specified camera preset into this container. If the camera preset
+        /// is a default one, nothing is stored.
+        /// </summary>
+        public void StoreCameraPreset(CameraPreset cameraPreset)
+        {
+            if (cameraPreset.DefaultPreset)
+            {
+                return;
+            }
+
+            _cameraPresets[cameraPreset.Id] = cameraPreset;
+        }
+
+        public void Serialize(BinaryWriter writer)
+        {
+            writer.Write(CONTAINER_VERSION);
+
+            SerializeDict(writer, _colorProfiles);
+            SerializeDict(writer, _cameraPresets);
+        }
+
+        public void Deserialize(BinaryReader reader, int version = 0)
+        {
+            // This container has separate versioning
+            version = reader.ReadInt32();
+
+            DeserializeDict(reader, _colorProfiles);
+            DeserializeDict(reader, _cameraPresets);
+        }
+
+        private static void SerializeDict<T>(BinaryWriter writer, Dictionary<Guid, T> dict)
+        {
+            var serializer = new JsonSerializer();
+
+            writer.Write(dict.Count);
+            foreach (var (key, value) in dict)
+            {
+                // Write key
+                writer.Write(key);
+
+                // Convert preset to BSON
+                using var stream = new MemoryStream();
+                using var bson = new BsonDataWriter(stream);
+                serializer.Serialize(bson, value);
+
+                // Write preset
+                writer.Write(stream.Length);
+                writer.Write(stream.ToArray());
+            }
+        }
+
+        private static void DeserializeDict<T>(BinaryReader reader, Dictionary<Guid, T> dict)
+        {
+            var serializer = new JsonSerializer();
+
+            dict.Clear();
+            int len = reader.ReadInt32();
+            for (int i = 0; i < len; i++)
+            {
+                // Read key
+                var guid = reader.ReadGuid();
+
+                // Read preset
+                var bytesLength = reader.ReadInt32();
+                var bytes = reader.ReadBytes(bytesLength);
+
+                // Convert BSON to preset
+                using var stream = new MemoryStream(bytes);
+                using var bson = new BsonDataReader(stream);
+
+                dict.Add(guid, serializer.Deserialize<T>(bson)!);
+            }
+        }
+    }
+}

--- a/YARG.Core/Replays/ReplayPresetContainer.cs
+++ b/YARG.Core/Replays/ReplayPresetContainer.cs
@@ -15,6 +15,14 @@ namespace YARG.Core.Replays
     /// </summary>
     public class ReplayPresetContainer : IBinarySerializable
     {
+        private static readonly JsonSerializerSettings _jsonSettings = new()
+        {
+            Converters =
+            {
+                new JsonColorConverter()
+            }
+        };
+
         private const int CONTAINER_VERSION = 0;
 
         private readonly Dictionary<Guid, ColorProfile> _colorProfiles = new();
@@ -83,7 +91,7 @@ namespace YARG.Core.Replays
 
         private static void SerializeDict<T>(BinaryWriter writer, Dictionary<Guid, T> dict)
         {
-            var serializer = new JsonSerializer();
+            var serializer = JsonSerializer.Create(_jsonSettings);
 
             writer.Write(dict.Count);
             foreach (var (key, value) in dict)
@@ -104,7 +112,7 @@ namespace YARG.Core.Replays
 
         private static void DeserializeDict<T>(BinaryReader reader, Dictionary<Guid, T> dict)
         {
-            var serializer = new JsonSerializer();
+            var serializer = JsonSerializer.Create(_jsonSettings);
 
             dict.Clear();
             int len = reader.ReadInt32();

--- a/YARG.Core/YARG.Core.csproj
+++ b/YARG.Core/YARG.Core.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Melanchall.DryWetMidi.Nativeless" Version="7.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3-beta1" />
     <PackageReference Include="PolySharp" Version="1.13.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
**Requires YARG Changes**

Refactors the replay preset store to work with camera presets, and use BSON instead of binary serialization. If the latter is not preferred, then we can easily switch back over to binary with the same refactor. The reason for this change is to reduce the amount of serialization code in preset classes (especially in color profiles). This change does slightly increase read and write times of replay files, however, it can be decreased by adding an option to ignore the presets during (de)serialization, when it's not needed (such as when analyzing them).

Edit: Also wanna do some testing tomorrow to see if this works with IL2CPP