### PR TITLE
Implement Duplicate Entry Removal Functionality

### DIFF
--- a/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
+++ b/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
@@ -7,6 +7,7 @@ namespace YARG.Core.UnitTests.Scanning
     {
         private List<string> songDirectories;
         private readonly bool MULTITHREADING = true;
+        private readonly bool ALLOW_DUPLICATES = true;
         private static readonly string SongCachePath = Path.Combine(Environment.CurrentDirectory, "songcache.bin");
         private static readonly string BadSongsPath = Path.Combine(Environment.CurrentDirectory, "badsongs.txt");
 
@@ -24,7 +25,7 @@ namespace YARG.Core.UnitTests.Scanning
         public void FullScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            var cache = CacheHandler.RunScan(false, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
+            var cache = CacheHandler.RunScan(false, SongCachePath, BadSongsPath, MULTITHREADING, ALLOW_DUPLICATES, songDirectories);
             // TODO: Any cache properties we want to check here?
             // Currently the only fail condition would be an unhandled exception
         }
@@ -33,7 +34,7 @@ namespace YARG.Core.UnitTests.Scanning
         public void QuickScan()
         {
             YargTrace.AddListener(new YargDebugTraceListener());
-            var cache = CacheHandler.RunScan(true, SongCachePath, BadSongsPath, MULTITHREADING, songDirectories);
+            var cache = CacheHandler.RunScan(true, SongCachePath, BadSongsPath, MULTITHREADING, ALLOW_DUPLICATES, songDirectories);
             // TODO: see above
         }
     }

--- a/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
@@ -36,18 +36,18 @@ namespace YARG.Core.Song.Cache
             return true;
         }
 
-        public bool RemoveEntry(string name, int index)
+        public void RemoveEntry(string name, int index)
         {
             lock (entryLock)
             {
-                if (!entries.TryGetValue(name, out var dict) || !dict.Remove(index))
-                    return false;
-
-                --_entryCount;
+                var dict = entries[name];
+                dict.Remove(index);
                 if (dict.Count == 0)
+                {
                     entries.Remove(name);
+                }
+                --_entryCount;
             }
-            return true;
         }
 
         public bool TryGetEntry(string name, int index, out SongMetadata? entry)

--- a/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
@@ -22,6 +22,25 @@ namespace YARG.Core.Song.Cache
             }
         }
 
+        public bool TryRemoveEntry(SongMetadata entry)
+        {
+            // No locking as the post-scan removal sequence
+            // cannot be parallelized
+            if (entries.TryGetValue(entry.Hash, out var list))
+            {
+                if (list.Remove(entry))
+                {
+                    if (list.Count == 0)
+                    {
+                        entries.Remove(entry.Hash);
+                    }
+                    --_count;
+                    return true;
+                }
+            }
+            return false;
+        }
+
         public byte[] SerializeEntries(string directory, Dictionary<SongMetadata, CategoryCacheWriteNode> nodes)
         {
             using MemoryStream ms = new();

--- a/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
@@ -9,6 +9,8 @@ namespace YARG.Core.Song.Cache
         public readonly Dictionary<HashWrapper, List<SongMetadata>> entries = new();
         private int _count;
 
+        public int Count => _count;
+
         public void AddEntry(SongMetadata entry)
         {
             var hash = entry.Hash;

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -213,8 +213,8 @@ namespace YARG.Core.Song.Cache
         {
             if (group.TryGetEntry(name, index, out var entry))
             {
-                if (!AddEntry(entry!) && group.RemoveEntry(name, index))
-                    YargTrace.DebugInfo($"{filename} - {name} removed as duplicate");
+                if (!AddEntry(entry!))
+                    group.RemoveEntry(name, index);
             }
             else
             {
@@ -235,8 +235,8 @@ namespace YARG.Core.Song.Cache
         {
             if (group.TryGetEntry(name, index, out var entry))
             {
-                if (!AddEntry(entry!) && group.RemoveEntry(name, index))
-                    YargTrace.DebugInfo($"{directory} - {name} removed as duplicate");
+                if (!AddEntry(entry!))
+                    group.RemoveEntry(name, index);
             }
             else
             {

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -446,7 +446,7 @@ namespace YARG.Core.Song.Cache
                 }
                 else if (!allowDuplicates)
                 {
-                    if (list[0].CompareTo(entry) < 0)
+                    if (list[0].IsPreferedOver(entry))
                     {
                         duplicatesRejected.Add(entry);
                         return false;

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -27,9 +27,9 @@ namespace YARG.Core.Song.Cache
     {
         public static ScanProgressTracker Progress => _progress;
         private static ScanProgressTracker _progress;
-        public static SongCache RunScan(bool fast, string cacheLocation, string badSongsLocation, bool multithreading, List<string> baseDirectories)
+        public static SongCache RunScan(bool fast, string cacheLocation, string badSongsLocation, bool multithreading, bool allowDuplicates, List<string> baseDirectories)
         {
-            CacheHandler handler = new(baseDirectories);
+            var handler = new CacheHandler(baseDirectories, allowDuplicates);
             try
             {
                 if (!fast || !handler.QuickScan(cacheLocation, multithreading))
@@ -74,12 +74,15 @@ namespace YARG.Core.Song.Cache
         private readonly HashSet<string> preScannedFiles = new();
         private readonly SortedDictionary<string, ScanResult> badSongs = new();
 
-        private CacheHandler(List<string> baseDirectories)
+        private readonly bool allowDuplicates = true;
+
+        private CacheHandler(List<string> baseDirectories, bool allowDuplicates)
         {
             _progress = default;
             iniGroups = new(baseDirectories.Count);
             foreach (string dir in baseDirectories)
                 iniGroups.TryAdd(dir, new IniGroup());
+            this.allowDuplicates = allowDuplicates;
         }
 
         private IniGroup? GetBaseIniGroup(string path)

--- a/YARG.Core/Song/Metadata/SongMetadata.Sorting.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Sorting.cs
@@ -33,6 +33,38 @@ namespace YARG.Core.Song
             }
             return strCmp;
         }
+
+        private enum EntryType
+        {
+            Ini,
+            Sng,
+            ExCON,
+            CON,
+        }
+
+        public bool IsPreferedOver(SongMetadata other)
+        {
+            static EntryType ParseType(SongMetadata entry)
+            {
+                if (entry._iniData != null)
+                {
+                    return entry._iniData is SngSubmetadata ? EntryType.Sng : EntryType.Ini;
+                }
+
+                return entry._rbData is RBPackedCONMetadata ? EntryType.CON : EntryType.ExCON;
+            }
+
+            var thisType = ParseType(this);
+            var otherType = ParseType(other);
+            if (thisType != otherType)
+            {
+                // CON > ExCON > Sng > Ini
+                return thisType > otherType;
+            }
+            // Otherwise, whatever would appear first
+            return CompareTo(other) < 0;
+        }
+
     }
 
     public sealed class EntryComparer : IComparer<SongMetadata>


### PR DESCRIPTION
Requires an accompanying main repo update when approved, but said update will not add the explicit toggleable setting out the gate.

We possibly could have it export a file that lists the duplicates that were ignored, but I wanted get the basic portion out first.