### PR TITLE
Rework HashWrapper

### DIFF
--- a/YARG.Core/Replays/Replay.cs
+++ b/YARG.Core/Replays/Replay.cs
@@ -29,7 +29,7 @@ namespace YARG.Core.Replays
             Magic = EightCC.Read(reader);
             ReplayVersion = reader.ReadInt32();
             EngineVersion = reader.ReadInt32();
-            ReplayChecksum = new HashWrapper(reader);
+            ReplayChecksum = HashWrapper.Deserialize(reader);
         }
     }
 
@@ -108,7 +108,7 @@ namespace YARG.Core.Replays
             BandStars = (StarAmount) reader.ReadByte();
             ReplayLength = reader.ReadDouble();
             Date = DateTime.FromBinary(reader.ReadInt64());
-            SongChecksum = new HashWrapper(reader);
+            SongChecksum = HashWrapper.Deserialize(reader);
 
             // TODO: Find a way to skip this step when analyzing replays
             ReplayPresetContainer = new ReplayPresetContainer();

--- a/YARG.Core/Replays/ReplayFile.cs
+++ b/YARG.Core/Replays/ReplayFile.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.IO;
 using YARG.Core.Song;
 using YARG.Core.Utility;
@@ -51,11 +52,11 @@ namespace YARG.Core.Replays
             using var dataWriter = new NullStringBinaryWriter(dataStream);
 
             Replay.Serialize(dataWriter);
-            Header.ReplayChecksum = HashWrapper.Create(dataStream);
+            var data = new ReadOnlySpan<byte>(dataStream.GetBuffer(), 0, (int) dataStream.Length);
+            Header.ReplayChecksum = HashWrapper.Hash(data);
 
             Header.Serialize(writer);
-            dataStream.Position = 0;
-            dataStream.CopyTo(writer.BaseStream);
+            writer.Write(data);
         }
 
         public void Deserialize(BinaryReader reader, int version = 0)

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
@@ -187,7 +187,7 @@ namespace YARG.Core.Song
 
             byte[] file = File.ReadAllBytes(chart.File);
             var result = ScanIniChartFile(file, chart.Type, iniModifiers);
-            return (result.Item1, result.Item2 != null ? new(metadata, result.Item2, HashWrapper.Create(file), iniModifiers) : null);
+            return (result.Item1, result.Item2 != null ? new(metadata, result.Item2, HashWrapper.Hash(file), iniModifiers) : null);
         }
 
         public static SongMetadata? IniFromCache(string baseDirectory, YARGBinaryReader reader, CategoryCacheStrings strings)

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
@@ -176,7 +176,7 @@ namespace YARG.Core.Song
             byte[] file = sng.LoadAllBytes(sng[chart.File]);
             var result = ScanIniChartFile(file, chart.Type, sng.Metadata);
 
-            return (result.Item1, result.Item2 != null ? new SongMetadata(metadata, result.Item2, HashWrapper.Create(file), sng.Metadata) : null );
+            return (result.Item1, result.Item2 != null ? new SongMetadata(metadata, result.Item2, HashWrapper.Hash(file), sng.Metadata) : null );
         }
 
         public static SongMetadata? SngFromCache(string baseDirectory, YARGBinaryReader reader, CategoryCacheStrings strings)

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -339,7 +339,7 @@ namespace YARG.Core.Song
                 {
                     System.Runtime.CompilerServices.Unsafe.CopyBlock(ref buffer[offset], ref upgradeFile[0], (uint)upgradeFile.Length);
                 }
-                _hash = HashWrapper.Create(buffer);
+                _hash = HashWrapper.Hash(buffer);
                 return ScanResult.Success;
             }
             catch

--- a/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
@@ -44,7 +44,7 @@ namespace YARG.Core.Song
             _parseSettings.DrumsType = (DrumsType)reader.Read<int>(Endianness.Little);
 
             _parts = new(reader);
-            _hash = new(reader);
+            _hash = HashWrapper.Deserialize(reader);
         }
 
         public void Serialize(BinaryWriter writer, CategoryCacheWriteNode node)


### PR DESCRIPTION
+ Use FixedArray as the internal hash storage over built-in byte[]. Main reasoning for this change is to remove the many calls to the `fixed` operator to perform special casts. Additional side effect is that the `HashBytes` property is *forced* to provide a copy of the hash instead of the original, making it inherently more safe from outside alterations.

+ Replace constructors with named functions. This requires a slight alteration to ReplayFile serialization.

Requires small main repo update