### PR TITLE
SNG Handling Changes

### DIFF
--- a/YARG.Core/IO/SngHandler/SngFileListing.cs
+++ b/YARG.Core/IO/SngHandler/SngFileListing.cs
@@ -4,13 +4,27 @@ namespace YARG.Core.IO
 {
     public class SngFileListing
     {
+        public readonly string Name;
         public readonly long Position;
         public readonly long Length;
 
-        public SngFileListing(YARGBinaryReader reader)
+        public SngFileListing(string name, YARGBinaryReader reader)
         {
+            Name = name;
             Length = reader.Read<long>(Endianness.Little);
             Position = reader.Read<long>(Endianness.Little);
+        }
+
+        public byte[] LoadAllBytes(SngFile sngFile)
+        {
+            var stream = sngFile.LoadFileStream();
+            return SngFileStream.LoadFile(stream, sngFile.Mask.Clone(), Length, Position);
+        }
+
+        public SngFileStream CreateStream(SngFile sngFile)
+        {
+            var stream = sngFile.LoadFileStream();
+            return new SngFileStream(Name, stream, sngFile.Mask.Clone(), Length, Position);
         }
     }
 }

--- a/YARG.Core/IO/SngHandler/SngFileStream.cs
+++ b/YARG.Core/IO/SngHandler/SngFileStream.cs
@@ -27,7 +27,7 @@ namespace YARG.Core.IO
             }
         }
 
-        public static byte[] LoadFile(Stream stream, SngMask mask, long fileSize, long position)
+        public static byte[] LoadFile(FileStream stream, SngMask mask, long fileSize, long position)
         {
             if (stream.Seek(position, SeekOrigin.Begin) != position)
                 throw new EndOfStreamException();
@@ -56,12 +56,14 @@ namespace YARG.Core.IO
         private const int SEEK_MODULUS = BUFFER_SIZE - 1;
         private const int SEEK_MODULUS_MINUS = ~SEEK_MODULUS;
 
-        private readonly Stream _stream;
+        private readonly FileStream _stream;
         private readonly long fileSize;
         private readonly long initialOffset;
 
         private readonly SngMask mask;
         private readonly FixedArray<byte> dataBuffer = FixedArray<byte>.Alloc(BUFFER_SIZE);
+
+        public  readonly string Name;
 
 
         private int bufferPosition;
@@ -90,8 +92,9 @@ namespace YARG.Core.IO
             }
         }
 
-        public SngFileStream(Stream stream, SngMask mask, long fileSize, long position)
+        public SngFileStream(string name, FileStream stream, SngMask mask, long fileSize, long position)
         {
+            Name = name;
             _stream = stream;
 
             this.fileSize = fileSize;

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
@@ -51,7 +51,7 @@ namespace YARG.Core.Song
                 if (sngFile == null)
                     return null;
 
-                return sngFile.CreateStream(sngFile[chart.File]);
+                return sngFile[chart.File].CreateStream(sngFile);
             }
 
             public Dictionary<SongStem, Stream> GetAudioStreams(params SongStem[] ignoreStems)
@@ -72,7 +72,7 @@ namespace YARG.Core.Song
                             var file = stem + format;
                             if (sngFile.TryGetValue(file, out var listing))
                             {
-                                streams.Add(stemEnum, sngFile.CreateStream(listing));
+                                streams.Add(stemEnum, listing.CreateStream(sngFile));
                                 // Parse no duplicate stems
                                 break;
                             }
@@ -92,7 +92,7 @@ namespace YARG.Core.Song
                 {
                     if (sngFile.TryGetValue(albumFile, out var listing))
                     {
-                        return sngFile.LoadAllBytes(listing);
+                        return listing.LoadAllBytes(sngFile);
                     }
                 }
                 return null;
@@ -110,7 +110,7 @@ namespace YARG.Core.Song
                 {
                     if (sngFile.TryGetValue("bg.yarground", out var listing))
                     {
-                        return (BackgroundType.Yarground, sngFile.CreateStream(listing));
+                        return (BackgroundType.Yarground, listing.CreateStream(sngFile));
                     }
                 }
 
@@ -122,7 +122,7 @@ namespace YARG.Core.Song
                         {
                             if (sngFile.TryGetValue(stem + format, out var listing))
                             {
-                                return (BackgroundType.Video, sngFile.CreateStream(listing));
+                                return (BackgroundType.Video, listing.CreateStream(sngFile));
                             }
                         }
                     }
@@ -136,7 +136,7 @@ namespace YARG.Core.Song
                         {
                             if (sngFile.TryGetValue(stem + format, out var listing))
                             {
-                                return (BackgroundType.Image, sngFile.CreateStream(listing));
+                                return (BackgroundType.Image, listing.CreateStream(sngFile));
                             }
                         }
                     }
@@ -155,7 +155,7 @@ namespace YARG.Core.Song
                 {
                     if (sngFile.TryGetValue("preview" + format, out var listing))
                     {
-                        return sngFile.CreateStream(listing);
+                        return listing.CreateStream(sngFile);
                     }
                 }
 
@@ -176,7 +176,7 @@ namespace YARG.Core.Song
             if (sng.Metadata.Count == 0 && !SngSubmetadata.DoesSoloChartHaveAudio(sng))
                 return (ScanResult.LooseChart_NoAudio, null);
 
-            byte[] file = sng.LoadAllBytes(sng[chart.File]);
+            byte[] file = sng[chart.File].LoadAllBytes(sng);
             var result = ScanIniChartFile(file, chart.Type, sng.Metadata);
             if (result.Item2 == null)
             {


### PR DESCRIPTION
+ Alter YARGSongFileStream to inherit from Filestream instead of Stream. Allows it to just use overriden functions from FileStream without having to manually define them.
+ Move LoadAllBytes() & CreateStream() from SngFile to SngFileListing
+ Construct SngFile straight from the initial stream
+ Hold the name of the subfile inside of SngFileStream