### PR TITLE
A Conglomeration of CacheHandler Updates + DateAdded Category

### DIFF
--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -20,14 +20,14 @@ namespace YARG.Core.IO
         /// </summary>
         public readonly DateTime LastUpdatedTime;
 
-        public AbridgedFileInfo(string file)
-            : this(new FileInfo(file)) { }
+        public AbridgedFileInfo(string file, bool checkCreationTime = true)
+            : this(new FileInfo(file), checkCreationTime) { }
 
-        public AbridgedFileInfo(FileInfo info)
+        public AbridgedFileInfo(FileInfo info, bool checkCreationTime = true)
         {
             FullName = info.FullName;
             LastUpdatedTime = info.LastWriteTime;
-            if (info.CreationTime > LastUpdatedTime)
+            if (checkCreationTime && info.CreationTime > LastUpdatedTime)
             {
                 LastUpdatedTime = info.CreationTime;
             }
@@ -65,7 +65,7 @@ namespace YARG.Core.IO
             return File.Exists(FullName);
         }
 
-        public bool IsStillValid()
+        public bool IsStillValid(bool checkCreationTime = true)
         {
             var info = new FileInfo(FullName);
             if (!info.Exists)
@@ -74,7 +74,7 @@ namespace YARG.Core.IO
             }
 
             var timeToCompare = info.LastWriteTime;
-            if (info.CreationTime > timeToCompare)
+            if (checkCreationTime && info.CreationTime > timeToCompare)
             {
                 timeToCompare = info.CreationTime;
             }
@@ -84,15 +84,15 @@ namespace YARG.Core.IO
         /// <summary>
         /// Used for cache validation
         /// </summary>
-        public static AbridgedFileInfo? TryParseInfo(YARGBinaryReader reader)
+        public static AbridgedFileInfo? TryParseInfo(YARGBinaryReader reader, bool checkCreationTime = true)
         {
-            return TryParseInfo(reader.ReadLEBString(), reader);
+            return TryParseInfo(reader.ReadLEBString(), reader, checkCreationTime);
         }
 
         /// <summary>
         /// Used for cache validation
         /// </summary>
-        public static AbridgedFileInfo? TryParseInfo(string file, YARGBinaryReader reader)
+        public static AbridgedFileInfo? TryParseInfo(string file, YARGBinaryReader reader, bool checkCreationTime = true)
         {
             var info = new FileInfo(file);
             if (!info.Exists)
@@ -100,7 +100,7 @@ namespace YARG.Core.IO
                 return null;
             }
 
-            var abridged = new AbridgedFileInfo(info);
+            var abridged = new AbridgedFileInfo(info, checkCreationTime);
             if (abridged.LastUpdatedTime != DateTime.FromBinary(reader.Read<long>(Endianness.Little)))
             {
                 return null;

--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -60,6 +60,11 @@ namespace YARG.Core.IO
             writer.Write(LastUpdatedTime.ToBinary());
         }
 
+        public bool Exists()
+        {
+            return File.Exists(FullName);
+        }
+
         public bool IsStillValid()
         {
             var info = new FileInfo(FullName);

--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -5,6 +5,8 @@ namespace YARG.Core.IO
 {
     public sealed class AbridgedFileInfo
     {
+        public const FileAttributes RECALL_ON_DATA_ACCESS = (FileAttributes)0x00400000;
+
         public readonly string FullName;
         public readonly DateTime LastWriteTime;
 

--- a/YARG.Core/IO/ConHandler/CONFileListing.cs
+++ b/YARG.Core/IO/ConHandler/CONFileListing.cs
@@ -49,7 +49,7 @@ namespace YARG.Core.IO
         public override string ToString() => $"STFS File Listing: {Filename}";
         public bool IsDirectory() { return (flags & CONFileListingFlag.Directory) > 0; }
         public bool IsContiguous() { return (flags & CONFileListingFlag.Contiguous) > 0; }
-        public bool IsStillValid() { return ConFile.IsStillValid(); }
+        public bool IsStillValid(in DateTime listingLastWrite) { return listingLastWrite == lastWrite && ConFile.IsStillValid(); }
 
         public CONFileStream CreateStream()
         {

--- a/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
@@ -21,7 +21,7 @@ namespace YARG.Core.Song.Cache
             DefaultPlaylist = defaultPlaylist;
         }
 
-        public abstract bool ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings);
+        public abstract void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings);
         public abstract byte[] SerializeEntries(Dictionary<SongMetadata, CategoryCacheWriteNode> nodes);
 
         public void AddEntry(string name, int index, SongMetadata entry)

--- a/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
@@ -56,7 +56,7 @@ namespace YARG.Core.Song.Cache
             using MemoryStream ms = new();
             using BinaryWriter writer = new(ms);
 
-            writer.Write(Directory);
+            writer.Write(Location);
             writer.Write(_count);
             foreach (var shared in entries)
             {
@@ -75,7 +75,7 @@ namespace YARG.Core.Song.Cache
             using MemoryStream ms = new();
             using BinaryWriter writer = new(ms);
 
-            entry.IniData!.Serialize(writer, Directory);
+            entry.IniData!.Serialize(writer, Location);
             entry.Serialize(writer, node);
 
             return ms.ToArray();

--- a/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
@@ -45,14 +45,13 @@ namespace YARG.Core.Song.Cache
             CONLastWrite = info.LastWriteTime;
         }
 
-        public override bool ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
+        public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             var song = SongMetadata.PackedRBCONFromCache(CONFile, nodeName, upgrades, reader, strings);
-            if (song == null)
-                return false;
-
-            AddEntry(nodeName, index, song);
-            return true;
+            if (song != null)
+            {
+                AddEntry(nodeName, index, song);
+            }
         }
 
         public override byte[] SerializeEntries(Dictionary<SongMetadata, CategoryCacheWriteNode> nodes)

--- a/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
@@ -11,7 +11,7 @@ namespace YARG.Core.Song.Cache
         public const string UPGRADESFILEPATH = "songs_upgrades/upgrades.dta";
 
         public readonly CONFile CONFile;
-        public readonly DateTime CONLastWrite;
+        public readonly DateTime CONLastUpdated;
         public readonly Dictionary<string, IRBProUpgrade> Upgrades = new();
 
         private readonly object upgradeLock = new();
@@ -42,7 +42,7 @@ namespace YARG.Core.Song.Cache
             : base(info.FullName, defaultPlaylist)
         {
             CONFile = file;
-            CONLastWrite = info.LastWriteTime;
+            CONLastUpdated = info.LastUpdatedTime;
         }
 
         public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
@@ -94,7 +94,7 @@ namespace YARG.Core.Song.Cache
             using BinaryWriter writer = new(ms);
 
             writer.Write(Location);
-            writer.Write(CONLastWrite.ToBinary());
+            writer.Write(CONLastUpdated.ToBinary());
             writer.Write(upgradeDta!.lastWrite.ToBinary());
             writer.Write(Upgrades.Count);
             foreach (var upgrade in Upgrades)

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
@@ -11,7 +11,7 @@ namespace YARG.Core.Song.Cache
         public UnpackedCONGroup(string directory, FileInfo dta, string defaultPlaylist)
             : base(directory, defaultPlaylist)
         {
-            DTA = dta;
+            DTA = new AbridgedFileInfo(dta);
         }
 
         public YARGDTAReader? LoadDTA()
@@ -34,7 +34,7 @@ namespace YARG.Core.Song.Cache
             using BinaryWriter writer = new(ms);
 
             writer.Write(Location);
-            writer.Write(DTA.LastWriteTime.ToBinary());
+            writer.Write(DTA.LastUpdatedTime.ToBinary());
             Serialize(writer, ref nodes);
             return ms.ToArray();
         }

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
@@ -19,14 +19,13 @@ namespace YARG.Core.Song.Cache
             return YARGDTAReader.TryCreate(DTA.FullName);
         }
 
-        public override bool ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
+        public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
             var song = SongMetadata.UnpackedRBCONFromCache(DTA, nodeName, upgrades, reader, strings);
-            if (song == null)
-                return false;
-
-            AddEntry(nodeName, index, song);
-            return true;
+            if (song != null)
+            {
+                AddEntry(nodeName, index, song);
+            }
         }
 
         public override byte[] SerializeEntries(Dictionary<SongMetadata, CategoryCacheWriteNode> nodes)

--- a/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
@@ -7,13 +7,13 @@ namespace YARG.Core.Song.Cache
     public sealed class UpdateGroup : IModificationGroup
     {
         private readonly string _directory;
-        private readonly DateTime _dtaLastWrite;
+        private readonly DateTime _dtaLastUpdate;
         public readonly List<string> updates = new();
 
-        public UpdateGroup(string directory, DateTime dtaLastWrite)
+        public UpdateGroup(string directory, DateTime dtaLastUpdate)
         {
             _directory = directory;
-            _dtaLastWrite = dtaLastWrite;
+            _dtaLastUpdate = dtaLastUpdate;
         }
 
         public byte[] SerializeModifications()
@@ -22,7 +22,7 @@ namespace YARG.Core.Song.Cache
             using BinaryWriter writer = new(ms);
 
             writer.Write(_directory);
-            writer.Write(_dtaLastWrite.ToBinary());
+            writer.Write(_dtaLastUpdate.ToBinary());
             writer.Write(updates.Count);
             for (int i = 0; i < updates.Count; ++i)
                 writer.Write(updates[i]);

--- a/YARG.Core/Song/Cache/CacheGroups/UpgradeGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UpgradeGroup.cs
@@ -7,13 +7,13 @@ namespace YARG.Core.Song.Cache
     public sealed class UpgradeGroup : IModificationGroup
     {
         private readonly string _directory;
-        private readonly DateTime _dtaLastWrite;
+        private readonly DateTime _dtaLastUpdate;
         public readonly Dictionary<string, IRBProUpgrade> upgrades = new();
 
-        public UpgradeGroup(string directory, DateTime dtaLastWrite)
+        public UpgradeGroup(string directory, DateTime dtaLastUpdate)
         {
             _directory = directory;
-            _dtaLastWrite = dtaLastWrite;
+            _dtaLastUpdate = dtaLastUpdate;
         }
 
         public byte[] SerializeModifications()
@@ -22,7 +22,7 @@ namespace YARG.Core.Song.Cache
             using BinaryWriter writer = new(ms);
 
             writer.Write(_directory);
-            writer.Write(_dtaLastWrite.ToBinary());
+            writer.Write(_dtaLastUpdate.ToBinary());
             writer.Write(upgrades.Count);
             foreach (var upgrade in upgrades)
             {

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -10,39 +10,80 @@ namespace YARG.Core.Song.Cache
     {
         private sealed class FileCollector
         {
-            public readonly string directory;
-            public readonly SongMetadata.IniChartNode?[] charts = new SongMetadata.IniChartNode?[3];
-            public string? ini = null;
-            public readonly List<string> subfiles = new();
+            public readonly DirectoryInfo directory;
+            public readonly SongMetadata.IniChartNode<FileInfo>?[] charts = new SongMetadata.IniChartNode<FileInfo>?[3];
+            public FileInfo? ini = null;
+            public readonly List<FileInfo> subfiles = new();
+            public readonly List<DirectoryInfo> subDirectories = new();
 
-            public FileCollector(string directory)
+            public FileCollector(DirectoryInfo directory)
             {
                 this.directory = directory;
-                foreach (string subFile in Directory.EnumerateFileSystemEntries(directory))
+                foreach (var info in directory.EnumerateFileSystemInfos())
                 {
-                    switch (Path.GetFileName(subFile).ToLower())
+                    switch (info)
                     {
-                        case "song.ini": ini = subFile; break;
-                        case "notes.mid": charts[0] = new(SongMetadata.ChartType.Mid, subFile); break;
-                        case "notes.midi": charts[1] = new(SongMetadata.ChartType.Midi, subFile); break;
-                        case "notes.chart": charts[2] = new(SongMetadata.ChartType.Chart, subFile); break;
-                        default: subfiles.Add(subFile); break;
+                        case FileInfo subFile:
+                        {
+                            switch (subFile.Name.ToLower())
+                            {
+                                case "song.ini": ini = subFile; break;
+                                case "notes.mid": charts[0] = new (SongMetadata.ChartType.Mid, subFile); break;
+                                case "notes.midi": charts[1] = new (SongMetadata.ChartType.Midi, subFile); break;
+                                case "notes.chart": charts[2] = new (SongMetadata.ChartType.Chart, subFile); break;
+                                default: subfiles.Add(subFile); break;
+                            }
+                            break;
+                        }
+                        case DirectoryInfo subDirectory:
+                        {
+                            subDirectories.Add(subDirectory);
+                            break;
+                        }
                     }
                 }
+            }
+
+            public bool ContainsAudio()
+            {
+                foreach (var subFile in subfiles)
+                {
+                    if (SongMetadata.IniAudioChecker.IsAudioFile(subFile.Name.ToLower()))
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
         }
 
         private sealed class SngCollector
         {
             public readonly SngFile sng;
-            public readonly SongMetadata.IniChartNode?[] charts = new SongMetadata.IniChartNode?[3];
+            public readonly SongMetadata.IniChartNode<string>?[] charts = new SongMetadata.IniChartNode<string>?[3];
 
             public SngCollector(SngFile sng)
             {
                 this.sng = sng;
                 for (int i = 0; i < SongMetadata.IIniMetadata.CHART_FILE_TYPES.Length; ++i)
+                {
                     if (sng.ContainsKey(SongMetadata.IIniMetadata.CHART_FILE_TYPES[i].File))
+                    {
                         charts[i] = SongMetadata.IIniMetadata.CHART_FILE_TYPES[i];
+                    }
+                }
+            }
+
+            public bool ContainsAudio()
+            {
+                foreach (var subFile in sng)
+                {
+                    if (SongMetadata.IniAudioChecker.IsAudioFile(subFile.Key))
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
         }
 
@@ -85,9 +126,26 @@ namespace YARG.Core.Song.Cache
         private void FindNewEntries(bool multithreading)
         {
             _progress.Stage = ScanStage.LoadingSongs;
+            var tracker = new PlaylistTracker(fullDirectoryPlaylists);
             if (multithreading)
             {
-                Parallel.ForEach(iniGroups, group => ScanDirectory_Parallel(group.Directory, group, new PlaylistTracker(fullDirectoryPlaylists)));
+                if (iniGroups.Count > 1)
+                {
+                    var iniTasks = new Task[iniGroups.Count];
+                    for (int i = 0; i < iniGroups.Count; ++i)
+                    {
+                        var group = iniGroups[i];
+                        var dirInfo = new DirectoryInfo(group.Directory);
+                        iniTasks[i] = Task.Run(() => ScanDirectory_Parallel(dirInfo, group, tracker));
+                    }
+                    Task.WaitAll(iniTasks);
+                }
+                else if (iniGroups.Count == 1)
+                {
+                    var group = iniGroups[0];
+                    var dirInfo = new DirectoryInfo(group.Directory);
+                    ScanDirectory_Parallel(dirInfo, group, tracker);
+                }
 
                 var conTasks = new Task[conGroups.Values.Count + extractedConGroups.Values.Count];
                 int con = 0;
@@ -107,7 +165,8 @@ namespace YARG.Core.Song.Cache
             {
                 foreach (var group in iniGroups)
                 {
-                    ScanDirectory(group.Directory, group, new PlaylistTracker(fullDirectoryPlaylists));
+                    var dirInfo = new DirectoryInfo(group.Directory);
+                    ScanDirectory(dirInfo, group, tracker);
                 }
 
                 foreach (var group in conGroups.Values)
@@ -122,12 +181,13 @@ namespace YARG.Core.Song.Cache
             }
         }
 
-        private bool TraversalPreTest(string directory, string defaultPlaylist)
+        private bool TraversalPreTest(DirectoryInfo dirInfo, string defaultPlaylist)
         {
-            if (!FindOrMarkDirectory(directory) || (File.GetAttributes(directory) & FileAttributes.Hidden) != 0)
+            string directory = dirInfo.FullName;
+            if (!FindOrMarkDirectory(dirInfo.FullName) || (dirInfo.Attributes & FileAttributes.Hidden) != 0)
                 return false;
 
-            string filename = Path.GetFileName(directory);
+            string filename = dirInfo.Name;
             if (filename == "songs_updates")
             {
                 FileInfo dta = new(Path.Combine(directory, "songs_updates.dta"));
@@ -157,96 +217,131 @@ namespace YARG.Core.Song.Cache
             }
             return true;
         }
-
-        private bool ScanIniEntry(FileCollector results, IniGroup group, string defaultPlaylist)
+        
+        private void ScanFile(FileInfo file, IniGroup group, ref PlaylistTracker tracker)
         {
-            for (int i = results.ini != null ? 0 : 2; i < 3; ++i)
+            string filename = file.FullName;
+            try
             {
-                var chart = results.charts[i];
-                if (chart != null)
+                // Ensures only fully downloaded unmarked files are processed
+                if (FindOrMarkFile(filename) && (file.Attributes & AbridgedFileInfo.RECALL_ON_DATA_ACCESS) == 0)
                 {
-                    try
+                    if (!AddPossibleCON(file, tracker.Playlist) && (filename.EndsWith(".sng") || filename.EndsWith(".yargsong")))
                     {
-                        var entry = SongMetadata.FromIni(results.directory, chart, results.ini, defaultPlaylist);
-                        if (entry.Item2 != null)
-                        {
-                            if (AddEntry(entry.Item2))
-                                group.AddEntry(entry.Item2);
-                        }
-                        else if (entry.Item1 != ScanResult.LooseChart_NoAudio)
-                            AddToBadSongs(chart.File, entry.Item1);
-                        else
-                            return false;
+                        ScanSngFile(file, group, tracker.Playlist);
                     }
-                    catch (PathTooLongException)
-                    {
-                        YargTrace.LogWarning($"Path {chart.File} is too long for the file system!");
-                        AddToBadSongs(chart.File, ScanResult.PathTooLong);
-                    }
-                    catch (Exception e)
-                    {
-                        YargTrace.LogException(e, $"Error while scanning chart file {chart.File}!");
-                        AddToBadSongs(Path.GetDirectoryName(chart.File), ScanResult.IniEntryCorruption);
-                    }
-                    return true;
                 }
             }
-            return false;
+            catch (PathTooLongException)
+            {
+                YargTrace.LogError($"Path {filename} is too long for the file system!");
+                AddToBadSongs(filename, ScanResult.PathTooLong);
+            }
+            catch (Exception e)
+            {
+                YargTrace.LogException(e, $"Error while scanning file {filename}!");
+            }
         }
 
-        private bool ScanSngFile(string filename, IniGroup group, string defaultPlaylist)
+        private bool ScanIniEntry(FileCollector collector, IniGroup group, string defaultPlaylist)
         {
-            var sngFile = SngFile.TryLoadFromFile(filename);
-            if (sngFile == null)
+            for (int i = collector.ini != null ? 0 : 2; i < 3; ++i)
             {
-                AddToBadSongs(filename, ScanResult.PossibleCorruption);
-                return false;
-            }
-
-            var results = new SngCollector(sngFile);
-            for (int i = sngFile.Metadata.Count != 0 ? 0 : 2; i < 3; ++i)
-            {
-                var chart = results.charts[i];
+                var chart = collector.charts[i];
                 if (chart == null)
                 {
                     continue;
                 }
 
+                if (!collector.ContainsAudio())
+                {
+                    AddToBadSongs(chart.File.FullName, ScanResult.NoAudio);
+                    break;
+                }
+
                 try
                 {
-                    var fileInfo = new AbridgedFileInfo(filename);
-                    var entry = SongMetadata.FromSng(sngFile, fileInfo, chart, defaultPlaylist);
-                    if (entry.Item2 != null)
+                    var entry = SongMetadata.FromIni(collector.directory.FullName, chart, collector.ini, defaultPlaylist);
+                    if (entry.Item2 == null)
                     {
-                        if (AddEntry(entry.Item2))
-                        {
-                            group.AddEntry(entry.Item2);
-                        }
+                        AddToBadSongs(chart.File.FullName, entry.Item1);
                     }
-                    else if (entry.Item1 != ScanResult.LooseChart_NoAudio)
+                    else if (AddEntry(entry.Item2))
                     {
-                        AddToBadSongs(filename, entry.Item1);
+                        group.AddEntry(entry.Item2);
+                    }
+                }
+                catch (PathTooLongException)
+                {
+                    YargTrace.LogError($"Path {chart.File} is too long for the file system!");
+                    AddToBadSongs(chart.File.FullName, ScanResult.PathTooLong);
+                }
+                catch (Exception e)
+                {
+                    YargTrace.LogException(e, $"Error while scanning chart file {chart.File}!");
+                    AddToBadSongs(collector.directory.FullName, ScanResult.IniEntryCorruption);
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private bool ScanSngFile(FileInfo file, IniGroup group, string defaultPlaylist)
+        {
+            var sngFile = SngFile.TryLoadFromFile(file);
+            if (sngFile == null)
+            {
+                AddToBadSongs(file.FullName, ScanResult.PossibleCorruption);
+                return false;
+            }
+
+            var collector = new SngCollector(sngFile);
+            for (int i = sngFile.Metadata.Count > 0 ? 0 : 2; i < 3; ++i)
+            {
+                var chart = collector.charts[i];
+                if (chart == null)
+                {
+                    continue;
+                }
+
+                if (!collector.ContainsAudio())
+                {
+                    AddToBadSongs(file.FullName, ScanResult.NoAudio);
+                    break;
+                }
+
+                try
+                {
+                    var entry = SongMetadata.FromSng(sngFile, chart, defaultPlaylist);
+                    if (entry.Item2 == null)
+                    {
+                        AddToBadSongs(file.FullName, entry.Item1);
+                    }
+                    else if (AddEntry(entry.Item2))
+                    {
+                        group.AddEntry(entry.Item2);
                     }
                 }
                 catch (Exception e)
                 {
-                    YargTrace.LogException(e, $"Error while scanning chart file {chart} within {filename}!");
-                    AddToBadSongs(filename, ScanResult.IniEntryCorruption);
+                    YargTrace.LogException(e, $"Error while scanning chart file {chart} within {file}!");
+                    AddToBadSongs(file.FullName, ScanResult.IniEntryCorruption);
                 }
                 break;
             }
             return true;
         }
 
-        private bool AddPossibleCON(string filename, string defaultPlaylist)
+        private bool AddPossibleCON(FileInfo info, string defaultPlaylist)
         {
-            var result = CONFile.TryLoadFile(filename);
-            if (result == null)
+            var abridged = new AbridgedFileInfo(info);
+            var file = CONFile.TryLoadFile(abridged);
+            if (file == null)
                 return false;
 
-            var group = new PackedCONGroup(result.File, result.Info, defaultPlaylist);
+            var group = new PackedCONGroup(file, info, defaultPlaylist);
             conGroups.Add(group);
-            TryParseUpgrades(filename, group);
+            TryParseUpgrades(info.FullName, group);
             return true;
         }
 

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -227,6 +227,7 @@ namespace YARG.Core.Song.Cache
                     CategorySorter<SortString, SourceConfig>.     Add(entry, cache.Sources);
                     CategorySorter<string,     ArtistAlbumConfig>.Add(entry, cache.ArtistAlbums);
                     CategorySorter<string,     SongLengthConfig>. Add(entry, cache.SongLengths);
+                    CategorySorter<DateTime,   DateAddedConfig>.  Add(entry, cache.DatesAdded);
 
                     foreach (var instrument in instruments)
                         instrument.Add(entry);

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -372,7 +372,7 @@ namespace YARG.Core.Song.Cache
                     FileInfo info = new(Path.Combine(directory, $"{name}_plus.mid"));
                     if (info.Exists)
                     {
-                        var abridged = new AbridgedFileInfo(info);
+                        var abridged = new AbridgedFileInfo(info, false);
                         if (CanAddUpgrade(name, abridged.LastUpdatedTime))
                         {
                             IRBProUpgrade upgrade = new UnpackedRBProUpgrade(abridged);

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -48,7 +48,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 24_01_24_03;
+        public const int CACHE_VERSION = 24_01_29_02;
 
         private static readonly object dirLock = new();
         private static readonly object fileLock = new();

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -115,7 +115,6 @@ namespace YARG.Core.Song.Cache
             {
                 if (!Deserialize_Quick(cacheLocation, multithreading))
                 {
-                    //ToastManager.ToastWarning("Song cache is not present or outdated - performing rescan");
                     return false;
                 }
             }
@@ -126,7 +125,6 @@ namespace YARG.Core.Song.Cache
 
             if (_progress.Count == 0)
             {
-                //ToastManager.ToastWarning("Song cache provided zero songs - performing rescan");
                 return false;
             }
 
@@ -272,6 +270,9 @@ namespace YARG.Core.Song.Cache
                     case ScanResult.IniEntryCorruption:
                         writer.WriteLine("Corruption of either the ini file or chart/mid file");
                         break;
+                    case ScanResult.NoAudio:
+                        writer.WriteLine("No audio accompanying the chart file");
+                        break;
                     case ScanResult.NoName:
                         writer.WriteLine("Name metadata not provided");
                         break;
@@ -295,6 +296,12 @@ namespace YARG.Core.Song.Cache
                         break;
                     case ScanResult.MissingUpgradeMidi:
                         writer.WriteLine("Upgrade Midi file queried for found missing");
+                        break;
+                    case ScanResult.IniNotDownloaded:
+                        writer.WriteLine("Ini file not fully downloaded - try again once it completes");
+                        break;
+                    case ScanResult.ChartNotDownloaded:
+                        writer.WriteLine("Chart file not fully downloaded - try again once it completes");
                         break;
                     case ScanResult.PossibleCorruption:
                         writer.WriteLine("Possible corruption of a queried midi file");

--- a/YARG.Core/Song/Cache/SongCache.cs
+++ b/YARG.Core/Song/Cache/SongCache.cs
@@ -6,6 +6,15 @@ namespace YARG.Core.Song.Cache
     [Serializable]
     public sealed class SongCache
     {
+        private readonly struct DateFlippedComparer : IComparer<DateTime>
+        {
+            public static readonly DateFlippedComparer COMPARER = default;
+            public int Compare(DateTime x, DateTime y)
+            {
+                return y.CompareTo(x);
+            }
+        }
+
         [NonSerialized]
         public readonly Dictionary<HashWrapper, List<SongMetadata>> Entries = new();
 
@@ -15,6 +24,9 @@ namespace YARG.Core.Song.Cache
         public readonly SortedDictionary<string,     List<SongMetadata>> SongLengths  = new();
         [NonSerialized]
         public readonly SortedDictionary<string,     List<SongMetadata>> Instruments  = new();
+        [NonSerialized]
+        public readonly SortedDictionary<DateTime,   List<SongMetadata>> DatesAdded   = new(DateFlippedComparer.COMPARER);
+
         public readonly SortedDictionary<string,     List<SongMetadata>> Titles       = new();
         public readonly SortedDictionary<string,     List<SongMetadata>> Years        = new();
         public readonly SortedDictionary<SortString, List<SongMetadata>> Artists      = new();

--- a/YARG.Core/Song/Cache/SongCategories.cs
+++ b/YARG.Core/Song/Cache/SongCategories.cs
@@ -66,6 +66,16 @@ namespace YARG.Core.Song.Cache
         }
     }
 
+    public readonly struct DateAddedConfig : CategoryConfig<DateTime>
+    {
+        private static readonly EntryComparer _COMPARER = new(SongAttribute.Name);
+        public EntryComparer Comparer => _COMPARER;
+        public DateTime GetKey(SongMetadata entry)
+        {
+            return entry.GetAddTime().Date;
+        }
+    }
+
     public readonly struct ArtistConfig : CategoryConfig<SortString>
     {
         private static readonly EntryComparer _COMPARER = new(SongAttribute.Artist);

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIni.cs
@@ -22,6 +22,7 @@ namespace YARG.Core.Song
 
             public string Root => directory;
             public ChartType Type => chartType;
+            public DateTime LastUpdatedTime => chartFile.LastUpdatedTime;
 
             public UnpackedIniSubmetadata(string directory, ChartType chartType, AbridgedFileInfo chartFile, AbridgedFileInfo? iniFile)
             {

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIniBase.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIniBase.cs
@@ -99,6 +99,7 @@ namespace YARG.Core.Song
 
             public string Root { get; }
             public ChartType Type { get; }
+            public DateTime LastUpdatedTime { get; }
 
             public void Serialize(BinaryWriter writer, string groupDirectory);
             public Stream? GetChartStream();

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIniBase.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongIniBase.cs
@@ -24,12 +24,12 @@ namespace YARG.Core.Song
             Chart,
         };
 
-        public class IniChartNode
+        public class IniChartNode<T>
         {
             public readonly ChartType Type;
-            public readonly string File;
+            public readonly T File;
 
-            public IniChartNode(ChartType type, string file)
+            public IniChartNode(ChartType type, T file)
             {
                 Type = type;
                 File = file;
@@ -70,7 +70,7 @@ namespace YARG.Core.Song
 
         public interface IIniMetadata
         {
-            public static readonly IniChartNode[] CHART_FILE_TYPES =
+            public static readonly IniChartNode<string>[] CHART_FILE_TYPES =
             {
                 new(ChartType.Mid, "notes.mid"),
                 new(ChartType.Midi, "notes.midi"),

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
@@ -38,7 +38,7 @@ namespace YARG.Core.Song
 
                 writer.Write(version);
                 writer.Write(relative);
-                writer.Write(sngInfo.LastWriteTime.ToBinary());
+                writer.Write(sngInfo.LastUpdatedTime.ToBinary());
                 writer.Write((byte) chart.Type);
             }
 

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
@@ -15,12 +15,12 @@ namespace YARG.Core.Song
         {
             private readonly uint version;
             private readonly AbridgedFileInfo sngInfo;
-            private readonly IniChartNode chart;
+            private readonly IniChartNode<string> chart;
 
             public string Root => sngInfo.FullName;
             public ChartType Type => chart.Type;
 
-            public SngSubmetadata(uint version, AbridgedFileInfo sngInfo, IniChartNode chart)
+            public SngSubmetadata(uint version, AbridgedFileInfo sngInfo, IniChartNode<string> chart)
             {
                 this.version = version;
                 this.sngInfo = sngInfo;
@@ -47,7 +47,7 @@ namespace YARG.Core.Song
                 if (!sngInfo.IsStillValid())
                     return null;
 
-                var sngFile = SngFile.TryLoadFromFile(sngInfo.FullName);
+                var sngFile = SngFile.TryLoadFromFile(sngInfo);
                 if (sngFile == null)
                     return null;
 
@@ -58,7 +58,7 @@ namespace YARG.Core.Song
             {
                 Dictionary<SongStem, Stream> streams = new();
 
-                var sngFile = SngFile.TryLoadFromFile(sngInfo.FullName);
+                var sngFile = SngFile.TryLoadFromFile(sngInfo);
                 if (sngFile != null)
                 {
                     foreach (var stem in IniAudioChecker.SupportedStems)
@@ -84,7 +84,7 @@ namespace YARG.Core.Song
 
             public byte[]? GetUnprocessedAlbumArt()
             {
-                var sngFile = SngFile.TryLoadFromFile(sngInfo.FullName);
+                var sngFile = SngFile.TryLoadFromFile(sngInfo);
                 if (sngFile == null)
                     return null;
 
@@ -100,7 +100,7 @@ namespace YARG.Core.Song
 
             public (BackgroundType Type, Stream? Stream) GetBackgroundStream(BackgroundType selections)
             {
-                var sngFile = SngFile.TryLoadFromFile(sngInfo.FullName);
+                var sngFile = SngFile.TryLoadFromFile(sngInfo);
                 if (sngFile == null)
                 {
                     return (default, null);
@@ -147,7 +147,7 @@ namespace YARG.Core.Song
 
             public Stream? GetPreviewAudioStream()
             {
-                var sngFile = SngFile.TryLoadFromFile(sngInfo.FullName);
+                var sngFile = SngFile.TryLoadFromFile(sngInfo);
                 if (sngFile == null)
                     return null;
 
@@ -161,21 +161,10 @@ namespace YARG.Core.Song
 
                 return null;
             }
-
-            public static bool DoesSoloChartHaveAudio(SngFile sng)
-            {
-                foreach (var listing in sng)
-                    if (IniAudioChecker.IsAudioFile(listing.Key))
-                        return true;
-                return false;
-            }
         }
 
-        public static (ScanResult, SongMetadata?) FromSng(SngFile sng, AbridgedFileInfo sngInfo, IniChartNode chart, string defaultPlaylist)
+        public static (ScanResult, SongMetadata?) FromSng(SngFile sng, IniChartNode<string> chart, string defaultPlaylist)
         {
-            if (sng.Metadata.Count == 0 && !SngSubmetadata.DoesSoloChartHaveAudio(sng))
-                return (ScanResult.LooseChart_NoAudio, null);
-
             byte[] file = sng[chart.File].LoadAllBytes(sng);
             var result = ScanIniChartFile(file, chart.Type, sng.Metadata);
             if (result.Item2 == null)
@@ -183,7 +172,7 @@ namespace YARG.Core.Song
                 return (result.Item1, null);
             }
 
-            var packed = new SngSubmetadata(sng.Version, sngInfo, chart);
+            var packed = new SngSubmetadata(sng.Version, sng.Info, chart);
             var metadata = new SongMetadata(packed, result.Item2, HashWrapper.Hash(file), sng.Metadata, defaultPlaylist);
             return (result.Item1, metadata);
         }
@@ -197,7 +186,7 @@ namespace YARG.Core.Song
             if (sngInfo == null)
                 return null;
 
-            var sngFile = SngFile.TryLoadFromFile(sngPath);
+            var sngFile = SngFile.TryLoadFromFile(sngInfo);
             if (sngFile == null || sngFile.Version != version)
             {
                 // TODO: Implement Update-in-place functionality
@@ -208,7 +197,7 @@ namespace YARG.Core.Song
             if (chartTypeIndex >= IIniMetadata.CHART_FILE_TYPES.Length)
                 return null;
 
-            var sngData = new SngSubmetadata(sngFile.Version, sngInfo,IIniMetadata.CHART_FILE_TYPES[chartTypeIndex]);
+            var sngData = new SngSubmetadata(sngFile.Version, sngInfo, IIniMetadata.CHART_FILE_TYPES[chartTypeIndex]);
 
             return new SongMetadata(sngData, reader, strings)
             {

--- a/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
+++ b/YARG.Core/Song/Metadata/Ini/SongMetadata.SongSng.cs
@@ -19,6 +19,7 @@ namespace YARG.Core.Song
 
             public string Root => sngInfo.FullName;
             public ChartType Type => chart.Type;
+            public DateTime LastUpdatedTime => sngInfo.LastUpdatedTime;
 
             public SngSubmetadata(uint version, AbridgedFileInfo sngInfo, IniChartNode<string> chart)
             {

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
@@ -132,14 +132,14 @@ namespace YARG.Core.Song
 
             public Stream? GetMidiStream()
             {
-                if (_midiListing == null || !_midiListing.IsStillValid())
+                if (_midiListing == null || !_midiListing.IsStillValid(LastUpdateTime))
                     return null;
                 return _midiListing.CreateStream();
             }
 
             public byte[]? LoadMidiFile(CONFile? file)
             {
-                if (_midiListing == null || !_midiListing.IsStillValid())
+                if (_midiListing == null || !_midiListing.IsStillValid(LastUpdateTime))
                 {
                     return null;
                 }

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
@@ -62,7 +62,7 @@ namespace YARG.Core.Song
                 AbridgedFileInfo? updateMidi = null;
                 if (reader.ReadBoolean())
                 {
-                    updateMidi = AbridgedFileInfo.TryParseInfo(reader);
+                    updateMidi = AbridgedFileInfo.TryParseInfo(reader, false);
                     if (updateMidi == null)
                     {
                         return null;
@@ -140,21 +140,27 @@ namespace YARG.Core.Song
             public byte[]? LoadMidiFile(CONFile? file)
             {
                 if (_midiListing == null || !_midiListing.IsStillValid())
+                {
                     return null;
+                }
                 return _midiListing.LoadAllBytes(file!);
             }
 
             public byte[]? LoadMiloFile()
             {
                 if (SharedMetadata.Milo != null && SharedMetadata.Milo.Exists())
+                {
                     return File.ReadAllBytes(SharedMetadata.Milo.FullName);
+                }
                 return _miloListing?.LoadAllBytes();
             }
 
             public byte[]? LoadImgFile()
             {
                 if (SharedMetadata.Image != null && SharedMetadata.Image.Exists())
+                {
                     return File.ReadAllBytes(SharedMetadata.Image.FullName);
+                }
                 return _imgListing?.LoadAllBytes();
             }
 

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
@@ -250,7 +250,10 @@ namespace YARG.Core.Song
             {
                 packedMeta.SharedMetadata.Upgrade = upgrade.Item2;
             }
-            return new SongMetadata(packedMeta, reader, strings);
+            return new SongMetadata(packedMeta, reader, strings)
+            {
+                _directory = packedMeta.SharedMetadata.Directory
+            };
         }
 
         public static SongMetadata PackedRBCONFromCache_Quick(CONFile file, string nodename, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
@@ -260,7 +263,10 @@ namespace YARG.Core.Song
             {
                 packedMeta.SharedMetadata.Upgrade = upgrade.Item2;
             }
-            return new SongMetadata(packedMeta, reader, strings);
+            return new SongMetadata(packedMeta, reader, strings)
+            {
+                _directory = packedMeta.SharedMetadata.Directory
+            };
         }
     }
 }

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
 using YARG.Core.Extensions;
@@ -13,190 +12,169 @@ namespace YARG.Core.Song
         [Serializable]
         public sealed class RBPackedCONMetadata : IRBCONMetadata
         {
-            public readonly CONFileListing? midiListing;
-            public readonly CONFileListing? moggListing;
-            public readonly CONFileListing? miloListing;
-            public readonly CONFileListing? imgListing;
-            public readonly RBCONSubMetadata _metadata;
-            public readonly DateTime _midiLastWrite;
+            private readonly CONFileListing? _midiListing;
+            private readonly CONFileListing? _moggListing;
+            private readonly CONFileListing? _miloListing;
+            private readonly CONFileListing? _imgListing;
+            
+            public RBCONSubMetadata SharedMetadata { get; }
 
-            public RBCONSubMetadata SharedMetadata => _metadata;
-
-            public DateTime MidiLastUpdateTime => _midiLastWrite;
+            public DateTime LastUpdateTime { get; }
 
             public RBPackedCONMetadata(PackedCONGroup group, RBCONSubMetadata metadata, string nodeName, string location)
             {
-                _metadata = metadata;
+                SharedMetadata = metadata;
 
                 string midiPath = location + ".mid";
-                midiListing = group.CONFile.TryGetListing(midiPath);
-                if (midiListing == null)
+                _midiListing = group.CONFile.TryGetListing(midiPath);
+                if (_midiListing == null)
                     throw new Exception($"Required midi file '{midiPath}' was not located");
-                _midiLastWrite = midiListing.lastWrite;
+                LastUpdateTime = _midiListing.lastWrite;
 
-                string midiDirectory = group.CONFile.Listings[midiListing.pathIndex].Filename;
-
-                moggListing = group.CONFile.TryGetListing(location + ".mogg");
-
+                _moggListing = group.CONFile.TryGetListing(location + ".mogg");
+                
                 if (!location.StartsWith($"songs/{nodeName}"))
-                    nodeName = midiDirectory.Split('/')[1];
+                    nodeName = _midiListing.Filename.Split('/')[1];
 
-                string genPAth = $"songs/{nodeName}/gen/{nodeName}";
-                miloListing = group.CONFile.TryGetListing(genPAth + ".milo_xbox");
-                imgListing = group.CONFile.TryGetListing(genPAth + "_keep.png_xbox");
+                string genPath = $"songs/{nodeName}/gen/{nodeName}";
+                _miloListing = group.CONFile.TryGetListing(genPath + ".milo_xbox");
+                _imgListing = group.CONFile.TryGetListing(genPath + "_keep.png_xbox");
 
+                string midiDirectory = group.CONFile.Listings[_midiListing.pathIndex].Filename;
                 metadata.Directory = Path.Combine(group.Location, midiDirectory);
             }
 
-            public RBPackedCONMetadata(CONFile file, string nodeName, CONFileListing? midi, DateTime midiLastWrite, CONFileListing? moggListing, AbridgedFileInfo? moggInfo, AbridgedFileInfo? updateInfo, YARGBinaryReader reader)
+            public static RBPackedCONMetadata? TryLoadFromCache(CONFile file, string nodename, YARGBinaryReader reader)
             {
-                midiListing = midi;
-                _midiLastWrite = midiLastWrite;
+                string midiFilename = reader.ReadLEBString();
+                var midiListing = file.TryGetListing(midiFilename);
+                if (midiListing == null)
+                {
+                    return null;
+                }
 
-                if (moggListing != null)
-                    this.moggListing = moggListing;
+                var midiLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
+                if (midiListing.lastWrite != midiLastWrite)
+                {
+                    return null;
+                }
 
-                if (midiListing != null && !midiListing.Filename.StartsWith($"songs/{nodeName}"))
-                    nodeName = file.Listings[midiListing.pathIndex].Filename.Split('/')[1];
-
-                string genPAth = $"songs/{nodeName}/gen/{nodeName}";
-
-                AbridgedFileInfo? miloInfo = null;
+                AbridgedFileInfo? updateMidi = null;
                 if (reader.ReadBoolean())
                 {
-                    miloListing = file.TryGetListing(genPAth + ".milo_xbox");
-                }
-                else
-                {
-                    string milopath = reader.ReadLEBString();
-                    if (milopath.Length > 0)
+                    updateMidi = AbridgedFileInfo.TryParseInfo(reader);
+                    if (updateMidi == null)
                     {
-                        var info = new FileInfo(milopath);
-                        if (info.Exists)
-                        {
-                            miloInfo = new AbridgedFileInfo(info);
-                        }
+                        return null;
                     }
                 }
 
-                AbridgedFileInfo? imageInfo = null;
-                if (reader.ReadBoolean())
-                {
-                    imgListing = file.TryGetListing(genPAth + "_keep.png_xbox");
-                }
-                else
-                {
-                    string imgpath = reader.ReadLEBString();
-                    if (imgpath != string.Empty)
-                    {
-                        var info = new FileInfo(imgpath);
-                        if (info.Exists)
-                        {
-                            imageInfo = new AbridgedFileInfo(info);
-                        }
-                    }
-                }
+                var moggListing = file.TryGetListing(Path.ChangeExtension(midiFilename, ".mogg"));
 
-                _metadata = new RBCONSubMetadata(reader)
-                {
-                    Mogg = moggInfo,
-                    UpdateMidi = updateInfo,
-                    Milo = miloInfo,
-                    Image = imageInfo,
-                };
+                if (!midiFilename.StartsWith($"songs/{nodename}"))
+                    nodename = midiFilename.Split('/')[1];
+
+                string genPath = $"songs/{nodename}/gen/{nodename}";
+                var miloListing = file.TryGetListing(genPath + ".milo_xbox");
+                var imgListing = file.TryGetListing(genPath + "_keep.png_xbox");
+
+                var baseMetadata = new RBCONSubMetadata(updateMidi, reader);
+                return new RBPackedCONMetadata(midiListing, midiLastWrite, moggListing, miloListing, imgListing, baseMetadata);
+            }
+
+            public static RBPackedCONMetadata LoadFromCache_Quick(CONFile file, string nodename, YARGBinaryReader reader)
+            {
+                string midiFilename = reader.ReadLEBString();
+                var midiListing = file.TryGetListing(midiFilename);
+                var midiLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
+
+                var updateMidi = reader.ReadBoolean() ? new AbridgedFileInfo(reader) : null;
+
+                var moggListing = file.TryGetListing(Path.ChangeExtension(midiFilename, ".mogg"));
+
+                if (!midiFilename.StartsWith($"songs/{nodename}"))
+                    nodename = midiFilename.Split('/')[1];
+
+                string genPath = $"songs/{nodename}/gen/{nodename}";
+                var miloListing = file.TryGetListing(genPath + ".milo_xbox");
+                var imgListing = file.TryGetListing(genPath + "_keep.png_xbox");
+
+                var baseMetadata = new RBCONSubMetadata(updateMidi, reader);
+                return new RBPackedCONMetadata(midiListing, midiLastWrite, moggListing, miloListing, imgListing, baseMetadata);
+            }
+
+            private RBPackedCONMetadata(CONFileListing? midi, DateTime midiLastWrite, CONFileListing? moggListing, CONFileListing? miloListing, CONFileListing? imgListing, RBCONSubMetadata baseMetadata)
+            {
+                _midiListing = midi;
+                _moggListing = moggListing;
+                _miloListing = miloListing;
+                _imgListing = imgListing;
+                
+                SharedMetadata = baseMetadata;
+                LastUpdateTime = midiLastWrite;
             }
 
             public void Serialize(BinaryWriter writer)
             {
-                writer.Write(midiListing!.Filename);
-                writer.Write(_midiLastWrite.ToBinary());
+                writer.Write(_midiListing!.Filename);
+                writer.Write(_midiListing.lastWrite.ToBinary());
 
-                if (_metadata.Mogg == null)
+                if (SharedMetadata.UpdateMidi != null)
                 {
                     writer.Write(true);
-                    writer.Write(moggListing!.Filename);
-                    writer.Write(moggListing.lastWrite.ToBinary());
-                }
-                else
-                {
-                    writer.Write(false);
-                    _metadata.Mogg.Serialize(writer);
-                }
-
-                if (_metadata.UpdateMidi != null)
-                {
-                    writer.Write(true);
-                    _metadata.UpdateMidi.Serialize(writer);
+                    SharedMetadata.UpdateMidi.Serialize(writer);
                 }
                 else
                     writer.Write(false);
 
-                if (_metadata.Milo != null)
-                {
-                    writer.Write(false);
-                    writer.Write(_metadata.Milo.FullName);
-                }
-                else
-                    writer.Write(true);
-
-                if (_metadata.Image != null)
-                {
-                    writer.Write(false);
-                    writer.Write(_metadata.Image.FullName);
-                }
-                else
-                    writer.Write(true);
-
-                _metadata.Serialize(writer);
+                SharedMetadata.Serialize(writer);
             }
 
             public Stream? GetMidiStream()
             {
-                if (midiListing == null || !midiListing.IsStillValid())
+                if (_midiListing == null || !_midiListing.IsStillValid())
                     return null;
-                return midiListing.CreateStream();
+                return _midiListing.CreateStream();
             }
 
             public byte[]? LoadMidiFile(CONFile? file)
             {
-                if (midiListing == null || !midiListing.IsStillValid())
+                if (_midiListing == null || !_midiListing.IsStillValid())
                     return null;
-                return midiListing.LoadAllBytes(file!);
+                return _midiListing.LoadAllBytes(file!);
             }
 
             public byte[]? LoadMiloFile()
             {
-                if (_metadata.Milo != null && File.Exists(_metadata.Milo.FullName))
-                    return File.ReadAllBytes(_metadata.Milo.FullName);
-                return miloListing?.LoadAllBytes();
+                if (SharedMetadata.Milo != null && SharedMetadata.Milo.Exists())
+                    return File.ReadAllBytes(SharedMetadata.Milo.FullName);
+                return _miloListing?.LoadAllBytes();
             }
 
             public byte[]? LoadImgFile()
             {
-                if (_metadata.Image != null && File.Exists(_metadata.Image.FullName))
-                    return File.ReadAllBytes(_metadata.Image.FullName);
-                return imgListing?.LoadAllBytes();
+                if (SharedMetadata.Image != null && SharedMetadata.Image.Exists())
+                    return File.ReadAllBytes(SharedMetadata.Image.FullName);
+                return _imgListing?.LoadAllBytes();
             }
 
             public Stream? GetMoggStream()
             {
-                var stream = _metadata.GetMoggStream();
+                var stream = SharedMetadata.GetMoggStream();
                 if (stream != null)
                     return stream;
-                return moggListing?.CreateStream();
+                return _moggListing?.CreateStream();
             }
 
             public bool IsMoggValid(CONFile? file)
             {
-                using var stream = _metadata.GetMoggStream();
+                using var stream = SharedMetadata.GetMoggStream();
                 if (stream != null)
                 {
                     int version = stream.Read<int>(Endianness.Little);
                     return version == 0x0A || version == 0xf0;
                 }
-                else if (moggListing != null)
-                    return CONFileListing.GetMoggVersion(moggListing, file!) == 0x0A;
-                return false;
+                return _moggListing != null && CONFileListing.GetMoggVersion(_moggListing, file!) == 0x0A;
             }
         }
 
@@ -234,78 +212,25 @@ namespace YARG.Core.Song
             }
         }
 
-        public static SongMetadata? PackedRBCONFromCache(CONFile file, string nodeName, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
+        public static SongMetadata? PackedRBCONFromCache(CONFile file, string nodename, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
-            var midiListing = file.TryGetListing(reader.ReadLEBString());
-            if (midiListing == null)
+            var packedMeta = RBPackedCONMetadata.TryLoadFromCache(file, nodename, reader);
+            if (packedMeta == null)
             {
                 return null;
             }
 
-            var midiLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
-            if (midiListing.lastWrite != midiLastWrite)
-            {
-                return null;
-            }
-
-            CONFileListing? moggListing = null;
-            AbridgedFileInfo? moggInfo = null;
-            if (reader.ReadBoolean())
-            {
-                moggListing = file.TryGetListing(reader.ReadLEBString());
-                if (moggListing == null || moggListing.lastWrite != DateTime.FromBinary(reader.Read<long>(Endianness.Little)))
-                {
-                    return null;
-                }
-            }
-            else
-            {
-                moggInfo = AbridgedFileInfo.TryParseInfo(reader);
-                if (moggInfo == null)
-                {
-                    return null;
-                }
-            }
-
-            AbridgedFileInfo? updateInfo = null;
-            if (reader.ReadBoolean())
-            {
-                updateInfo = AbridgedFileInfo.TryParseInfo(reader);
-                if (updateInfo == null)
-                {
-                    return null;
-                }
-            }
-
-            RBPackedCONMetadata packedMeta = new(file, nodeName, midiListing, midiLastWrite, moggListing, moggInfo, updateInfo, reader);
-            if (upgrades.TryGetValue(nodeName, out var upgrade))
+            if (upgrades.TryGetValue(nodename, out var upgrade))
             {
                 packedMeta.SharedMetadata.Upgrade = upgrade.Item2;
             }
             return new SongMetadata(packedMeta, reader, strings);
         }
 
-        public static SongMetadata PackedRBCONFromCache_Quick(CONFile file, string nodeName, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
+        public static SongMetadata PackedRBCONFromCache_Quick(CONFile file, string nodename, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, YARGBinaryReader reader, CategoryCacheStrings strings)
         {
-            var midiListing = file.TryGetListing(reader.ReadLEBString());
-            var midiLastWrite = DateTime.FromBinary(reader.Read<long>(Endianness.Little));
-
-            CONFileListing? moggListing = null;
-            AbridgedFileInfo? moggInfo = null;
-            if (reader.ReadBoolean())
-            {
-                moggListing = file.TryGetListing(reader.ReadLEBString());
-                reader.Move(SIZEOF_DATETIME);
-            }
-            else
-            {
-                moggInfo = new AbridgedFileInfo(reader);
-            }
-
-            var updateInfo = reader.ReadBoolean() ? new AbridgedFileInfo(reader) : null;
-
-            RBPackedCONMetadata packedMeta = new(file, nodeName, midiListing, midiLastWrite, moggListing, moggInfo, updateInfo, reader);
-            if (upgrades.TryGetValue(nodeName, out var upgrade))
+            var packedMeta = RBPackedCONMetadata.LoadFromCache_Quick(file, nodename, reader);
+            if (upgrades.TryGetValue(nodename, out var upgrade))
             {
                 packedMeta.SharedMetadata.Upgrade = upgrade.Item2;
             }

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -149,7 +149,7 @@ namespace YARG.Core.Song
                 {
                     return null;
                 }
-                return new AbridgedFileInfo(reader.ReadLEBString());
+                return new AbridgedFileInfo(reader.ReadLEBString(), false);
             }
 
             private static int[] ReadIntArray(YARGBinaryReader reader)
@@ -212,7 +212,7 @@ namespace YARG.Core.Song
                     var updateInfo = new FileInfo(path);
                     if (updateInfo.Exists)
                     {
-                        var abridged = new AbridgedFileInfo(updateInfo);
+                        var abridged = new AbridgedFileInfo(updateInfo, false);
                         if (UpdateMidi == null || abridged.LastUpdatedTime > UpdateMidi.LastUpdatedTime)
                         {
                             UpdateMidi = abridged;
@@ -225,7 +225,7 @@ namespace YARG.Core.Song
                 var moggInfo = new FileInfo(Path.Combine(dir, $"{nodeName}_update.mogg"));
                 if (moggInfo.Exists)
                 {
-                    var abridged = new AbridgedFileInfo(moggInfo);
+                    var abridged = new AbridgedFileInfo(moggInfo, false);
                     if (Mogg == null || abridged.LastUpdatedTime > Mogg.LastUpdatedTime)
                     {
                         Mogg = abridged;
@@ -236,7 +236,7 @@ namespace YARG.Core.Song
                 var miloInfo = new FileInfo(Path.Combine(dir, $"{nodeName}.milo_xbox"));
                 if (miloInfo.Exists)
                 {
-                    var abridged = new AbridgedFileInfo(miloInfo);
+                    var abridged = new AbridgedFileInfo(miloInfo, false);
                     if (Milo == null || abridged.LastUpdatedTime > Milo.LastUpdatedTime)
                     {
                         Milo = abridged;
@@ -248,7 +248,7 @@ namespace YARG.Core.Song
                     var imageInfo = new FileInfo(Path.Combine(dir, $"{nodeName}_keep.png_xbox"));
                     if (imageInfo.Exists)
                     {
-                        var abridged = new AbridgedFileInfo(imageInfo);
+                        var abridged = new AbridgedFileInfo(imageInfo, false);
                         if (Image == null || abridged.LastUpdatedTime > Image.LastUpdatedTime)
                         {
                             Image = abridged;
@@ -259,7 +259,7 @@ namespace YARG.Core.Song
 
             public byte[]? LoadMidiUpdateFile()
             {
-                if (UpdateMidi == null || !UpdateMidi.IsStillValid())
+                if (UpdateMidi == null || !UpdateMidi.IsStillValid(false))
                 {
                     return null;
                 }

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -284,7 +284,7 @@ namespace YARG.Core.Song
         public interface IRBCONMetadata
         {
             public RBCONSubMetadata SharedMetadata { get; }
-            public DateTime LastUpdateTime { get; }
+            public DateTime GetAbsoluteLastUpdateTime();
             public Stream? GetMidiStream();
             public byte[]? LoadMidiFile(CONFile? file);
             public byte[]? LoadMiloFile();

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
@@ -108,6 +108,27 @@ namespace YARG.Core.Song
                 SharedMetadata.Serialize(writer);
             }
 
+            public DateTime GetAbsoluteLastUpdateTime()
+            {
+                var lastUpdateTime = _midi.LastUpdatedTime;
+                if (SharedMetadata.UpdateMidi != null)
+                {
+                    if (SharedMetadata.UpdateMidi.LastUpdatedTime > lastUpdateTime)
+                    {
+                        lastUpdateTime = SharedMetadata.UpdateMidi.LastUpdatedTime;
+                    }
+                }
+
+                if (SharedMetadata.Upgrade != null)
+                {
+                    if (SharedMetadata.Upgrade.LastUpdatedTime > lastUpdateTime)
+                    {
+                        lastUpdateTime = SharedMetadata.Upgrade.LastUpdatedTime;
+                    }
+                }
+                return lastUpdateTime;
+            }
+
             public Stream? GetMidiStream()
             {
                 if (_dta == null || !_dta.IsStillValid() || !_midi.IsStillValid())

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
@@ -56,7 +56,7 @@ namespace YARG.Core.Song
                 AbridgedFileInfo? updateMidi = null;
                 if (reader.ReadBoolean())
                 {
-                    updateMidi = AbridgedFileInfo.TryParseInfo(reader);
+                    updateMidi = AbridgedFileInfo.TryParseInfo(reader, false);
                     if (updateMidi == null)
                     {
                         return null;

--- a/YARG.Core/Song/Metadata/SongMetadata.Sorting.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Sorting.cs
@@ -16,6 +16,7 @@ namespace YARG.Core.Song
         Playlist,
         Source,
         SongLength,
+        DateAdded,
         Instrument,
     };
 
@@ -32,6 +33,11 @@ namespace YARG.Core.Song
                 strCmp = Directory.CompareTo(other.Directory);
             }
             return strCmp;
+        }
+
+        public DateTime GetAddTime()
+        {
+            return _iniData != null ? _iniData.LastUpdatedTime : _rbData!.GetAbsoluteLastUpdateTime();
         }
 
         private enum EntryType

--- a/YARG.Core/Song/Metadata/SongMetadata.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.cs
@@ -9,6 +9,8 @@ namespace YARG.Core.Song
         Success,
         DirectoryError,
         IniEntryCorruption,
+        IniNotDownloaded,
+        ChartNotDownloaded,
         NoName,
         NoNotes,
         DTAError,
@@ -20,7 +22,7 @@ namespace YARG.Core.Song
         PossibleCorruption,
         FailedSngLoad,
 
-        LooseChart_NoAudio,
+        NoAudio,
         PathTooLong,
         MultipleMidiTrackNames,
         MultipleMidiTrackNames_Update,

--- a/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
+++ b/YARG.Core/Song/Metadata/Types/RBProUpgrade.cs
@@ -8,7 +8,7 @@ namespace YARG.Core.Song
 {
     public interface IRBProUpgrade
     {
-        public DateTime LastWrite { get; }
+        public DateTime LastUpdatedTime { get; }
         public void WriteToCache(BinaryWriter writer);
         public Stream? GetUpgradeMidiStream();
         public byte[]? LoadUpgradeMidi();
@@ -18,32 +18,36 @@ namespace YARG.Core.Song
     public sealed class PackedRBProUpgrade : IRBProUpgrade
     {
         private readonly CONFileListing? _midiListing;
-        private readonly DateTime _lastWrite;
+        private readonly DateTime _lastUpdatedTime;
 
-        public DateTime LastWrite => _lastWrite;
+        public DateTime LastUpdatedTime => _lastUpdatedTime;
 
         public PackedRBProUpgrade(CONFileListing? listing, DateTime lastWrite)
         {
             _midiListing = listing;
-            _lastWrite = listing != null ? listing.lastWrite : lastWrite;
+            _lastUpdatedTime = listing?.lastWrite ?? lastWrite;
         }
 
         public void WriteToCache(BinaryWriter writer)
         {
-            writer.Write(_lastWrite.ToBinary());
+            writer.Write(_lastUpdatedTime.ToBinary());
         }
 
         public Stream? GetUpgradeMidiStream()
         {
             if (_midiListing == null || !_midiListing.ConFile.IsStillValid())
+            {
                 return null;
+            }
             return _midiListing.CreateStream();
         }
 
         public byte[]? LoadUpgradeMidi()
         {
             if (_midiListing == null || !_midiListing.ConFile.IsStillValid())
+            {
                 return null;
+            }
             return _midiListing.LoadAllBytes();
         }
     }
@@ -53,16 +57,16 @@ namespace YARG.Core.Song
     {
         private AbridgedFileInfo _midiFile;
         public AbridgedFileInfo Midi => _midiFile;
-        public DateTime LastWrite => _midiFile.LastWriteTime;
+        public DateTime LastUpdatedTime => _midiFile.LastUpdatedTime;
 
-        public UnpackedRBProUpgrade(string filename, DateTime lastWrite)
+        public UnpackedRBProUpgrade(AbridgedFileInfo info)
         {
-            _midiFile = new(filename, lastWrite);
+            _midiFile = info;
         }
 
         public void WriteToCache(BinaryWriter writer)
         {
-            writer.Write(_midiFile.LastWriteTime.ToBinary());
+            writer.Write(_midiFile.LastUpdatedTime.ToBinary());
         }
 
         public Stream? GetUpgradeMidiStream()


### PR DESCRIPTION
+ Adds checks to ignore scanning files that are not fully downloaded to a user's OS. Should solve the issue of hanging when reading songs from repositories like OneDrive.

+ Slightly improved performance through using DirectoryInfo & FileInfo queries during directory traversal instead of just string filenames.

+ Change ini entry behavior through fully ignoring new entries that don't have any audio files accompanying them (though the scanner will communicate those situations in badsongs.txt).

+ Other algorithmic adjustments.

+ Take into account the "added to OS" DateTime of a file when setting up AbridgedFileInfo. This made DateAdded sorting now possible.

+ Added a `TimeAdded` category. Requires a main repo update to take advantage of it.

+ Refactors and certain simplifications of the RBCON metadata types