### PR TITLE
Add interfaces to standardise writing/reading to a data source

### DIFF
--- a/YARG.Core/Engine/BaseEngineParameters.cs
+++ b/YARG.Core/Engine/BaseEngineParameters.cs
@@ -33,7 +33,7 @@ namespace YARG.Core.Engine
             HitWindow = hitWindow;
         }
 
-        public virtual void Serialize(BinaryWriter writer)
+        public virtual void Serialize(IBinaryDataWriter writer)
         {
             HitWindow.Serialize(writer);
 
@@ -47,7 +47,7 @@ namespace YARG.Core.Engine
             }
         }
 
-        public virtual void Deserialize(BinaryReader reader, int version = 0)
+        public virtual void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             // Since "HitWindow" is a property and returns
             // a "temporary value," we gotta do this.

--- a/YARG.Core/Engine/BaseStats.cs
+++ b/YARG.Core/Engine/BaseStats.cs
@@ -163,7 +163,7 @@ namespace YARG.Core.Engine
             Stars = 0;
         }
 
-        public virtual void Serialize(BinaryWriter writer)
+        public virtual void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(CommittedScore);
             writer.Write(PendingScore);
@@ -188,7 +188,7 @@ namespace YARG.Core.Engine
             // writer.Write(Stars);
         }
 
-        public virtual void Deserialize(BinaryReader reader, int version = 0)
+        public virtual void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             CommittedScore = reader.ReadInt32();
             PendingScore = reader.ReadInt32();

--- a/YARG.Core/Engine/Drums/DrumsEngineParameters.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngineParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Drums
 {
@@ -27,14 +28,14 @@ namespace YARG.Core.Engine.Drums
             Mode = mode;
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
             writer.Write((byte) Mode);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/Guitar/GuitarEngineParameters.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Guitar
 {
@@ -34,7 +35,7 @@ namespace YARG.Core.Engine.Guitar
             AntiGhosting = antiGhosting;
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
@@ -49,7 +50,7 @@ namespace YARG.Core.Engine.Guitar
             writer.Write(AntiGhosting);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/Guitar/GuitarStats.cs
+++ b/YARG.Core/Engine/Guitar/GuitarStats.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Guitar
 {
@@ -45,7 +46,7 @@ namespace YARG.Core.Engine.Guitar
             StarPowerWhammyGain = 0;
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
@@ -55,7 +56,7 @@ namespace YARG.Core.Engine.Guitar
             writer.Write(StarPowerWhammyGain);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/HitWindowSettings.cs
+++ b/YARG.Core/Engine/HitWindowSettings.cs
@@ -144,7 +144,7 @@ namespace YARG.Core.Engine
             }
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(MaxWindow);
             writer.Write(MinWindow);
@@ -152,7 +152,7 @@ namespace YARG.Core.Engine
             writer.Write(FrontToBackRatio);
         }
 
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             MaxWindow = reader.ReadDouble();
             MinWindow = reader.ReadDouble();

--- a/YARG.Core/Engine/Logging/BaseEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/BaseEngineEvent.cs
@@ -16,13 +16,13 @@ namespace YARG.Core.Engine.Logging
             EventTime = eventTime;
         }
 
-        public virtual void Serialize(BinaryWriter writer)
+        public virtual void Serialize(IBinaryDataWriter writer)
         {
             writer.Write((int) EventType);
             writer.Write(EventTime);
         }
 
-        public virtual void Deserialize(BinaryReader reader, int version = 0)
+        public virtual void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             // Don't deserialize event type as it's done manually to determine object type
 

--- a/YARG.Core/Engine/Logging/EngineEventLogger.cs
+++ b/YARG.Core/Engine/Logging/EngineEventLogger.cs
@@ -20,7 +20,7 @@ namespace YARG.Core.Engine.Logging
             _events.Clear();
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(_events.Count);
             foreach (var engineEvent in _events)
@@ -29,7 +29,7 @@ namespace YARG.Core.Engine.Logging
             }
         }
 
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             int count = reader.ReadInt32();
             for (int i = 0; i < count; i++)

--- a/YARG.Core/Engine/Logging/NoteEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/NoteEngineEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Logging
 {
@@ -17,7 +18,7 @@ namespace YARG.Core.Engine.Logging
         {
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
@@ -31,7 +32,7 @@ namespace YARG.Core.Engine.Logging
             writer.Write(WasSkipped);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/Logging/ScoreEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/ScoreEngineEvent.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Logging
 {
@@ -10,14 +11,14 @@ namespace YARG.Core.Engine.Logging
         {
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
             writer.Write(Score);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/Logging/StarPowerEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/StarPowerEngineEvent.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Logging
 {
@@ -10,14 +11,14 @@ namespace YARG.Core.Engine.Logging
         {
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
             writer.Write(IsActive);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/Logging/TimerEngineEvent.cs
+++ b/YARG.Core/Engine/Logging/TimerEngineEvent.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Logging
 {
@@ -17,7 +18,7 @@ namespace YARG.Core.Engine.Logging
         {
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
@@ -28,7 +29,7 @@ namespace YARG.Core.Engine.Logging
             writer.Write(TimerExpired);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Vocals
 {
@@ -32,7 +33,7 @@ namespace YARG.Core.Engine.Vocals
             SingToActivateStarPower = singToActivateStarPower;
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
@@ -41,7 +42,7 @@ namespace YARG.Core.Engine.Vocals
             writer.Write(SingToActivateStarPower);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Engine/Vocals/VocalsStats.cs
+++ b/YARG.Core/Engine/Vocals/VocalsStats.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine.Vocals
 {
@@ -31,7 +32,7 @@ namespace YARG.Core.Engine.Vocals
             VocalTicksMissed = 0;
         }
 
-        public override void Serialize(BinaryWriter writer)
+        public override void Serialize(IBinaryDataWriter writer)
         {
             base.Serialize(writer);
 
@@ -39,7 +40,7 @@ namespace YARG.Core.Engine.Vocals
             writer.Write(VocalTicksMissed);
         }
 
-        public override void Deserialize(BinaryReader reader, int version = 0)
+        public override void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             base.Deserialize(reader, version);
 

--- a/YARG.Core/Extensions/BinaryReaderWriterExtensions.cs
+++ b/YARG.Core/Extensions/BinaryReaderWriterExtensions.cs
@@ -1,23 +1,24 @@
 using System;
 using System.Drawing;
 using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Extensions
 {
     public static class BinaryWriterExtensions
     {
-        public static void Write(this BinaryWriter writer, Color color)
+        public static void Write(this IBinaryDataWriter writer, Color color)
         {
             writer.Write(color.ToArgb());
         }
 
-        public static Color ReadColor(this BinaryReader reader)
+        public static Color ReadColor(this IBinaryDataReader reader)
         {
             int argb = reader.ReadInt32();
             return Color.FromArgb(argb);
         }
 
-        public static void Write(this BinaryWriter writer, Guid guid)
+        public static void Write(this IBinaryDataWriter writer, Guid guid)
         {
             Span<byte> span = stackalloc byte[16];
             if (!guid.TryWriteBytes(span))
@@ -28,7 +29,7 @@ namespace YARG.Core.Extensions
             writer.Write(span);
         }
 
-        public static Guid ReadGuid(this BinaryReader reader)
+        public static Guid ReadGuid(this IBinaryDataReader reader)
         {
             Span<byte> span = stackalloc byte[16];
             if (reader.Read(span) != span.Length)

--- a/YARG.Core/Extensions/StreamExtensions.cs
+++ b/YARG.Core/Extensions/StreamExtensions.cs
@@ -50,7 +50,7 @@ namespace YARG.Core.Extensions
             }
         }
 
-        private static unsafe void CorrectByteOrder<TType>(byte* bytes, Endianness endianness)
+        public static unsafe void CorrectByteOrder<TType>(byte* bytes, Endianness endianness)
             where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
         {
             // Have to flip bits if the OS uses the opposite Endian

--- a/YARG.Core/Extensions/StreamExtensions.cs
+++ b/YARG.Core/Extensions/StreamExtensions.cs
@@ -23,6 +23,17 @@ namespace YARG.Core.Extensions
             return value;
         }
 
+        public static void Write<TType>(this Stream stream, TType value, Endianness endianness)
+            where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
+        {
+            unsafe
+            {
+                byte* buffer = (byte*) &value;
+                CorrectByteOrder<TType>(buffer, endianness);
+                stream.Write(new Span<byte>(buffer, sizeof(TType)));
+            }
+        }
+
         public static bool ReadBoolean(this Stream stream)
         {
             byte b = (byte)stream.ReadByte();
@@ -37,17 +48,6 @@ namespace YARG.Core.Extensions
                 throw new EndOfStreamException($"Not enough data in the stream to read {length} bytes!");
             }
             return buffer;
-        }
-
-        public static void Write<TType>(this Stream stream, TType value, Endianness endianness)
-            where TType : unmanaged, IComparable, IComparable<TType>, IConvertible, IEquatable<TType>, IFormattable
-        {
-            unsafe
-            {
-                byte* buffer = (byte*) &value;
-                CorrectByteOrder<TType>(buffer, endianness);
-                stream.Write(new Span<byte>(buffer, sizeof(TType)));
-            }
         }
 
         public static unsafe void CorrectByteOrder<TType>(byte* bytes, Endianness endianness)

--- a/YARG.Core/Game/Presets/ColorProfile.FiveFretGuitar.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FiveFretGuitar.cs
@@ -150,7 +150,7 @@ namespace YARG.Core.Game
                 return (FiveFretGuitarColors) MemberwiseClone();
             }
 
-            public void Serialize(BinaryWriter writer)
+            public void Serialize(IBinaryDataWriter writer)
             {
                 writer.Write(OpenFret);
                 writer.Write(GreenFret);
@@ -188,7 +188,7 @@ namespace YARG.Core.Game
                 writer.Write(OrangeNoteStarPower);
             }
 
-            public void Deserialize(BinaryReader reader, int version = 0)
+            public void Deserialize(IBinaryDataReader reader, int version = 0)
             {
                 OpenFret = reader.ReadColor();
                 GreenFret = reader.ReadColor();

--- a/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
@@ -158,7 +158,7 @@ namespace YARG.Core.Game
                 return (FiveLaneDrumsColors) MemberwiseClone();
             }
 
-            public void Serialize(BinaryWriter writer)
+            public void Serialize(IBinaryDataWriter writer)
             {
                 writer.Write(KickFret);
                 writer.Write(RedFret);
@@ -198,7 +198,7 @@ namespace YARG.Core.Game
                 writer.Write(ActivationNote);
             }
 
-            public void Deserialize(BinaryReader reader, int version = 0)
+            public void Deserialize(IBinaryDataReader reader, int version = 0)
             {
                 KickFret = reader.ReadColor();
                 RedFret = reader.ReadColor();

--- a/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
@@ -164,7 +164,7 @@ namespace YARG.Core.Game
                 return (FourLaneDrumsColors) MemberwiseClone();
             }
 
-            public void Serialize(BinaryWriter writer)
+            public void Serialize(IBinaryDataWriter writer)
             {
                 writer.Write(KickFret);
                 writer.Write(RedFret);
@@ -207,7 +207,7 @@ namespace YARG.Core.Game
                 writer.Write(ActivationNote);
             }
 
-            public void Deserialize(BinaryReader reader, int version = 0)
+            public void Deserialize(IBinaryDataReader reader, int version = 0)
             {
                 KickFret = reader.ReadColor();
                 RedFret = reader.ReadColor();

--- a/YARG.Core/Game/Presets/ColorProfile.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.cs
@@ -44,7 +44,7 @@ namespace YARG.Core.Game
             };
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(Version);
             writer.Write(Name);
@@ -54,7 +54,7 @@ namespace YARG.Core.Game
             FiveLaneDrums.Serialize(writer);
         }
 
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             version = reader.ReadInt32();
             Name = reader.ReadString();

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -48,7 +48,7 @@ namespace YARG.Core.Game
 
         /// <summary>
         /// The difficulty to be saved in the profile.
-        /// 
+        ///
         /// If a song does not contain this difficulty, so long as the player
         /// does not *explicitly* and *manually* change the difficulty, this value
         /// should remain unchanged.
@@ -173,7 +173,7 @@ namespace YARG.Core.Game
         }
 
         // For replay serialization
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(PROFILE_VERSION);
 
@@ -195,7 +195,7 @@ namespace YARG.Core.Game
             writer.Write(LeftyFlip);
         }
 
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             version = reader.ReadInt32();
 

--- a/YARG.Core/IO/CharacterCodes.cs
+++ b/YARG.Core/IO/CharacterCodes.cs
@@ -37,19 +37,12 @@ namespace YARG.Core.IO
         }
 
         public static FourCC Read(Stream stream) => new(stream.Read<uint>(Endianness.Big));
-        public static FourCC Read(BinaryReader reader) => new(reader.BaseStream.Read<uint>(Endianness.Big));
+        public static FourCC Read(IBinaryDataReader reader) => new(reader.Read<uint>(Endianness.Big));
         public static FourCC Read(YARGBinaryReader reader) => new(reader.Read<uint>(Endianness.Big));
 
         public void Serialize(IBinaryDataWriter writer)
         {
-            uint code = _code;
-            unsafe
-            {
-                byte* pCode = (byte*) &code;
-                StreamExtensions.CorrectByteOrder<uint>(pCode, Endianness.Big);
-            }
-
-            writer.Write(code);
+            writer.Write(_code, Endianness.Big);
         }
 
         [Obsolete("FourCC is a readonly struct, use the Read static method instead.", true)]
@@ -107,19 +100,12 @@ namespace YARG.Core.IO
         }
 
         public static EightCC Read(Stream stream) => new(stream.Read<ulong>(Endianness.Big));
-        public static EightCC Read(BinaryReader reader) => new(reader.BaseStream.Read<ulong>(Endianness.Big));
+        public static EightCC Read(IBinaryDataReader reader) => new(reader.Read<ulong>(Endianness.Big));
         public static EightCC Read(YARGBinaryReader reader) => new(reader.Read<ulong>(Endianness.Big));
 
         public void Serialize(IBinaryDataWriter writer)
         {
-            ulong code = _code;
-            unsafe
-            {
-                byte* pCode = (byte*) &code;
-                StreamExtensions.CorrectByteOrder<ulong>(pCode, Endianness.Big);
-            }
-
-            writer.Write(code);
+            writer.Write(_code, Endianness.Big);
         }
 
         [Obsolete("EightCC is a readonly struct, use the Read static method instead.", true)]

--- a/YARG.Core/IO/CharacterCodes.cs
+++ b/YARG.Core/IO/CharacterCodes.cs
@@ -103,13 +103,13 @@ namespace YARG.Core.IO
         public static EightCC Read(BinaryReader reader) => new(reader.BaseStream.Read<ulong>(Endianness.Big));
         public static EightCC Read(YARGBinaryReader reader) => new(reader.Read<ulong>(Endianness.Big));
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.BaseStream.Write(_code, Endianness.Big);
         }
 
         [Obsolete("EightCC is a readonly struct, use the Read static method instead.", true)]
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
             => throw new InvalidOperationException("EightCC is a readonly struct, use the Read static method instead.");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/YARG.Core/IO/CharacterCodes.cs
+++ b/YARG.Core/IO/CharacterCodes.cs
@@ -40,13 +40,20 @@ namespace YARG.Core.IO
         public static FourCC Read(BinaryReader reader) => new(reader.BaseStream.Read<uint>(Endianness.Big));
         public static FourCC Read(YARGBinaryReader reader) => new(reader.Read<uint>(Endianness.Big));
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
-            writer.BaseStream.Write(_code, Endianness.Big);
+            uint code = _code;
+            unsafe
+            {
+                byte* pCode = (byte*) &code;
+                StreamExtensions.CorrectByteOrder<uint>(pCode, Endianness.Big);
+            }
+
+            writer.Write(code);
         }
 
         [Obsolete("FourCC is a readonly struct, use the Read static method instead.", true)]
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
             => throw new InvalidOperationException("FourCC is a readonly struct, use the Read static method instead.");
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -105,7 +112,14 @@ namespace YARG.Core.IO
 
         public void Serialize(IBinaryDataWriter writer)
         {
-            writer.BaseStream.Write(_code, Endianness.Big);
+            ulong code = _code;
+            unsafe
+            {
+                byte* pCode = (byte*) &code;
+                StreamExtensions.CorrectByteOrder<ulong>(pCode, Endianness.Big);
+            }
+
+            writer.Write(code);
         }
 
         [Obsolete("EightCC is a readonly struct, use the Read static method instead.", true)]

--- a/YARG.Core/Replays/Replay.cs
+++ b/YARG.Core/Replays/Replay.cs
@@ -15,7 +15,7 @@ namespace YARG.Core.Replays
         public int         EngineVersion;
         public HashWrapper ReplayChecksum;
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             Magic.Serialize(writer);
             writer.Write(ReplayVersion);
@@ -24,7 +24,7 @@ namespace YARG.Core.Replays
             ReplayChecksum.Serialize(writer);
         }
 
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             Magic = EightCC.Read(reader);
             ReplayVersion = reader.ReadInt32();
@@ -62,12 +62,12 @@ namespace YARG.Core.Replays
             Frames = Array.Empty<ReplayFrame>();
         }
 
-        public Replay(BinaryReader reader, int version = 0)
+        public Replay(IBinaryDataReader reader, int version = 0)
         {
             Deserialize(reader, version);
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(SongName);
             writer.Write(ArtistName);
@@ -99,7 +99,7 @@ namespace YARG.Core.Replays
         [MemberNotNull(nameof(ReplayPresetContainer))]
         [MemberNotNull(nameof(PlayerNames))]
         [MemberNotNull(nameof(Frames))]
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             SongName = reader.ReadString();
             ArtistName = reader.ReadString();

--- a/YARG.Core/Replays/ReplayFile.cs
+++ b/YARG.Core/Replays/ReplayFile.cs
@@ -28,7 +28,7 @@ namespace YARG.Core.Replays
             Replay = replay;
         }
 
-        public static ReplayFile Create(BinaryReader reader)
+        public static ReplayFile Create(IBinaryDataReader reader)
         {
             var replayFile = new ReplayFile
             {
@@ -40,16 +40,17 @@ namespace YARG.Core.Replays
             return replayFile;
         }
 
-        public void ReadData(BinaryReader reader, int version = 0)
+        public void ReadData(IBinaryDataReader reader, int version = 0)
         {
             Replay = new Replay();
             Replay.Deserialize(reader, version);
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             using var dataStream = new MemoryStream();
-            using var dataWriter = new NullStringBinaryWriter(dataStream);
+            using var bDataWriter = new NullStringBinaryWriter(dataStream);
+            using var dataWriter = new BinaryWriterWrapper(bDataWriter);
 
             Replay.Serialize(dataWriter);
             var data = new ReadOnlySpan<byte>(dataStream.GetBuffer(), 0, (int) dataStream.Length);
@@ -59,7 +60,7 @@ namespace YARG.Core.Replays
             writer.Write(data);
         }
 
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             Header = new ReplayHeader();
             Replay = new Replay();

--- a/YARG.Core/Replays/ReplayFrame.cs
+++ b/YARG.Core/Replays/ReplayFrame.cs
@@ -30,7 +30,7 @@ namespace YARG.Core.Replays
             EventLog = new EngineEventLogger();
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             PlayerInfo.Serialize(writer);
             EngineParameters.Serialize(writer);
@@ -43,14 +43,14 @@ namespace YARG.Core.Replays
                 writer.Write(Inputs[i].Action);
                 writer.Write(Inputs[i].Integer);
             }
-            
+
             EventLog.Serialize(writer);
         }
 
         [MemberNotNull(nameof(EngineParameters))]
         [MemberNotNull(nameof(Stats))]
         [MemberNotNull(nameof(Inputs))]
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             PlayerInfo = new ReplayPlayerInfo(reader, version);
 
@@ -88,7 +88,7 @@ namespace YARG.Core.Replays
 
                 Inputs[i] = new GameInput(time, action, value);
             }
-            
+
             EventLog.Deserialize(reader, version);
         }
     }

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using YARG.Core.IO;
 using YARG.Core.Song;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Replays
 {
@@ -31,7 +32,8 @@ namespace YARG.Core.Replays
         public static ReplayReadResult ReadReplay(string path, out ReplayFile? replayFile)
         {
             using var stream = File.OpenRead(path);
-            using var reader = new BinaryReader(stream);
+            using var bReader = new BinaryReader(stream);
+            using var reader = new BinaryReaderWrapper(bReader);
 
             try
             {
@@ -57,7 +59,8 @@ namespace YARG.Core.Replays
         public static HashWrapper? WriteReplay(string path, Replay replay)
         {
             using var stream = File.OpenWrite(path);
-            using var writer = new BinaryWriter(stream);
+            using var bWriter = new BinaryWriter(stream);
+            using var writer = new BinaryWriterWrapper(bWriter);
 
             try
             {

--- a/YARG.Core/Replays/ReplayPlayerInfo.cs
+++ b/YARG.Core/Replays/ReplayPlayerInfo.cs
@@ -11,12 +11,12 @@ namespace YARG.Core.Replays
         public int         ColorProfileId;
         public YargProfile Profile;
 
-        public ReplayPlayerInfo(BinaryReader reader, int version = 0) : this()
+        public ReplayPlayerInfo(IBinaryDataReader reader, int version = 0) : this()
         {
             Deserialize(reader, version);
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(PlayerId);
             writer.Write(ColorProfileId);
@@ -25,7 +25,7 @@ namespace YARG.Core.Replays
         }
 
         [MemberNotNull(nameof(Profile))]
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             PlayerId = reader.ReadInt32();
             ColorProfileId = reader.ReadInt32();

--- a/YARG.Core/Replays/ReplayPresetContainer.cs
+++ b/YARG.Core/Replays/ReplayPresetContainer.cs
@@ -72,7 +72,7 @@ namespace YARG.Core.Replays
             _cameraPresets[cameraPreset.Id] = cameraPreset;
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(CONTAINER_VERSION);
 
@@ -80,7 +80,7 @@ namespace YARG.Core.Replays
             SerializeDict(writer, _cameraPresets);
         }
 
-        public void Deserialize(BinaryReader reader, int version = 0)
+        public void Deserialize(IBinaryDataReader reader, int version = 0)
         {
             // This container has separate versioning
             version = reader.ReadInt32();
@@ -89,7 +89,7 @@ namespace YARG.Core.Replays
             DeserializeDict(reader, _cameraPresets);
         }
 
-        private static void SerializeDict<T>(BinaryWriter writer, Dictionary<Guid, T> dict)
+        private static void SerializeDict<T>(IBinaryDataWriter writer, Dictionary<Guid, T> dict)
         {
             writer.Write(dict.Count);
             foreach (var (key, value) in dict)
@@ -103,7 +103,7 @@ namespace YARG.Core.Replays
             }
         }
 
-        private static void DeserializeDict<T>(BinaryReader reader, Dictionary<Guid, T> dict)
+        private static void DeserializeDict<T>(IBinaryDataReader reader, Dictionary<Guid, T> dict)
         {
             dict.Clear();
             int len = reader.ReadInt32();

--- a/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using YARG.Core.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Song.Cache
 {
@@ -114,9 +115,10 @@ namespace YARG.Core.Song.Cache
         {
             using MemoryStream ms = new();
             using BinaryWriter writer = new(ms);
+            using BinaryWriterWrapper writerWrapper = new(writer);
 
             entry.RBData!.Serialize(writer);
-            entry.Serialize(writer, node);
+            entry.Serialize(writerWrapper, node);
 
             return ms.ToArray();
         }

--- a/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/IniGroup.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Song.Cache
 {
@@ -74,9 +75,10 @@ namespace YARG.Core.Song.Cache
         {
             using MemoryStream ms = new();
             using BinaryWriter writer = new(ms);
+            using BinaryWriterWrapper writerWrapper = new(writer);
 
             entry.IniData!.Serialize(writer, Location);
-            entry.Serialize(writer, node);
+            entry.Serialize(writerWrapper, node);
 
             return ms.ToArray();
         }

--- a/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.cs
+++ b/YARG.Core/Song/Metadata/AvailableParts/AvailableParts.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using YARG.Core.Chart;
 using YARG.Core.IO;
 using YARG.Core.Song.Preparsers;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Song
 {
@@ -114,7 +113,7 @@ namespace YARG.Core.Song
             ProGuitar_22Fret = DeserializeValues();
             ProBass_17Fret = DeserializeValues();
             ProBass_22Fret = DeserializeValues();
-    
+
             ProKeys = DeserializeValues();
 
             // Dj = DeserializeValues();
@@ -124,7 +123,7 @@ namespace YARG.Core.Song
             SetVocalsCount();
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             void SerializeValues(ref PartValues values)
             {

--- a/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
+++ b/YARG.Core/Song/Metadata/SongMetadata.Serialization.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.IO;
-using YARG.Core.Song.Cache;
+﻿using YARG.Core.Song.Cache;
 using YARG.Core.IO;
 using YARG.Core.Chart;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Song
 {
@@ -47,7 +46,7 @@ namespace YARG.Core.Song
             _hash = HashWrapper.Deserialize(reader);
         }
 
-        public void Serialize(BinaryWriter writer, CategoryCacheWriteNode node)
+        public void Serialize(IBinaryDataWriter writer, CategoryCacheWriteNode node)
         {
             writer.Write(node.title);
             writer.Write(node.artist);

--- a/YARG.Core/Song/Metadata/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Metadata/Types/HashWrapper.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Security.Cryptography;
 using YARG.Core.Extensions;
 using YARG.Core.IO;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Song
 {
@@ -76,7 +77,7 @@ namespace YARG.Core.Song
             }
         }
 
-        public void Serialize(BinaryWriter writer)
+        public void Serialize(IBinaryDataWriter writer)
         {
             writer.Write(_hash.ReadOnlySpan);
         }

--- a/YARG.Core/Song/Metadata/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Metadata/Types/HashWrapper.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using YARG.Core.Extensions;
 using YARG.Core.IO;
@@ -38,7 +36,7 @@ namespace YARG.Core.Song
             return new HashWrapper(hash.Release());
         }
 
-        public static HashWrapper Deserialize(BinaryReader reader)
+        public static HashWrapper Deserialize(IBinaryDataReader reader)
         {
             using var hash = DisposableCounter.Wrap(FixedArray<byte>.Alloc(HASH_SIZE_IN_BYTES));
             if (reader.Read(hash.Value.Span) != HASH_SIZE_IN_BYTES)

--- a/YARG.Core/Utility/BinaryReaderWrapper.cs
+++ b/YARG.Core/Utility/BinaryReaderWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using YARG.Core.Extensions;
+using YARG.Core.IO;
 
 namespace YARG.Core.Utility
 {
@@ -58,5 +60,11 @@ namespace YARG.Core.Utility
         public uint ReadUInt32() => _reader.ReadUInt32();
 
         public ulong ReadUInt64() => _reader.ReadUInt64();
+
+        public T Read<T>(Endianness endianness)
+            where T : unmanaged, IComparable, IComparable<T>, IConvertible, IEquatable<T>, IFormattable
+        {
+            return _reader.BaseStream.Read<T>(endianness);
+        }
     }
 }

--- a/YARG.Core/Utility/BinaryReaderWrapper.cs
+++ b/YARG.Core/Utility/BinaryReaderWrapper.cs
@@ -1,0 +1,57 @@
+﻿using System.IO;
+
+namespace YARG.Core.Utility
+{
+    public class BinaryReaderWrapper : IBinaryDataReader
+    {
+        private readonly BinaryReader _reader;
+
+        public BinaryReaderWrapper(BinaryReader reader)
+        {
+            _reader = reader;
+        }
+
+        public void Dispose()
+        {
+            _reader.Dispose();
+        }
+
+        public int Read() => _reader.Read();
+
+        public int Read(byte[] buffer, int index, int count) => _reader.Read(buffer, index, count);
+
+        public int Read(char[] buffer, int index, int count) => _reader.Read(buffer, index, count);
+
+        public bool ReadBoolean() => _reader.ReadBoolean();
+
+        public byte ReadByte() => _reader.ReadByte();
+
+        public byte[] ReadBytes(int count) => _reader.ReadBytes(count);
+
+        public char ReadChar() => _reader.ReadChar();
+
+        public char[] ReadChars(int count) => _reader.ReadChars(count);
+
+        public decimal ReadDecimal() => _reader.ReadDecimal();
+
+        public double ReadDouble() => _reader.ReadDouble();
+
+        public short ReadInt16() => _reader.ReadInt16();
+
+        public int ReadInt32() => _reader.ReadInt32();
+
+        public long ReadInt64() => _reader.ReadInt64();
+
+        public sbyte ReadSByte() => _reader.ReadSByte();
+
+        public float ReadSingle() => _reader.ReadSingle();
+
+        public string ReadString() => _reader.ReadString();
+
+        public ushort ReadUInt16() => _reader.ReadUInt16();
+
+        public uint ReadUInt32() => _reader.ReadUInt32();
+
+        public ulong ReadUInt64() => _reader.ReadUInt64();
+    }
+}

--- a/YARG.Core/Utility/BinaryReaderWrapper.cs
+++ b/YARG.Core/Utility/BinaryReaderWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace YARG.Core.Utility
 {
@@ -21,6 +22,10 @@ namespace YARG.Core.Utility
         public int Read(byte[] buffer, int index, int count) => _reader.Read(buffer, index, count);
 
         public int Read(char[] buffer, int index, int count) => _reader.Read(buffer, index, count);
+
+        public int Read(Span<byte> buffer) => _reader.Read(buffer);
+
+        public int Read(Span<char> buffer) => _reader.Read(buffer);
 
         public bool ReadBoolean() => _reader.ReadBoolean();
 

--- a/YARG.Core/Utility/BinaryWriterWrapper.cs
+++ b/YARG.Core/Utility/BinaryWriterWrapper.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.IO;
+using YARG.Core.Extensions;
+using YARG.Core.IO;
 
 namespace YARG.Core.Utility
 {
@@ -53,5 +55,9 @@ namespace YARG.Core.Utility
         public void Write(uint value) => _writer.Write(value);
 
         public void Write(ulong value) => _writer.Write(value);
+        public void Write<T>(T value, Endianness endianness) where T : unmanaged, IComparable, IComparable<T>, IConvertible, IEquatable<T>, IFormattable
+        {
+            _writer.BaseStream.Write(value, endianness);
+        }
     }
 }

--- a/YARG.Core/Utility/BinaryWriterWrapper.cs
+++ b/YARG.Core/Utility/BinaryWriterWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 namespace YARG.Core.Utility
 {
@@ -36,6 +37,10 @@ namespace YARG.Core.Utility
         public void Write(int value) => _writer.Write(value);
 
         public void Write(long value) => _writer.Write(value);
+
+        public void Write(ReadOnlySpan<byte> buffer) => _writer.Write(buffer);
+
+        public void Write(ReadOnlySpan<char> buffer) => _writer.Write(buffer);
 
         public void Write(sbyte value) => _writer.Write(value);
 

--- a/YARG.Core/Utility/BinaryWriterWrapper.cs
+++ b/YARG.Core/Utility/BinaryWriterWrapper.cs
@@ -1,0 +1,52 @@
+﻿using System.IO;
+
+namespace YARG.Core.Utility
+{
+    public class BinaryWriterWrapper : IBinaryDataWriter
+    {
+        private readonly BinaryWriter _writer;
+
+        public BinaryWriterWrapper(BinaryWriter writer)
+        {
+            _writer = writer;
+        }
+
+        public void Dispose() => _writer.Dispose();
+
+        public void Write(bool value) => _writer.Write(value);
+
+        public void Write(byte value) => _writer.Write(value);
+
+        public void Write(byte[] buffer) => _writer.Write(buffer);
+
+        public void Write(byte[] buffer, int index, int count) => _writer.Write(buffer, index, count);
+
+        public void Write(char ch) => _writer.Write(ch);
+
+        public void Write(char[] chars) => _writer.Write(chars);
+
+        public void Write(char[] chars, int index, int count) => _writer.Write(chars, index, count);
+
+        public void Write(decimal value) => _writer.Write(value);
+
+        public void Write(double value) => _writer.Write(value);
+
+        public void Write(short value) => _writer.Write(value);
+
+        public void Write(int value) => _writer.Write(value);
+
+        public void Write(long value) => _writer.Write(value);
+
+        public void Write(sbyte value) => _writer.Write(value);
+
+        public void Write(float value) => _writer.Write(value);
+
+        public void Write(string value) => _writer.Write(value);
+
+        public void Write(ushort value) => _writer.Write(value);
+
+        public void Write(uint value) => _writer.Write(value);
+
+        public void Write(ulong value) => _writer.Write(value);
+    }
+}

--- a/YARG.Core/Utility/IBinaryDataReader.cs
+++ b/YARG.Core/Utility/IBinaryDataReader.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace YARG.Core.Utility
+{
+    public interface IBinaryDataReader : IDisposable
+    {
+
+        public int Read();
+        public int Read(byte[] buffer, int index, int count);
+        public int Read(char[] buffer, int index, int count);
+        public bool ReadBoolean();
+        public byte ReadByte();
+        public byte[] ReadBytes(int count);
+        public char ReadChar();
+        public char[] ReadChars(int count);
+        public decimal ReadDecimal();
+        public double ReadDouble();
+        public short ReadInt16();
+        public int ReadInt32();
+        public long ReadInt64();
+        public sbyte ReadSByte();
+        public float ReadSingle();
+        public string ReadString();
+        public ushort ReadUInt16();
+        public uint ReadUInt32();
+        public ulong ReadUInt64();
+
+    }
+}

--- a/YARG.Core/Utility/IBinaryDataReader.cs
+++ b/YARG.Core/Utility/IBinaryDataReader.cs
@@ -4,10 +4,11 @@ namespace YARG.Core.Utility
 {
     public interface IBinaryDataReader : IDisposable
     {
-
         public int Read();
         public int Read(byte[] buffer, int index, int count);
         public int Read(char[] buffer, int index, int count);
+        public int Read(Span<byte> buffer);
+        public int Read(Span<char> buffer);
         public bool ReadBoolean();
         public byte ReadByte();
         public byte[] ReadBytes(int count);
@@ -24,6 +25,5 @@ namespace YARG.Core.Utility
         public ushort ReadUInt16();
         public uint ReadUInt32();
         public ulong ReadUInt64();
-
     }
 }

--- a/YARG.Core/Utility/IBinaryDataReader.cs
+++ b/YARG.Core/Utility/IBinaryDataReader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using YARG.Core.IO;
 
 namespace YARG.Core.Utility
 {
@@ -25,5 +26,6 @@ namespace YARG.Core.Utility
         public ushort ReadUInt16();
         public uint ReadUInt32();
         public ulong ReadUInt64();
+        public T Read<T>(Endianness endianness) where T : unmanaged, IComparable, IComparable<T>, IConvertible, IEquatable<T>, IFormattable;
     }
 }

--- a/YARG.Core/Utility/IBinaryDataWriter.cs
+++ b/YARG.Core/Utility/IBinaryDataWriter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.IO;
+
+namespace YARG.Core.Utility
+{
+    public interface IBinaryDataWriter : IDisposable
+    {
+        public void Write(bool value);
+        public void Write(byte value);
+        public void Write(byte[] buffer);
+        public void Write(byte[] buffer, int index, int count);
+        public void Write(char ch);
+        public void Write(char[] chars);
+        public void Write(char[] chars, int index, int count);
+        public void Write(decimal value);
+        public void Write(double value);
+        public void Write(short value);
+        public void Write(int value);
+        public void Write(long value);
+        public void Write(sbyte value);
+        public void Write(float value);
+        public void Write(string value);
+        public void Write(ushort value);
+        public void Write(uint value);
+        public void Write(ulong value);
+    }
+}

--- a/YARG.Core/Utility/IBinaryDataWriter.cs
+++ b/YARG.Core/Utility/IBinaryDataWriter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 
 namespace YARG.Core.Utility
 {
@@ -17,6 +16,8 @@ namespace YARG.Core.Utility
         public void Write(short value);
         public void Write(int value);
         public void Write(long value);
+        public void Write(ReadOnlySpan<byte> buffer);
+        public void Write(ReadOnlySpan<char> buffer);
         public void Write(sbyte value);
         public void Write(float value);
         public void Write(string value);

--- a/YARG.Core/Utility/IBinaryDataWriter.cs
+++ b/YARG.Core/Utility/IBinaryDataWriter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using YARG.Core.IO;
 
 namespace YARG.Core.Utility
 {
@@ -24,5 +25,6 @@ namespace YARG.Core.Utility
         public void Write(ushort value);
         public void Write(uint value);
         public void Write(ulong value);
+        public void Write<T>(T value, Endianness endianness) where T : unmanaged, IComparable, IComparable<T>, IConvertible, IEquatable<T>, IFormattable;
     }
 }

--- a/YARG.Core/Utility/IBinarySerializable.cs
+++ b/YARG.Core/Utility/IBinarySerializable.cs
@@ -1,13 +1,11 @@
-using System.IO;
-
 namespace YARG.Core.Utility
 {
     public interface IBinarySerializable
     {
 
-        public void Serialize(BinaryWriter writer);
+        public void Serialize(IBinaryDataWriter writer);
 
-        public void Deserialize(BinaryReader reader, int version = 0);
+        public void Deserialize(IBinaryDataReader reader, int version = 0);
 
     }
 }


### PR DESCRIPTION
Need this for the future to avoid code duplication. Everything that took in a `BinaryReader/Writer` has been replaced with a `IBinaryDataReader/Writer`.

- Added wrappers around the existing BinaryReader and BinaryWriter which are 1:1 calls with the interface. 
- Added a method to read and write a type with endianness for the FourCC and EightCC structs.

Requires a main YARG repo PR after this is merged. Want to ensure that this is the best approach and I haven't screwed with the scanning code badly