### PR TITLE
Enhance Song Updates Scanning Functionality

### DIFF
--- a/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
+++ b/YARG.Core.UnitTests/Scanning/SongScanningTests.cs
@@ -18,7 +18,7 @@ namespace YARG.Core.UnitTests.Scanning
             songDirectories = new()
             {
                 
-            };       
+            };
             Assert.That(songDirectories, Is.Not.Empty, "Add directories to scan for the test");
         }
 

--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -24,7 +24,7 @@ namespace YARG.Core.IO
         public AbridgedFileInfo(string file, bool checkCreationTime = true)
             : this(new FileInfo(file), checkCreationTime) { }
 
-        public AbridgedFileInfo(FileInfo info, bool checkCreationTime = true)
+        public AbridgedFileInfo(FileSystemInfo info, bool checkCreationTime = true)
         {
             FullName = info.FullName;
             LastUpdatedTime = info.LastWriteTime;

--- a/YARG.Core/IO/YARGDTAReader.cs
+++ b/YARG.Core/IO/YARGDTAReader.cs
@@ -59,7 +59,12 @@ namespace YARG.Core.IO
             SkipWhitespace();
         }
 
-        public YARGDTAReader(YARGDTAReader reader)
+        public YARGDTAReader Clone()
+        {
+            return new YARGDTAReader(this);
+        }
+
+        private YARGDTAReader(YARGDTAReader reader)
         {
             container = new(reader.container);
             encoding = reader.encoding;

--- a/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
@@ -1,35 +1,135 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using YARG.Core.Extensions;
 using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {
-    public class SongUpdate
+    public class SongUpdate : IComparable<SongUpdate>
     {
-        public readonly string Name;
+        private readonly DateTime _dtaLastWrite;
+        private readonly List<YARGDTAReader> _readers = new();
+
+        public readonly string Directory;
         public readonly AbridgedFileInfo? Midi;
         public readonly AbridgedFileInfo? Mogg;
         public readonly AbridgedFileInfo? Milo;
         public readonly AbridgedFileInfo? Image;
 
-        public SongUpdate(string baseDirectory, string name)
+        public YARGDTAReader[] Readers
         {
-            Name = name;
-
-            string dir = Path.Combine(baseDirectory, name);
-            Midi = Get(Path.Combine(dir, name + "_update.mid"));
-            Mogg = Get(Path.Combine(dir, name + "_update.mogg"));
-
-            dir = Path.Combine(dir, "gen");
-            Milo = Get(Path.Combine(dir, name + ".milo_xbox"));
-            Image = Get(Path.Combine(dir, name + "_keep.png_xbox"));
+            get
+            {
+                var readers = new YARGDTAReader[_readers.Count];
+                for (int i = 0; i < readers.Length; i++)
+                {
+                    readers[i] = _readers[i].Clone();
+                }
+                return readers;
+            }
         }
 
-        private AbridgedFileInfo? Get(string filename)
+        public SongUpdate(string directory, string name, in DateTime dtaLastWrite)
         {
-            var imageInfo = new FileInfo(filename);
-            return imageInfo.Exists ? new AbridgedFileInfo(imageInfo, false) : null;
+            _dtaLastWrite = dtaLastWrite;
+
+            Directory = directory;
+            Midi = GetInfo(Path.Combine(directory, name + "_update.mid"));
+            Mogg = GetInfo(Path.Combine(directory, name + "_update.mogg"));
+
+            directory = Path.Combine(directory, "gen");
+            Milo = GetInfo(Path.Combine(directory, name + ".milo_xbox"));
+            Image = GetInfo(Path.Combine(directory, name + "_keep.png_xbox"));
+
+            static AbridgedFileInfo? GetInfo(string filename)
+            {
+                var info = new FileInfo(filename);
+                return info.Exists ? new AbridgedFileInfo(info, false) : null;
+            }
+        }
+
+        public void AddReader(YARGDTAReader reader)
+        {
+            _readers.Add(reader);
+        }
+
+        public void Serialize(BinaryWriter writer)
+        {
+            WriteInfo(Midi, writer);
+            WriteInfo(Mogg, writer);
+            WriteInfo(Milo, writer);
+            WriteInfo(Image, writer);
+
+            static void WriteInfo(AbridgedFileInfo? info, BinaryWriter writer)
+            {
+                if (info != null)
+                {
+                    writer.Write(true);
+                    writer.Write(info.LastUpdatedTime.ToBinary());
+                }
+                else
+                {
+                    writer.Write(false);
+                }
+            }
+        }
+
+        public bool Validate(BinaryReader reader)
+        {
+            if (!CheckInfo(Midi, reader))
+            {
+                goto FailedMidi;
+            }
+
+            if (!CheckInfo(Mogg, reader))
+            {
+                goto FailedMogg;
+            }
+
+            if (!CheckInfo(Milo, reader))
+            {
+                goto FailedMilo;
+            }
+            return CheckInfo(Image, reader);
+
+        FailedMidi:
+            SkipInfo(reader);
+        FailedMogg:
+            SkipInfo(reader);
+        FailedMilo:
+            SkipInfo(reader);
+            return false;
+
+            static bool CheckInfo(AbridgedFileInfo? info, BinaryReader reader)
+            {
+                if (reader.ReadBoolean())
+                {
+                    var lastWrite = DateTime.FromBinary(reader.ReadInt64());
+                    if (info == null || info.LastUpdatedTime != lastWrite)
+                    {
+                        return false;
+                    }
+                }
+                else if (info != null)
+                {
+                    return false;
+                }
+                return true;
+            }
+        }
+
+        public int CompareTo(SongUpdate other)
+        {
+            return _dtaLastWrite.CompareTo(other._dtaLastWrite);
+        }
+
+        public static void SkipInfo(BinaryReader reader)
+        {
+            if (reader.ReadBoolean())
+            {
+                reader.Move(SongMetadata.SIZEOF_DATETIME);
+            }
         }
     }
 

--- a/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
@@ -1,9 +1,38 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using YARG.Core.IO;
 
 namespace YARG.Core.Song.Cache
 {
+    public class SongUpdate
+    {
+        public readonly string Name;
+        public readonly AbridgedFileInfo? Midi;
+        public readonly AbridgedFileInfo? Mogg;
+        public readonly AbridgedFileInfo? Milo;
+        public readonly AbridgedFileInfo? Image;
+
+        public SongUpdate(string baseDirectory, string name)
+        {
+            Name = name;
+
+            string dir = Path.Combine(baseDirectory, name);
+            Midi = Get(Path.Combine(dir, name + "_update.mid"));
+            Mogg = Get(Path.Combine(dir, name + "_update.mogg"));
+
+            dir = Path.Combine(dir, "gen");
+            Milo = Get(Path.Combine(dir, name + ".milo_xbox"));
+            Image = Get(Path.Combine(dir, name + "_keep.png_xbox"));
+        }
+
+        private AbridgedFileInfo? Get(string filename)
+        {
+            var imageInfo = new FileInfo(filename);
+            return imageInfo.Exists ? new AbridgedFileInfo(imageInfo, false) : null;
+        }
+    }
+
     public sealed class UpdateGroup : IModificationGroup
     {
         private readonly string _directory;

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -114,7 +114,7 @@ namespace YARG.Core.Song.Cache
                     string name = reader.GetNameOfNode();
                     int index = GetCONIndex(indices, name);
 
-                    var node = new YARGDTAReader(reader);
+                    var node = reader.Clone();
                     tasks.Add(Task.Run(() => ScanPackedCONNode(group, name, index, node)));
                     reader.EndNode();
                 }
@@ -143,7 +143,7 @@ namespace YARG.Core.Song.Cache
                     string name = reader.GetNameOfNode();
                     int index = GetCONIndex(indices, name);
 
-                    var node = new YARGDTAReader(reader);
+                    var node = reader.Clone();
                     tasks.Add(Task.Run(() => ScanUnpackedCONNode(group, name, index, node)));
                     reader.EndNode();
                 }

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -59,7 +59,7 @@ namespace YARG.Core.Song.Cache
         {
             try
             {
-                if (!TraversalPreTest(directory, tracker.Playlist))
+                if (!TraversalPreTest(directory, tracker.Playlist, CreateUpdateGroup_Parallel))
                     return;
 
                 var collector = new FileCollector(directory);
@@ -332,6 +332,20 @@ namespace YARG.Core.Song.Cache
                     }
                 }));
             }
+        }
+
+        private UpdateGroup? CreateUpdateGroup_Parallel(string directory, AbridgedFileInfo dta, bool removeEntries)
+        {
+            var nodes = FindUpdateNodes(directory, dta);
+            if (nodes == null)
+            {
+                return null;
+            }
+
+            var group = new UpdateGroup(directory, dta.LastUpdatedTime);
+            Parallel.ForEach(nodes, node => ScanUpdateNode(group, node.Key, node.Value.ToArray(), removeEntries));
+            updateGroups.Add(group);
+            return group;
         }
     }
 }

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -147,6 +147,9 @@ namespace YARG.Core.Song.Cache
                     ScanDirectory_Parallel(dirInfo, group, tracker);
                 }
 
+                // Orders the updates from oldest to newest to apply more recent information last
+                Parallel.ForEach(updates, node => node.Value.Sort());
+
                 var conTasks = new Task[conGroups.Values.Count + extractedConGroups.Values.Count];
                 int con = 0;
                 foreach (var group in conGroups.Values)
@@ -167,6 +170,12 @@ namespace YARG.Core.Song.Cache
                 {
                     var dirInfo = new DirectoryInfo(group.Directory);
                     ScanDirectory(dirInfo, group, tracker);
+                }
+
+                foreach (var (_, list) in updates)
+                {
+                    // Orders the updates from oldest to newest to apply more recent information last
+                    list.Sort();
                 }
 
                 foreach (var group in conGroups.Values)
@@ -193,7 +202,7 @@ namespace YARG.Core.Song.Cache
                 FileInfo dta = new(Path.Combine(directory, "songs_updates.dta"));
                 if (dta.Exists)
                 {
-                    var abridged = new AbridgedFileInfo(dta);
+                    var abridged = new AbridgedFileInfo(dta, false);
                     CreateUpdateGroup(directory, abridged, true);
                     return false;
                 }
@@ -203,7 +212,7 @@ namespace YARG.Core.Song.Cache
                 FileInfo dta = new(Path.Combine(directory, "upgrades.dta"));
                 if (dta.Exists)
                 {
-                    var abridged = new AbridgedFileInfo(dta);
+                    var abridged = new AbridgedFileInfo(dta, false);
                     CreateUpgradeGroup(directory, abridged, true);
                     return false;
                 }

--- a/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
@@ -13,7 +13,7 @@ namespace YARG.Core.Song.Cache
         {
             try
             {
-                if (!TraversalPreTest(directory, tracker.Playlist))
+                if (!TraversalPreTest(directory, tracker.Playlist, CreateUpdateGroup))
                     return;
 
                 var collector = new FileCollector(directory);
@@ -209,6 +209,23 @@ namespace YARG.Core.Song.Cache
                 var entryReader = reader.Slice(length);
                 AddEntry(SongMetadata.UnpackedRBCONFromCache_Quick(dta, name, upgrades, entryReader, strings));
             }
+        }
+
+        private UpdateGroup? CreateUpdateGroup(string directory, AbridgedFileInfo dta, bool removeEntries)
+        {
+            var nodes = FindUpdateNodes(directory, dta);
+            if (nodes == null)
+            {
+                return null;
+            }
+
+            var group = new UpdateGroup(directory, dta.LastUpdatedTime);
+            foreach (var node in nodes)
+            {
+                ScanUpdateNode(group, node.Key, node.Value.ToArray(), removeEntries);
+            }
+            updateGroups.Add(group);
+            return group;
         }
     }
 }

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -343,7 +343,7 @@ namespace YARG.Core.Song.Cache
                 {
                     string name = reader.GetNameOfNode();
                     group.updates.Add(name);
-                    AddUpdate(name, new(directory, new YARGDTAReader(reader)));
+                    AddUpdate(name, new(directory, reader.Clone()));
 
                     if (removeEntries)
                         RemoveCONEntry(name);
@@ -381,7 +381,7 @@ namespace YARG.Core.Song.Cache
                         {
                             IRBProUpgrade upgrade = new UnpackedRBProUpgrade(abridged);
                             group.upgrades[name] = upgrade;
-                            AddUpgrade(name, new YARGDTAReader(reader), upgrade);
+                            AddUpgrade(name, reader.Clone(), upgrade);
 
                             if (removeEntries)
                                 RemoveCONEntry(name);
@@ -425,7 +425,7 @@ namespace YARG.Core.Song.Cache
                         {
                             IRBProUpgrade upgrade = new PackedRBProUpgrade(listing, listing.lastWrite);
                             group.Upgrades[name] = upgrade;
-                            AddUpgrade(name, new YARGDTAReader(reader), upgrade);
+                            AddUpgrade(name, reader.Clone(), upgrade);
                             RemoveCONEntry(name);
                         }
                     }

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongPackedRBCON.cs
@@ -204,7 +204,7 @@ namespace YARG.Core.Song
             }
         }
 
-        private SongMetadata(PackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<(string, YARGDTAReader)>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        private SongMetadata(PackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
         {
             RBCONSubMetadata rbMetadata = new();
 
@@ -217,7 +217,7 @@ namespace YARG.Core.Song
             FinalizeRBCONAudioValues(rbMetadata, dtaResults.pans, dtaResults.volumes, dtaResults.cores);
         }
 
-        public static (ScanResult, SongMetadata?) FromPackedRBCON(PackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<(string, YARGDTAReader)>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        public static (ScanResult, SongMetadata?) FromPackedRBCON(PackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
         {
             try
             {

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -204,7 +204,7 @@ namespace YARG.Core.Song
                     writer.Write(values[i]);
             }
 
-            public void Update(SongUpdate update, DTAResult results)
+            public void Update(SongUpdateFiles update, DTAResult results)
             {
                 if (results.discUpdate)
                 {
@@ -217,7 +217,7 @@ namespace YARG.Core.Song
                     }
                     else
                     {
-                        YargTrace.LogWarning($"Update midi expected inn directory {update.Directory}");
+                        YargTrace.LogWarning($"Update midi expected in directory {update.Directory}");
                     }
                 }
 
@@ -400,7 +400,14 @@ namespace YARG.Core.Song
                     try
                     {
                         var updateResults = ParseDTA(nodeName, sharedMetadata, update.Readers);
-                        sharedMetadata.Update(update, updateResults);
+                        if (update.Files != null)
+                        {
+                            sharedMetadata.Update(update.Files, updateResults);
+                        }
+                        else if (updateResults.discUpdate)
+                        {
+                            YargTrace.LogWarning($"Update midi expected with {update.Directory} - {nodeName}");
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -408,8 +408,8 @@ namespace YARG.Core.Song
                 {
                     try
                     {
-                        var updateResults = ParseDTA(nodeName, sharedMetadata, new YARGDTAReader(update.Item2));
                         sharedMetadata.Update(update.Item1, nodeName, updateResults);
+                        var updateResults = ParseDTA(nodeName, sharedMetadata, update.Item2.Clone());
                     }
                     catch (Exception ex)
                     {
@@ -426,7 +426,7 @@ namespace YARG.Core.Song
             {
                 try
                 {
-                    ParseDTA(nodeName, sharedMetadata, new YARGDTAReader(upgrade.Item1!));
+                    ParseDTA(nodeName, sharedMetadata, upgrade.Item1!.Clone());
                     sharedMetadata.Upgrade = upgrade.Item2;
                 }
                 catch (Exception ex)

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongRBCON.cs
@@ -204,55 +204,46 @@ namespace YARG.Core.Song
                     writer.Write(values[i]);
             }
 
-            public void Update(string folder, string nodeName, DTAResult results)
+            public void Update(SongUpdate update, DTAResult results)
             {
-                string dir = Path.Combine(folder, nodeName);
                 if (results.discUpdate)
                 {
-                    string path = Path.Combine(dir, $"{nodeName}_update.mid");
-                    var updateInfo = new FileInfo(path);
-                    if (updateInfo.Exists)
+                    if (update.Midi != null)
                     {
-                        var abridged = new AbridgedFileInfo(updateInfo, false);
-                        if (UpdateMidi == null || abridged.LastUpdatedTime > UpdateMidi.LastUpdatedTime)
+                        if (UpdateMidi == null || update.Midi.LastUpdatedTime > UpdateMidi.LastUpdatedTime)
                         {
-                            UpdateMidi = abridged;
+                            UpdateMidi = update.Midi;
                         }
                     }
                     else
-                        YargTrace.LogWarning($"Update midi expected at {path}");
-                }
-
-                var moggInfo = new FileInfo(Path.Combine(dir, $"{nodeName}_update.mogg"));
-                if (moggInfo.Exists)
-                {
-                    var abridged = new AbridgedFileInfo(moggInfo, false);
-                    if (Mogg == null || abridged.LastUpdatedTime > Mogg.LastUpdatedTime)
                     {
-                        Mogg = abridged;
+                        YargTrace.LogWarning($"Update midi expected inn directory {update.Directory}");
                     }
                 }
-                dir = Path.Combine(dir, "gen");
 
-                var miloInfo = new FileInfo(Path.Combine(dir, $"{nodeName}.milo_xbox"));
-                if (miloInfo.Exists)
+                if (update.Mogg != null)
                 {
-                    var abridged = new AbridgedFileInfo(miloInfo, false);
-                    if (Milo == null || abridged.LastUpdatedTime > Milo.LastUpdatedTime)
+                    if (Mogg == null || update.Mogg.LastUpdatedTime > Mogg.LastUpdatedTime)
                     {
-                        Milo = abridged;
+                        Mogg = update.Mogg;
+                    }
+                }
+
+                if (update.Milo != null)
+                {
+                    if (Milo == null || update.Milo.LastUpdatedTime > Milo.LastUpdatedTime)
+                    {
+                        Milo = update.Milo;
                     }
                 }
 
                 if (HasAlbumArt && results.alternatePath)
                 {
-                    var imageInfo = new FileInfo(Path.Combine(dir, $"{nodeName}_keep.png_xbox"));
-                    if (imageInfo.Exists)
+                    if (update.Image != null)
                     {
-                        var abridged = new AbridgedFileInfo(imageInfo, false);
-                        if (Image == null || abridged.LastUpdatedTime > Image.LastUpdatedTime)
+                        if (Image == null || update.Image.LastUpdatedTime > Image.LastUpdatedTime)
                         {
-                            Image = abridged;
+                            Image = update.Image;
                         }
                     }
                 }
@@ -399,7 +390,7 @@ namespace YARG.Core.Song
             }
         }
 
-        private void ApplyRBCONUpdates(string nodeName, Dictionary<string, List<(string, YARGDTAReader)>> updates)
+        private void ApplyRBCONUpdates(string nodeName, Dictionary<string, List<SongUpdate>> updates)
         {
             var sharedMetadata = _rbData!.SharedMetadata;
             if (updates.TryGetValue(nodeName, out var updateList))
@@ -408,12 +399,12 @@ namespace YARG.Core.Song
                 {
                     try
                     {
-                        sharedMetadata.Update(update.Item1, nodeName, updateResults);
-                        var updateResults = ParseDTA(nodeName, sharedMetadata, update.Item2.Clone());
+                        var updateResults = ParseDTA(nodeName, sharedMetadata, update.Readers);
+                        sharedMetadata.Update(update, updateResults);
                     }
                     catch (Exception ex)
                     {
-                        YargTrace.LogException(ex, $"Error processing CON Update {update.Item1} - {nodeName}!");
+                        YargTrace.LogException(ex, $"Error processing CON Update {update.Directory} - {nodeName}!");
                     }
                 }
             }
@@ -436,190 +427,192 @@ namespace YARG.Core.Song
             }
         }
 
-        private DTAResult ParseDTA(string nodeName, RBCONSubMetadata rbConMetadata, YARGDTAReader reader)
+        private DTAResult ParseDTA(string nodeName, RBCONSubMetadata rbConMetadata, params YARGDTAReader[] readers)
         {
             DTAResult result = new(nodeName);
-            while (reader.StartNode())
+            foreach (var reader in readers)
             {
-                string name = reader.GetNameOfNode();
-                switch (name)
+                while (reader.StartNode())
                 {
-                    case "name": _name = reader.ExtractText(); break;
-                    case "artist": _artist = reader.ExtractText(); break;
-                    case "master": _isMaster = reader.ExtractBoolean(); break;
-                    case "context": /*Context = reader.Read<uint>();*/ break;
-                    case "song": SongLoop(rbConMetadata, result, reader); break;
-                    case "song_vocals": while (reader.StartNode()) reader.EndNode(); break;
-                    case "song_scroll_speed": rbConMetadata.VocalSongScrollSpeed = reader.ExtractUInt32(); break;
-                    case "tuning_offset_cents": rbConMetadata.TuningOffsetCents = reader.ExtractInt32(); break;
-                    case "bank": rbConMetadata.VocalPercussionBank = reader.ExtractText(); break;
-                    case "anim_tempo":
-                        {
-                            string val = reader.ExtractText();
-                            rbConMetadata.AnimTempo = val switch
+                    string name = reader.GetNameOfNode();
+                    switch (name)
+                    {
+                        case "name": _name = reader.ExtractText(); break;
+                        case "artist": _artist = reader.ExtractText(); break;
+                        case "master": _isMaster = reader.ExtractBoolean(); break;
+                        case "context": /*Context = reader.Read<uint>();*/ break;
+                        case "song": SongLoop(rbConMetadata, result, reader); break;
+                        case "song_vocals": while (reader.StartNode()) reader.EndNode(); break;
+                        case "song_scroll_speed": rbConMetadata.VocalSongScrollSpeed = reader.ExtractUInt32(); break;
+                        case "tuning_offset_cents": rbConMetadata.TuningOffsetCents = reader.ExtractInt32(); break;
+                        case "bank": rbConMetadata.VocalPercussionBank = reader.ExtractText(); break;
+                        case "anim_tempo":
                             {
-                                "kTempoSlow" => 16,
-                                "kTempoMedium" => 32,
-                                "kTempoFast" => 64,
-                                _ => uint.Parse(val)
-                            };
-                            break;
-                        }
-                    case "preview":
-                        _previewStart = reader.ExtractUInt64();
-                        _previewEnd = reader.ExtractUInt64();
-                        break;
-                    case "rank": _parts.SetIntensities(rbConMetadata.RBDifficulties, reader); break;
-                    case "solo": rbConMetadata.Soloes = reader.ExtractList_String().ToArray(); break;
-                    case "genre": _genre = reader.ExtractText(); break;
-                    case "decade": /*Decade = reader.ExtractText();*/ break;
-                    case "vocal_gender": rbConMetadata.VocalGender = reader.ExtractText() == "male"; break;
-                    case "format": /*Format = reader.Read<uint>();*/ break;
-                    case "version": rbConMetadata.VenueVersion = reader.ExtractUInt32(); break;
-                    case "fake": /*IsFake = reader.ExtractText();*/ break;
-                    case "downloaded": /*Downloaded = reader.ExtractText();*/ break;
-                    case "game_origin":
-                        {
-                            string str = reader.ExtractText();
-                            if ((str == "ugc" || str == "ugc_plus"))
-                            {
-                                if (!nodeName.StartsWith("UGC_"))
-                                    _source = "customs";
-                            }
-                            else
-                                _source = str;
-
-                            //// if the source is any official RB game or its DLC, charter = Harmonix
-                            //if (SongSources.GetSource(str).Type == SongSources.SourceType.RB)
-                            //{
-                            //    _charter = "Harmonix";
-                            //}
-
-                            //// if the source is meant for usage in TBRB, it's a master track
-                            //// TODO: NEVER assume localized version contains "Beatles"
-                            //if (SongSources.SourceToGameName(str).Contains("Beatles")) _isMaster = true;
-                            break;
-                        }
-                    case "song_id": rbConMetadata.SongID = reader.ExtractText(); break;
-                    case "rating": rbConMetadata.SongRating = reader.ExtractUInt32(); break;
-                    case "short_version": /*ShortVersion = reader.Read<uint>();*/ break;
-                    case "album_art": rbConMetadata.HasAlbumArt = reader.ExtractBoolean(); break;
-                    case "year_released":
-                    case "year_recorded": YearAsNumber = reader.ExtractInt32(); break;
-                    case "album_name": _album = reader.ExtractText(); break;
-                    case "album_track_number": _albumTrack = reader.ExtractUInt16(); break;
-                    case "pack_name": _playlist = reader.ExtractText(); break;
-                    case "base_points": /*BasePoints = reader.Read<uint>();*/ break;
-                    case "band_fail_cue": /*BandFailCue = reader.ExtractText();*/ break;
-                    case "drum_bank": rbConMetadata.DrumBank = reader.ExtractText(); break;
-                    case "song_length": _songLength = reader.ExtractUInt64(); break;
-                    case "sub_genre": /*Subgenre = reader.ExtractText();*/ break;
-                    case "author": _charter = reader.ExtractText(); break;
-                    case "guide_pitch_volume": /*GuidePitchVolume = reader.ReadFloat();*/ break;
-                    case "encoding":
-                        var encoding = reader.ExtractText().ToLower() switch
-                        {
-                            "latin1" => YARGTextContainer.Latin1,
-                            "utf-8" or
-                            "utf8" => Encoding.UTF8,
-                            _ => reader.encoding
-                        };
-
-                        if (reader.encoding != encoding)
-                        {
-                            string Convert(string str)
-                            {
-                                byte[] bytes = reader.encoding.GetBytes(str);
-                                return encoding.GetString(bytes);
-                            }
-
-                            if (_name != DEFAULT_NAME)
-                                _name = Convert(_name);
-
-                            if (_artist != DEFAULT_ARTIST)
-                                _artist = Convert(_artist);
-
-                            if (_album != DEFAULT_ALBUM)
-                                _album = Convert(_album);
-
-                            if (_genre != DEFAULT_GENRE)
-                                _genre = Convert(_genre);
-
-                            if (_charter != DEFAULT_CHARTER)
-                                _charter = Convert(_charter);
-
-                            if (_source != DEFAULT_SOURCE)
-                                _source = Convert(_source);
-
-                            if (_playlist.Str.Length != 0)
-                                _playlist = Convert(_playlist);
-                            reader.encoding = encoding;
-                        }
-
-                        break;
-                    case "vocal_tonic_note": rbConMetadata.VocalTonicNote = reader.ExtractUInt32(); break;
-                    case "song_tonality": rbConMetadata.SongTonality = reader.ExtractBoolean(); break;
-                    case "alternate_path": result.alternatePath = reader.ExtractBoolean(); break;
-                    case "real_guitar_tuning":
-                        {
-                            if (reader.StartNode())
-                            {
-                                rbConMetadata.RealGuitarTuning = reader.ExtractList_Int().ToArray();
-                                reader.EndNode();
-                            }
-                            else
-                                rbConMetadata.RealGuitarTuning = new[] { reader.ExtractInt32() };
-                            break;
-                        }
-                    case "real_bass_tuning":
-                        {
-                            if (reader.StartNode())
-                            {
-                                rbConMetadata.RealBassTuning = reader.ExtractList_Int().ToArray();
-                                reader.EndNode();
-                            }
-                            else
-                                rbConMetadata.RealBassTuning = new[] { reader.ExtractInt32() };
-                            break;
-                        }
-                    case "video_venues":
-                        {
-                            if (reader.StartNode())
-                            {
-                                rbConMetadata.VideoVenues = reader.ExtractList_String().ToArray();
-                                reader.EndNode();
-                            }
-                            else
-                                rbConMetadata.VideoVenues = new[] { reader.ExtractText() };
-                            break;
-                        }
-                    case "extra_authoring":
-                        {
-                            StringBuilder authors = new();
-                            foreach (string str in reader.ExtractList_String())
-                            {
-                                if (str == "disc_update")
-                                    result.discUpdate = true;
-                                else if (authors.Length == 0 && _charter == DEFAULT_CHARTER)
-                                    authors.Append(str);
-                                else
+                                string val = reader.ExtractText();
+                                rbConMetadata.AnimTempo = val switch
                                 {
-                                    if (authors.Length == 0)
-                                        authors.Append(_charter);
-                                    authors.Append(", " + str);
+                                    "kTempoSlow" => 16,
+                                    "kTempoMedium" => 32,
+                                    "kTempoFast" => 64,
+                                    _ => uint.Parse(val)
+                                };
+                                break;
+                            }
+                        case "preview":
+                            _previewStart = reader.ExtractUInt64();
+                            _previewEnd = reader.ExtractUInt64();
+                            break;
+                        case "rank": _parts.SetIntensities(rbConMetadata.RBDifficulties, reader); break;
+                        case "solo": rbConMetadata.Soloes = reader.ExtractList_String().ToArray(); break;
+                        case "genre": _genre = reader.ExtractText(); break;
+                        case "decade": /*Decade = reader.ExtractText();*/ break;
+                        case "vocal_gender": rbConMetadata.VocalGender = reader.ExtractText() == "male"; break;
+                        case "format": /*Format = reader.Read<uint>();*/ break;
+                        case "version": rbConMetadata.VenueVersion = reader.ExtractUInt32(); break;
+                        case "fake": /*IsFake = reader.ExtractText();*/ break;
+                        case "downloaded": /*Downloaded = reader.ExtractText();*/ break;
+                        case "game_origin":
+                            {
+                                string str = reader.ExtractText();
+                                if ((str == "ugc" || str == "ugc_plus"))
+                                {
+                                    if (!nodeName.StartsWith("UGC_"))
+                                        _source = "customs";
                                 }
+                                else
+                                    _source = str;
+
+                                //// if the source is any official RB game or its DLC, charter = Harmonix
+                                //if (SongSources.GetSource(str).Type == SongSources.SourceType.RB)
+                                //{
+                                //    _charter = "Harmonix";
+                                //}
+
+                                //// if the source is meant for usage in TBRB, it's a master track
+                                //// TODO: NEVER assume localized version contains "Beatles"
+                                //if (SongSources.SourceToGameName(str).Contains("Beatles")) _isMaster = true;
+                                break;
+                            }
+                        case "song_id": rbConMetadata.SongID = reader.ExtractText(); break;
+                        case "rating": rbConMetadata.SongRating = reader.ExtractUInt32(); break;
+                        case "short_version": /*ShortVersion = reader.Read<uint>();*/ break;
+                        case "album_art": rbConMetadata.HasAlbumArt = reader.ExtractBoolean(); break;
+                        case "year_released":
+                        case "year_recorded": YearAsNumber = reader.ExtractInt32(); break;
+                        case "album_name": _album = reader.ExtractText(); break;
+                        case "album_track_number": _albumTrack = reader.ExtractUInt16(); break;
+                        case "pack_name": _playlist = reader.ExtractText(); break;
+                        case "base_points": /*BasePoints = reader.Read<uint>();*/ break;
+                        case "band_fail_cue": /*BandFailCue = reader.ExtractText();*/ break;
+                        case "drum_bank": rbConMetadata.DrumBank = reader.ExtractText(); break;
+                        case "song_length": _songLength = reader.ExtractUInt64(); break;
+                        case "sub_genre": /*Subgenre = reader.ExtractText();*/ break;
+                        case "author": _charter = reader.ExtractText(); break;
+                        case "guide_pitch_volume": /*GuidePitchVolume = reader.ReadFloat();*/ break;
+                        case "encoding":
+                            var encoding = reader.ExtractText().ToLower() switch
+                            {
+                                "latin1" => YARGTextContainer.Latin1,
+                                "utf-8" or
+                                "utf8" => Encoding.UTF8,
+                                _ => reader.encoding
+                            };
+
+                            if (reader.encoding != encoding)
+                            {
+                                string Convert(string str)
+                                {
+                                    byte[] bytes = reader.encoding.GetBytes(str);
+                                    return encoding.GetString(bytes);
+                                }
+
+                                if (_name != DEFAULT_NAME)
+                                    _name = Convert(_name);
+
+                                if (_artist != DEFAULT_ARTIST)
+                                    _artist = Convert(_artist);
+
+                                if (_album != DEFAULT_ALBUM)
+                                    _album = Convert(_album);
+
+                                if (_genre != DEFAULT_GENRE)
+                                    _genre = Convert(_genre);
+
+                                if (_charter != DEFAULT_CHARTER)
+                                    _charter = Convert(_charter);
+
+                                if (_source != DEFAULT_SOURCE)
+                                    _source = Convert(_source);
+
+                                if (_playlist.Str.Length != 0)
+                                    _playlist = Convert(_playlist);
+                                reader.encoding = encoding;
                             }
 
-                            if (authors.Length == 0)
-                                authors.Append(_charter);
+                            break;
+                        case "vocal_tonic_note": rbConMetadata.VocalTonicNote = reader.ExtractUInt32(); break;
+                        case "song_tonality": rbConMetadata.SongTonality = reader.ExtractBoolean(); break;
+                        case "alternate_path": result.alternatePath = reader.ExtractBoolean(); break;
+                        case "real_guitar_tuning":
+                            {
+                                if (reader.StartNode())
+                                {
+                                    rbConMetadata.RealGuitarTuning = reader.ExtractList_Int().ToArray();
+                                    reader.EndNode();
+                                }
+                                else
+                                    rbConMetadata.RealGuitarTuning = new[] { reader.ExtractInt32() };
+                                break;
+                            }
+                        case "real_bass_tuning":
+                            {
+                                if (reader.StartNode())
+                                {
+                                    rbConMetadata.RealBassTuning = reader.ExtractList_Int().ToArray();
+                                    reader.EndNode();
+                                }
+                                else
+                                    rbConMetadata.RealBassTuning = new[] { reader.ExtractInt32() };
+                                break;
+                            }
+                        case "video_venues":
+                            {
+                                if (reader.StartNode())
+                                {
+                                    rbConMetadata.VideoVenues = reader.ExtractList_String().ToArray();
+                                    reader.EndNode();
+                                }
+                                else
+                                    rbConMetadata.VideoVenues = new[] { reader.ExtractText() };
+                                break;
+                            }
+                        case "extra_authoring":
+                            {
+                                StringBuilder authors = new();
+                                foreach (string str in reader.ExtractList_String())
+                                {
+                                    if (str == "disc_update")
+                                        result.discUpdate = true;
+                                    else if (authors.Length == 0 && _charter == DEFAULT_CHARTER)
+                                        authors.Append(str);
+                                    else
+                                    {
+                                        if (authors.Length == 0)
+                                            authors.Append(_charter);
+                                        authors.Append(", " + str);
+                                    }
+                                }
 
-                            _charter = authors.ToString();
-                        }
-                        break;
+                                if (authors.Length == 0)
+                                    authors.Append(_charter);
+
+                                _charter = authors.ToString();
+                            }
+                            break;
+                    }
+                    reader.EndNode();
                 }
-                reader.EndNode();
             }
-
             return result;
         }
 

--- a/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
+++ b/YARG.Core/Song/Metadata/RBCON/SongMetadata.SongUnpackedRBCON.cs
@@ -210,7 +210,7 @@ namespace YARG.Core.Song
             }
         }
 
-        private SongMetadata(UnpackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<(string, YARGDTAReader)>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        private SongMetadata(UnpackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
         {
             RBCONSubMetadata rbMetadata = new();
 
@@ -223,7 +223,7 @@ namespace YARG.Core.Song
             FinalizeRBCONAudioValues(rbMetadata, dtaResults.pans, dtaResults.volumes, dtaResults.cores);
         }
 
-        public static (ScanResult, SongMetadata?) FromUnpackedRBCON(UnpackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<(string, YARGDTAReader)>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        public static (ScanResult, SongMetadata?) FromUnpackedRBCON(UnpackedCONGroup group, string nodeName, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
         {
             try
             {


### PR DESCRIPTION
Before this, the scanning algorithm didn't actually check for non-dta based updates. In other words, it never checked for updates to the .mid, .mogg, milo, or images present in update folders, even on full rescans. This changes that, hopefully without a noticeable decrease in scanning performance.