### PR TITLE
Convert ParseSettings To A Struct

### DIFF
--- a/YARG.Core.UnitTests/Parsing/ChartParsingTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ChartParsingTests.cs
@@ -1,4 +1,4 @@
-using MoonscraperChartEditor.Song;
+﻿using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
 using NUnit.Framework;
 using YARG.Core.Chart;
@@ -29,7 +29,7 @@ namespace YARG.Core.UnitTests.Parsing
             Assert.DoesNotThrow(() =>
             {
                 string chartPath = Path.Combine(chartsDirectory!, notesFile);
-                var song = ChartReader.ReadFromFile(ParseSettings.Default, chartPath);
+                var song = ChartReader.ReadFromFile(chartPath);
             });
         }
 
@@ -41,7 +41,7 @@ namespace YARG.Core.UnitTests.Parsing
             Assert.DoesNotThrow(() =>
             {
                 string chartPath = Path.Combine(chartsDirectory!, notesFile);
-                var song = MidReader.ReadMidi(ParseSettings.Default, chartPath);
+                var song = MidReader.ReadMidi(chartPath);
             });
         }
     }

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
@@ -3,6 +3,7 @@ using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
 using NUnit.Framework;
 using YARG.Core.Extensions;
+using YARG.Core.Parsing;
 
 namespace YARG.Core.UnitTests.Parsing
 {
@@ -283,7 +284,7 @@ namespace YARG.Core.UnitTests.Parsing
             MoonSong parsedSong;
             try
             {
-                parsedSong = ChartReader.ReadFromText(Settings, chartText);
+                parsedSong = ChartReader.ReadFromText(chartText);
             }
             catch (Exception ex)
             {

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
@@ -1,4 +1,4 @@
-using Melanchall.DryWetMidi.Common;
+﻿using Melanchall.DryWetMidi.Common;
 using Melanchall.DryWetMidi.Core;
 using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
@@ -19,7 +19,7 @@ namespace YARG.Core.UnitTests.Parsing
     public class MidiParseBehaviorTests
     {
         private const uint SUSTAIN_CUTOFF_THRESHOLD = RESOLUTION / 3;
-        private static readonly uint HopoThreshold = (uint)GetHopoThreshold(Settings, RESOLUTION);
+        private static readonly uint HopoThreshold = (uint)GetHopoThreshold(ParseSettings.Default, RESOLUTION);
 
         private static readonly Dictionary<MoonInstrument, string> InstrumentToNameLookup = new()
         {
@@ -560,7 +560,7 @@ namespace YARG.Core.UnitTests.Parsing
             MoonSong parsedSong;
             try
             {
-                parsedSong = MidReader.ReadMidi(Settings, midi);
+                parsedSong = MidReader.ReadMidi(midi);
             }
             catch (Exception ex)
             {

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -17,8 +17,6 @@ namespace YARG.Core.UnitTests.Parsing
         public const int NUMERATOR = 4;
         public const int DENOMINATOR = 4;
 
-        public static readonly ParseSettings Settings = ParseSettings.Default;
-
         public static readonly List<MoonText> GlobalEvents = new()
         {
         };

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -42,8 +42,8 @@ namespace YARG.Core.Chart
         {
             var song = Path.GetExtension(filePath).ToLower() switch
             {
-                ".mid" => MidReader.ReadMidi(settings, filePath),
-                ".chart" => ChartReader.ReadFromFile(settings, filePath),
+                ".mid" => MidReader.ReadMidi(ref settings, filePath),
+                ".chart" => ChartReader.ReadFromFile(ref settings, filePath),
                 _ => throw new ArgumentException($"Unrecognized file extension for chart path '{filePath}'!", nameof(filePath))
             };
 
@@ -52,13 +52,13 @@ namespace YARG.Core.Chart
 
         public static MoonSongLoader LoadMidi(ParseSettings settings, MidiFile midi)
         {
-            var song = MidReader.ReadMidi(settings, midi);
+            var song = MidReader.ReadMidi(ref settings, midi);
             return new(song, settings);
         }
 
         public static MoonSongLoader LoadDotChart(ParseSettings settings, string chartText)
         {
-            var song = ChartReader.ReadFromText(settings, chartText);
+            var song = ChartReader.ReadFromText(ref settings, chartText);
             return new(song, settings);
         }
 

--- a/YARG.Core/Chart/ParsingProperties.cs
+++ b/YARG.Core/Chart/ParsingProperties.cs
@@ -17,12 +17,12 @@ namespace YARG.Core.Chart
     /// <summary>
     /// Settings used when parsing charts.
     /// </summary>
-    public class ParseSettings
+    public struct ParseSettings
     {
         /// <summary>
         /// The default settings to use for parsing.
         /// </summary>
-        public static ParseSettings Default => new()
+        public static readonly ParseSettings Default = new()
         {
             DrumsType = DrumsType.Unknown,
 
@@ -109,7 +109,7 @@ namespace YARG.Core.Chart
         /// <summary>
         /// Calculates the HOPO threshold to use from the various HOPO settings.
         /// </summary>
-        public float GetHopoThreshold(float resolution)
+        public readonly float GetHopoThreshold(float resolution)
         {
             // Prefer in this order:
             // 1. hopo_threshold

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Melanchall.DryWetMidi.Core;
@@ -255,19 +255,19 @@ namespace YARG.Core.Chart
                 Harmony = song.Harmony;
         }
 
-        public static SongChart FromFile(ParseSettings settings, string filePath)
+        public static SongChart FromFile(in ParseSettings settings, string filePath)
         {
             var loader = MoonSongLoader.LoadSong(settings, filePath);
             return new(loader);
         }
 
-        public static SongChart FromMidi(ParseSettings settings, MidiFile midi)
+        public static SongChart FromMidi(in ParseSettings settings, MidiFile midi)
         {
             var loader = MoonSongLoader.LoadMidi(settings, midi);
             return new(loader);
         }
 
-        public static SongChart FromDotChart(ParseSettings settings, string chartText)
+        public static SongChart FromDotChart(in ParseSettings settings, string chartText)
         {
             var loader = MoonSongLoader.LoadDotChart(settings, chartText);
             return new(loader);

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartIOHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartIOHelper.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 using System.Collections.Generic;
@@ -97,7 +97,7 @@ namespace MoonscraperChartEditor.Song.IO
             { "GHLCoop",        MoonSong.MoonInstrument.GHLiveCoop },
         };
 
-        public static float GetHopoThreshold(ParseSettings settings, float resolution)
+        public static float GetHopoThreshold(in ParseSettings settings, float resolution)
         {
             // With a 192 resolution, .chart has a HOPO threshold of 65 ticks, not 64,
             // so we need to scale this factor to different resolutions (480 res = 162.5 threshold)

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.ProcessLists.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.ProcessLists.cs
@@ -168,9 +168,8 @@ namespace MoonscraperChartEditor.Song.IO
             };
         }
 
-        private static Dictionary<int, EventProcessFn> GetPhraseProcessDict(ParseSettings settings, MoonChart.GameMode gameMode)
+        private static Dictionary<int, EventProcessFn> GetPhraseProcessDict(int spNote, MoonChart.GameMode gameMode)
         {
-            int spNote = settings.StarPowerNote;
             // Set default if no override given
             if (spNote < 0)
                 spNote = MidIOHelper.STARPOWER_NOTE;

--- a/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
@@ -142,7 +142,9 @@ namespace YARG.Core.Song
                 return null;
 
             if (Type != ChartType.Chart)
+            {
                 return SongChart.FromMidi(_parseSettings, MidFileLoader.LoadMidiFile(stream));
+            }
 
             using var reader = new StreamReader(stream);
             return SongChart.FromDotChart(_parseSettings, reader.ReadToEnd());

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -322,19 +322,6 @@ namespace YARG.Core.Song
         {
             _parts = parts;
             _hash = hash;
-            _parseSettings = ParseSettings.Default;
-            if (parts.FourLaneDrums.SubTracks > 0)
-            {
-                _parseSettings.DrumsType = DrumsType.FourLane;
-            }
-            else if (parts.FiveLaneDrums.SubTracks > 0)
-            {
-                _parseSettings.DrumsType = DrumsType.FiveLane;
-            }
-            else
-            {
-                _parseSettings.DrumsType = DrumsType.Unknown;
-            }
 
             modifiers.TryGet("name", out _metadata.Name, SongMetadata.DEFAULT_NAME);
             modifiers.TryGet("artist", out _metadata.Artist, SongMetadata.DEFAULT_ARTIST);
@@ -422,6 +409,19 @@ namespace YARG.Core.Song
                 }
             }
 
+            if (parts.FourLaneDrums.SubTracks > 0)
+            {
+                _parseSettings.DrumsType = DrumsType.FourLane;
+            }
+            else if (parts.FiveLaneDrums.SubTracks > 0)
+            {
+                _parseSettings.DrumsType = DrumsType.FiveLane;
+            }
+            else
+            {
+                _parseSettings.DrumsType = DrumsType.Unknown;
+            }
+
             if (!modifiers.TryGet("hopo_frequency", out _parseSettings.HopoThreshold))
             {
                 _parseSettings.HopoThreshold = -1;
@@ -475,16 +475,14 @@ namespace YARG.Core.Song
             _metadata.VideoEndTime = reader.ReadInt64();
 
             _metadata.LoadingPhrase = reader.ReadString();
-            _parseSettings = new ParseSettings()
-            {
-                HopoThreshold = reader.ReadInt64(),
-                HopoFreq_FoF = reader.ReadInt32(),
-                EighthNoteHopo = reader.ReadBoolean(),
-                SustainCutoffThreshold = reader.ReadInt64(),
-                NoteSnapThreshold = reader.ReadInt64(),
-                StarPowerNote = reader.ReadInt32(),
-                DrumsType = (DrumsType) reader.ReadInt32(),
-            };
+
+            _parseSettings.HopoThreshold = reader.ReadInt64();
+            _parseSettings.HopoFreq_FoF = reader.ReadInt32();
+            _parseSettings.EighthNoteHopo = reader.ReadBoolean();
+            _parseSettings.SustainCutoffThreshold = reader.ReadInt64();
+            _parseSettings.NoteSnapThreshold = reader.ReadInt64();
+            _parseSettings.StarPowerNote = reader.ReadInt32();
+            _parseSettings.DrumsType = (DrumsType) reader.ReadInt32();
 
             unsafe
             {


### PR DESCRIPTION
Requires usage of `ref` during song loading to keep modifications valid.