### PR TITLE
Fix incorrect note/chord snap handling and enable chord snapping on CON files

### DIFF
--- a/YARG.Core/Chart/Events/ChartEvent.cs
+++ b/YARG.Core/Chart/Events/ChartEvent.cs
@@ -5,11 +5,11 @@ namespace YARG.Core.Chart
     /// </summary>
     public abstract class ChartEvent
     {
-        public double Time       { get; }
+        public double Time       { get; set; }
         public double TimeLength { get; set; }
         public double TimeEnd    => Time + TimeLength;
 
-        public uint Tick       { get; }
+        public uint Tick       { get; set; }
         public uint TickLength { get; set; }
         public uint TickEnd    => Tick + TickLength;
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -117,7 +117,8 @@ namespace YARG.Core.Chart
 
             // Extended sustains
             var nextNote = moonNote.NextSeperateMoonNote;
-            if (nextNote is not null && (moonNote.tick + moonNote.length) > nextNote.tick)
+            if (nextNote is not null && (moonNote.tick + moonNote.length) > nextNote.tick &&
+                (nextNote.tick - moonNote.tick) > _settings.NoteSnapThreshold)
             {
                 flags |= GuitarNoteFlags.ExtendedSustain;
             }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -286,13 +286,24 @@ namespace YARG.Core.Chart
             var previousParent = notes.Count > 1 ? notes[^2] : null;
 
             // Determine if this is part of a chord
-            if (currentParent != null && (note.Tick == currentParent.Tick ||
-                (note.Tick - currentParent.Tick) <= _settings.NoteSnapThreshold))
+            if (currentParent != null)
             {
-                // Same chord, assign previous and add as child
-                note.PreviousNote = previousParent;
-                currentParent.AddChildNote(note);
-                return;
+                if (note.Tick == currentParent.Tick)
+                {
+                    // Same chord, assign previous and add as child
+                    note.PreviousNote = previousParent;
+                    currentParent.AddChildNote(note);
+                    return;
+                }
+                else if ((note.Tick - currentParent.Tick) <= _settings.NoteSnapThreshold)
+                {
+                    // Chord needs to be snapped, copy values
+                    note.CopyValuesFrom(currentParent);
+
+                    note.PreviousNote = previousParent;
+                    currentParent.AddChildNote(note);
+                    return;
+                }
             }
 
             // New chord

--- a/YARG.Core/Chart/Notes/DrumNote.cs
+++ b/YARG.Core/Chart/Notes/DrumNote.cs
@@ -4,8 +4,7 @@ namespace YARG.Core.Chart
 {
     public class DrumNote : Note<DrumNote>
     {
-        private readonly DrumNoteFlags _drumFlags;
-
+        private DrumNoteFlags _drumFlags;
         public DrumNoteFlags DrumFlags;
 
         public int Pad { get; }
@@ -51,6 +50,14 @@ namespace YARG.Core.Chart
         {
             base.ResetNoteState();
             DrumFlags = _drumFlags;
+        }
+
+        protected override void CopyFlags(DrumNote other)
+        {
+            _drumFlags = other._drumFlags;
+            DrumFlags = other.DrumFlags;
+
+            Type = other.Type;
         }
 
         protected override DrumNote CloneNote()

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -4,8 +4,7 @@ namespace YARG.Core.Chart
 {
     public class GuitarNote : Note<GuitarNote>
     {
-        private readonly GuitarNoteFlags _guitarFlags;
-
+        private GuitarNoteFlags _guitarFlags;
         public GuitarNoteFlags GuitarFlags;
 
         public int Fret         { get; }
@@ -73,6 +72,14 @@ namespace YARG.Core.Chart
             base.ResetNoteState();
             GuitarFlags = _guitarFlags;
             SustainTicksHeld = 0;
+        }
+
+        protected override void CopyFlags(GuitarNote other)
+        {
+            _guitarFlags = other._guitarFlags;
+            GuitarFlags = other.GuitarFlags;
+
+            Type = other.Type;
         }
 
         protected override GuitarNote CloneNote()

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -21,8 +21,8 @@ namespace YARG.Core.Chart
         where TNote : Note<TNote>
     {
         protected readonly List<TNote> _childNotes = new();
-        private readonly NoteFlags  _flags;
 
+        private NoteFlags _flags;
         public NoteFlags Flags;
 
         private TNote? _originalPreviousNote;
@@ -65,9 +65,10 @@ namespace YARG.Core.Chart
 
         public virtual void AddChildNote(TNote note)
         {
-            if (note.Tick != Tick || note.ChildNotes.Count > 0) {
-                return;
-            }
+            if (note.Tick != Tick)
+                throw new InvalidOperationException("Child note being added is not on the same tick!");
+            if (note.ChildNotes.Count > 0)
+                throw new InvalidOperationException("Child note being added has its own children!");
 
             note.Parent = (TNote) this;
             _childNotes.Add(note);
@@ -180,6 +181,20 @@ namespace YARG.Core.Chart
             return mask;
         }
 
+        public void CopyValuesFrom(TNote other)
+        {
+            Time = other.Time;
+            TimeLength = other.TimeLength;
+            Tick = other.Tick;
+            TickLength = other.TickLength;
+
+            _flags = other._flags;
+            Flags = other.Flags;
+
+            CopyFlags(other);
+        }
+
+        protected abstract void CopyFlags(TNote other);
         protected abstract TNote CloneNote();
 
         /// <summary>

--- a/YARG.Core/Chart/Notes/ProGuitarNote.cs
+++ b/YARG.Core/Chart/Notes/ProGuitarNote.cs
@@ -4,8 +4,7 @@ namespace YARG.Core.Chart
 {
     public class ProGuitarNote : Note<ProGuitarNote>
     {
-        private readonly ProGuitarNoteFlags _proFlags;
-
+        private ProGuitarNoteFlags _proFlags;
         public ProGuitarNoteFlags ProFlags;
 
         public int String   { get; }
@@ -54,6 +53,14 @@ namespace YARG.Core.Chart
         {
             base.ResetNoteState();
             ProFlags = _proFlags;
+        }
+
+        protected override void CopyFlags(ProGuitarNote other)
+        {
+            _proFlags = other._proFlags;
+            ProFlags = other.ProFlags;
+
+            Type = other.Type;
         }
 
         protected override ProGuitarNote CloneNote()

--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -10,7 +10,7 @@ namespace YARG.Core.Chart
         /// <summary>
         /// The type of vocals note (either a phrase, a lyrical note or a percussion hit).
         /// </summary>
-        public VocalNoteType Type { get; }
+        public VocalNoteType Type { get; private set; }
 
         /// <summary>
         /// 0-based index for the harmony part this note is a part of.
@@ -205,6 +205,11 @@ namespace YARG.Core.Chart
                 if (note1.Tick < note2.Tick) return -1;
                 return 0;
             });
+        }
+
+        protected override void CopyFlags(VocalNote other)
+        {
+            Type = other.Type;
         }
 
         protected override VocalNote CloneNote()

--- a/YARG.Core/Chart/ParsingProperties.cs
+++ b/YARG.Core/Chart/ParsingProperties.cs
@@ -93,7 +93,7 @@ namespace YARG.Core.Chart
         /// The tick threshold to use for snapping together single notes into chords.
         /// </summary>
         /// <remarks>
-        /// Defaults to 10 ticks in .mid, and 0 in .chart.
+        /// Defaults to 10 in CON files, and 0 in other charts.
         /// </remarks>
         public long NoteSnapThreshold;
 

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -48,7 +48,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 24_02_21_01;
+        public const int CACHE_VERSION = 24_03_08_01;
 
         private static readonly object dirLock = new();
         private static readonly object fileLock = new();

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -71,6 +71,8 @@ namespace YARG.Core.Song
             public float[]? cores;
         }
 
+        private const long NOTE_SNAP_THRESHOLD = 10;
+
         private RBMetadata _rbMetadata;
         private RBCONDifficulties _rbDifficulties;
 
@@ -308,6 +310,7 @@ namespace YARG.Core.Song
             _rbMetadata = RBMetadata.Default;
             _rbDifficulties = RBCONDifficulties.Default;
             _parseSettings.DrumsType = DrumsType.FourLane;
+            _parseSettings.NoteSnapThreshold = NOTE_SNAP_THRESHOLD;
         }
 
         protected RBCONEntry(AbridgedFileInfo? updateMidi, IRBProUpgrade? upgrade, BinaryReader reader, CategoryCacheStrings strings)


### PR DESCRIPTION
A note snap threshold of 10 ticks is now applied to all CON entries.

Note snapping now correctly adjusts the properties of the note being snapped. Position, length, flags, and type are all copied from the parent note. This results in the following scenarios:

- Same length:

  ```
  o------   ->  o------
   o------  ->  o------
  ```

- First longer than the second:

  ```
  o------   ->  o------
   o        ->  o------
  ```

- Second longer than the first:

  ```
  o         ->  o
   o------  ->  o
  ```