### PR TITLE
Add total error count to Bad Songs file.

### DIFF
--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -261,6 +261,9 @@ namespace YARG.Core.Song.Cache
             using var stream = new FileStream(badSongsLocation, FileMode.Create, FileAccess.Write);
             using var writer = new StreamWriter(stream);
 
+            writer.WriteLine($"Total Errors: {badSongs.Count}");
+            writer.WriteLine();
+
             foreach (var error in badSongs)
             {
                 writer.WriteLine(error.Key);


### PR DESCRIPTION
Adding a line at the top of the Bad Songs file:

`Total Errors: 2`

Using this to show the count when the user scans, if there are any bad songs.