### PR TITLE
Fully consistent guitar engine (not counting sustains and starpower)

### DIFF
--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -590,7 +590,7 @@ namespace YARG.Core.Engine
 
         private void AdvanceToNextNote(TNoteType note)
         {
-            if(note.NextNote is null)
+            if (note.NextNote is null)
             {
                 return;
             }
@@ -605,17 +605,23 @@ namespace YARG.Core.Engine
 
             // This is the time when the note will enter the hit window in the front end. Engine will update at this time
             double frontEndTime = note.Time + frontEnd;
+
             // Only queue if the note is not already in the hit window, happens if
             // multiple notes are in the hit window and the back-most one gets hit/missed
             if (frontEndTime > State.CurrentTime)
+            {
                 QueueUpdateTime(frontEndTime);
+            }
 
             // This is the time when the note will leave the hit window in the back end (miss)
             double backEndTime = note.Time + backEnd;
+
             // Only queue if note has not already been missed
             // Very rare case; only happens when lagging enough to make a note skip the hit window entirely
             if (backEndTime > State.CurrentTime)
+            {
                 QueueUpdateTime(backEndTime);
+            }
 
             State.NoteIndex++;
         }

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -197,7 +197,11 @@ namespace YARG.Core.Engine
 
         protected void RunHitLogic(double time)
         {
-            UpdateEngineLogic(time);
+            bool exit = false;
+            while (!exit)
+            {
+                exit = !UpdateEngineLogic(time);
+            }
         }
 
         protected void StartTimer(ref EngineTimer timer, double startTime, double offset = 0)

--- a/YARG.Core/Engine/EngineTimer.cs
+++ b/YARG.Core/Engine/EngineTimer.cs
@@ -10,36 +10,26 @@ namespace YARG.Core.Engine
         public readonly double StartTime => _startTime;
         public readonly double EndTime => _startTime + TimeThreshold;
 
-        public bool IsActive { get; private set; }
-
         public EngineTimer(double threshold)
         {
             _startTime = double.MaxValue;
             TimeThreshold = threshold;
-            IsActive = false;
         }
 
         public void Start(double currentTime)
-        {
-            Start(ref _startTime, currentTime);
-            IsActive = true;
-        }
+            => Start(ref _startTime, currentTime);
 
         public void StartWithOffset(double currentTime, double offset)
-        {
-            StartWithOffset(ref _startTime, currentTime, TimeThreshold, offset);
-            IsActive = true;
-        }
+            => StartWithOffset(ref _startTime, currentTime, TimeThreshold, offset);
 
-        public void Disable()
-        {
-            IsActive = false;
-        }
+        public void Reset()
+            => Reset(ref _startTime);
+
+        public readonly bool IsActive(double currentTime)
+            => IsActive(_startTime, currentTime, TimeThreshold);
 
         public readonly bool IsExpired(double currentTime)
-        {
-            return currentTime >= EndTime;
-        }
+            => IsExpired(_startTime, currentTime, TimeThreshold);
 
         public static void Start(ref double startTime, double currentTime)
         {
@@ -55,6 +45,17 @@ namespace YARG.Core.Engine
         public static void Reset(ref double startTime)
         {
             startTime = double.MaxValue;
+        }
+
+        public static bool IsActive(double startTime, double currentTime, double threshold)
+        {
+            double elapsed = currentTime - startTime;
+            return elapsed < threshold && elapsed >= 0;
+        }
+
+        public static bool IsExpired(double startTime, double currentTime, double threshold)
+        {
+            return currentTime - startTime >= threshold;
         }
     }
 }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -139,6 +139,21 @@ namespace YARG.Core.Engine.Guitar.Engines
                         State.StrumLeniencyTimer.Reset();
                     }
 
+                    // Force infinite front end for the next note...
+                    if (State.NoteIndex < Notes.Count)
+                    {
+                        var nextNote = Notes[State.NoteIndex];
+
+                        // ...only if the current note is a strum
+                        if (note.IsStrum)
+                        {
+                            double newHitWindow =
+                                EngineParameters.HitWindow.CalculateHitWindow(GetAverageNoteDistance(note));
+
+                            CheckInfiniteFrontEndAndGhost(nextNote, newHitWindow);
+                        }
+                    }
+
                     return true;
                 }
             }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -55,7 +55,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             var note = Notes[State.NoteIndex];
             double hitWindow = EngineParameters.HitWindow.CalculateHitWindow(GetAverageNoteDistance(note));
 
-            var testIndex = State.NoteIndex is 93 or 94 or 95;
+            var testIndex = State.NoteIndex is 196 or 197 or 198;
 
             // Overstrum for strum leniency
             if (State.StrumLeniencyTimer.IsExpired(State.CurrentTime))
@@ -65,7 +65,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             }
 
             // Check for note miss note (back end)
-            if (State.CurrentTime > note.Time + EngineParameters.HitWindow.GetBackEnd(hitWindow))
+            if (State.CurrentTime >= note.Time + EngineParameters.HitWindow.GetBackEnd(hitWindow))
             {
                 if (!note.WasFullyHitOrMissed())
                 {
@@ -182,10 +182,10 @@ namespace YARG.Core.Engine.Guitar.Engines
 
                 if (strumConsumed)
                 {
-                    EventLogger.LogEvent(new ConsistentEngineEvent(State.CurrentTime)
-                    {
-                        Message = $"Index = {State.NoteIndex - 1}"
-                    });
+                    // EventLogger.LogEvent(new ConsistentEngineEvent(State.CurrentTime)
+                    // {
+                    //     Message = $"Index = {State.NoteIndex - 1}"
+                    // });
 
                     State.StrumLeniencyTimer.Reset();
                     return true;

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -27,6 +27,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             {
                 State.LastFretMask = State.FretMask;
                 State.HasFretted = true;
+                State.IsFretPress = gameInput.Button;
 
                 ToggleFret(gameInput.Action, gameInput.Button);
             }
@@ -207,13 +208,17 @@ namespace YARG.Core.Engine.Guitar.Engines
                 }
             }
 
-            bool ghosted = CheckForGhostInput(note);
-
-            if (ghosted)
+            // Don't ghost before the first note
+            if (note.PreviousNote is not null)
             {
-                EngineStats.GhostInputs++;
+                bool ghosted = CheckForGhostInput(note);
 
-                State.WasNoteGhosted = EngineParameters.AntiGhosting && ghosted;
+                if (ghosted)
+                {
+                    EngineStats.GhostInputs++;
+
+                    State.WasNoteGhosted = EngineParameters.AntiGhosting && ghosted;
+                }
             }
         }
 
@@ -384,7 +389,7 @@ namespace YARG.Core.Engine.Guitar.Engines
         protected bool CheckForGhostInput(GuitarNote note)
         {
             // First note cannot be ghosted, nor can a note be ghosted if a button is unpressed (pulloff)
-            if (note.PreviousNote is null)
+            if (note.PreviousNote is null || !State.IsFretPress)
             {
                 return false;
             }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using YARG.Core.Chart;
-using YARG.Core.Engine.Logging;
+﻿using YARG.Core.Chart;
 using YARG.Core.Input;
 
 namespace YARG.Core.Engine.Guitar.Engines
@@ -54,8 +52,6 @@ namespace YARG.Core.Engine.Guitar.Engines
 
             var note = Notes[State.NoteIndex];
             double hitWindow = EngineParameters.HitWindow.CalculateHitWindow(GetAverageNoteDistance(note));
-
-            var testIndex = State.NoteIndex is 196 or 197 or 198;
 
             // Overstrum for strum leniency
             if (State.StrumLeniencyTimer.IsExpired(State.CurrentTime))
@@ -133,6 +129,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 else
                 {
                     // If an input was consumed, a note was hit
+
                     return true;
                 }
             }
@@ -240,22 +237,23 @@ namespace YARG.Core.Engine.Guitar.Engines
             // If the note cannot be hit, try to note skip
             if (!CanNoteBeHit(note))
             {
-                // if (EngineStats.Combo != 0)
-                // {
-                //     return false;
-                // }
-                //
-                // // Skipping hopos or taps not allowed if its the first note
-                // if ((note.IsHopo || note.IsTap) && State.NoteIndex == 0)
-                // {
-                //     return false;
-                // }
-                //
-                // // Recursively call
-                // if (note.NextNote is not null)
-                // {
-                //     return ProcessNote(note.NextNote, strummed);
-                // }
+                if (EngineStats.Combo != 0)
+                {
+                    return false;
+                }
+
+                // Skipping hopos or taps not allowed if its the first note
+                if ((note.IsHopo || note.IsTap) && State.NoteIndex == 0)
+                {
+                    return false;
+                }
+
+                // Recursively call
+                if (note.NextNote is not null)
+                {
+                    var inputConsumed = ProcessNote(note.NextNote, strummed);
+                    return inputConsumed;
+                }
 
                 return false;
             }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -15,27 +15,24 @@ namespace YARG.Core.Engine.Guitar.Engines
         {
             var action = gameInput.GetAction<GuitarAction>();
 
-            // Star power
             if (action is GuitarAction.StarPower && gameInput.Button && EngineStats.CanStarPowerActivate)
             {
                 ActivateStarPower();
-                return;
             }
-
-            // Strumming
-            if (action is GuitarAction.StrumDown or GuitarAction.StrumUp && gameInput.Button)
+            else if (action is GuitarAction.StrumDown or GuitarAction.StrumUp && gameInput.Button)
             {
                 State.HasStrummed = true;
-                return;
             }
-
-            // Fretting
-            if (IsFretInput(gameInput))
+            else if (IsFretInput(gameInput))
             {
                 State.LastFretMask = State.FretMask;
                 State.HasFretted = true;
 
                 ToggleFret(gameInput.Action, gameInput.Button);
+            }
+            else if (action is GuitarAction.Whammy)
+            {
+                State.HasWhammied = true;
             }
         }
 
@@ -291,30 +288,30 @@ namespace YARG.Core.Engine.Guitar.Engines
         protected override bool CanNoteBeHit(GuitarNote note)
         {
             byte fretMask = State.FretMask;
-            // foreach (var sustain in ActiveSustains)
-            // {
-            //     var sustainNote = sustain.Note;
-            //
-            //     // Don't want to mask off the note we're checking otherwise it'll always return false lol
-            //     if (note == sustainNote)
-            //     {
-            //         continue;
-            //     }
-            //
-            //     // Mask off the disjoint mask if its disjointed or extended disjointed
-            //     // This removes just the single fret of the disjoint note
-            //     if ((sustainNote.IsExtendedSustain && sustainNote.IsDisjoint) || sustainNote.IsDisjoint)
-            //     {
-            //         fretMask -= (byte) sustainNote.DisjointMask;
-            //     }
-            //     else if (sustainNote.IsExtendedSustain)
-            //     {
-            //         // Remove the entire note mask if its an extended sustain
-            //         // Difference between NoteMask and DisjointMask is that DisjointMask is only a single fret
-            //         // while NoteMask is the entire chord
-            //         fretMask -= (byte) sustainNote.NoteMask;
-            //     }
-            // }
+            foreach (var sustain in ActiveSustains)
+            {
+                var sustainNote = sustain.Note;
+
+                // Don't want to mask off the note we're checking otherwise it'll always return false lol
+                if (note == sustainNote)
+                {
+                    continue;
+                }
+
+                // Mask off the disjoint mask if its disjointed or extended disjointed
+                // This removes just the single fret of the disjoint note
+                if ((sustainNote.IsExtendedSustain && sustainNote.IsDisjoint) || sustainNote.IsDisjoint)
+                {
+                    fretMask -= (byte) sustainNote.DisjointMask;
+                }
+                else if (sustainNote.IsExtendedSustain)
+                {
+                    // Remove the entire note mask if its an extended sustain
+                    // Difference between NoteMask and DisjointMask is that DisjointMask is only a single fret
+                    // while NoteMask is the entire chord
+                    fretMask -= (byte) sustainNote.NoteMask;
+                }
+            }
 
             // Only used for sustain logic
             bool useDisjointMask = note is { IsDisjoint: true, WasHit: true };

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -43,6 +43,7 @@ namespace YARG.Core.Engine.Guitar.Engines
         {
             UpdateTimeVariables(time);
             UpdateStarPower();
+            UpdateSustains();
 
             // Quit early if there are no notes left
             if (State.NoteIndex >= Notes.Count)

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -128,9 +128,17 @@ namespace YARG.Core.Engine.Guitar.Engines
                 }
                 else
                 {
-                    // TODO: Overstrum on double strum?
-
                     // If an input was consumed, a note was hit
+
+                    // If the strum was successful and there strum leniency is active,
+                    // then that means that there was an extra strum done.
+                    if (State.StrumLeniencyTimer.IsActive(State.CurrentTime))
+                    {
+                        // If the strum leniency timer was already active,
+                        // that means that the player is already in the leniency.
+                        Overstrum();
+                        State.StrumLeniencyTimer.Reset();
+                    }
 
                     return true;
                 }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -198,14 +198,14 @@ namespace YARG.Core.Engine.Guitar.Engines
             // start the infinite front end
             if (EngineParameters.InfiniteFrontEnd && (note.IsHopo || note.IsTap) && CanNoteBeHit(note))
             {
-                State.InfiniteFrontEndHitTime = note.Time + EngineParameters.HitWindow.GetFrontEnd(hitWindow);
-                QueueUpdateTime(State.InfiniteFrontEndHitTime.Value);
+                var hitTime = note.Time + EngineParameters.HitWindow.GetFrontEnd(hitWindow);
 
                 // If we're already past this point, then it wouldn't be an infinite front-end,
                 // it'd just be a normal front-end.
-                if (State.CurrentTime > State.InfiniteFrontEndHitTime)
+                if (State.CurrentTime <= hitTime)
                 {
-                    State.InfiniteFrontEndHitTime = null;
+                    State.InfiniteFrontEndHitTime = hitTime;
+                    QueueUpdateTime(hitTime);
                 }
             }
 

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -293,7 +293,9 @@ namespace YARG.Core.Engine.Guitar
                 {
                     // Only fail when the sustain has actually started
                     if (baseTick >= sustain.Note.Tick)
+                    {
                         YargTrace.Fail($"Sustain base tick cannot go backwards! Attempted to go from {sustain.BaseTick} to {baseTick}");
+                    }
 
                     continue;
                 }
@@ -380,7 +382,7 @@ namespace YARG.Core.Engine.Guitar
         {
             if (spSustainsActive)
             {
-                if (false)
+                if (State.HasWhammied)
                 {
                     // Rebase when beginning to SP whammy
                     if (!State.StarPowerWhammyTimer.IsActive(State.CurrentTime))

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -311,8 +311,6 @@ namespace YARG.Core.Engine.Guitar
 
         protected void StartSustain(GuitarNote note)
         {
-            return;
-
             var sustain = new ActiveSustain(note);
 
             ActiveSustains.Add(sustain);

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -307,10 +307,12 @@ namespace YARG.Core.Engine.Guitar
         }
 
         protected override double CalculateStarPowerGain(uint tick)
-            => State.StarPowerWhammyTimer.IsActive ? CalculateStarPowerBeatProgress(tick, State.StarPowerWhammyBaseTick) : 0;
+            => State.StarPowerWhammyTimer.IsActive(State.CurrentTime) ? CalculateStarPowerBeatProgress(tick, State.StarPowerWhammyBaseTick) : 0;
 
         protected void StartSustain(GuitarNote note)
         {
+            return;
+
             var sustain = new ActiveSustain(note);
 
             ActiveSustains.Add(sustain);
@@ -380,10 +382,10 @@ namespace YARG.Core.Engine.Guitar
         {
             if (spSustainsActive)
             {
-                if (State.HasWhammied)
+                if (false)
                 {
                     // Rebase when beginning to SP whammy
-                    if (!State.StarPowerWhammyTimer.IsActive)
+                    if (!State.StarPowerWhammyTimer.IsActive(State.CurrentTime))
                     {
                         RebaseProgressValues(State.CurrentTick);
                     }
@@ -397,14 +399,14 @@ namespace YARG.Core.Engine.Guitar
                         TimerValue = State.StarPowerWhammyTimer.TimeThreshold,
                     });
                 }
-                else if (State.StarPowerWhammyTimer.IsActive && State.StarPowerWhammyTimer.IsExpired(State.CurrentTime))
+                else if (State.StarPowerWhammyTimer.IsActive(State.CurrentTime) && State.StarPowerWhammyTimer.IsExpired(State.CurrentTime))
                 {
                     // Commit final whammy gain amount
                     UpdateProgressValues(State.CurrentTick);
                     RebaseProgressValues(State.CurrentTick);
 
                     // Stop whammy gain
-                    State.StarPowerWhammyTimer.Disable();
+                    State.StarPowerWhammyTimer.Reset();
 
                     EventLogger.LogEvent(new TimerEngineEvent(State.CurrentTime)
                     {
@@ -415,12 +417,12 @@ namespace YARG.Core.Engine.Guitar
                 }
             }
             // Rebase after SP whammy ends to commit the final amount to the base
-            else if(State.StarPowerWhammyTimer.IsActive)
+            else if(State.StarPowerWhammyTimer.IsActive(State.CurrentTime))
             {
                 RebaseProgressValues(State.CurrentTick);
 
                 double remainingTime = Math.Max(State.StarPowerWhammyTimer.EndTime - State.CurrentTime, 0);
-                State.StarPowerWhammyTimer.Disable();
+                State.StarPowerWhammyTimer.Reset();
 
                 EventLogger.LogEvent(new TimerEngineEvent(State.CurrentTime)
                 {

--- a/YARG.Core/Engine/Guitar/GuitarEngineState.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineState.cs
@@ -17,6 +17,7 @@
 
         public bool HasFretted;
         public bool HasStrummed;
+        public bool HasWhammied;
 
         public bool WasHopoStrummed;
         public bool WasNoteGhosted;

--- a/YARG.Core/Engine/Guitar/GuitarEngineState.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineState.cs
@@ -1,5 +1,12 @@
 ﻿namespace YARG.Core.Engine.Guitar
 {
+    public enum FretState : byte
+    {
+        None,
+        Down,
+        Up
+    }
+
     public class GuitarEngineState : BaseEngineState
     {
         // Dummy variable for now
@@ -10,11 +17,8 @@
 
         public bool HasFretted;
         public bool HasStrummed;
-        public bool HasTapped;
-        public bool HasWhammied;
 
-        public bool IsFretPress;
-
+        public bool WasHopoStrummed;
         public bool WasNoteGhosted;
 
         /// <summary>
@@ -22,16 +26,20 @@
         /// Strum after this time and it will overstrum.
         /// </summary>
         public EngineTimer HopoLeniencyTimer;
-
         /// <summary>
         /// The amount of time a strum can be inputted before fretting the correct note.
         /// Fretting after this time will overstrum.
         /// </summary>
         public EngineTimer StrumLeniencyTimer;
+        /// <summary>
+        /// The time at which the note should be hit for infinite front end. If null,
+        /// the note should not be hit without an input.
+        /// </summary>
+        public double? InfiniteFrontEndHitTime;
 
         public EngineTimer StarPowerWhammyTimer;
 
-        public double FrontEndExpireTime;
+        public double FrontEndStartTime;
 
         public uint StarPowerWhammyBaseTick;
 
@@ -51,13 +59,14 @@
             HasFretted = false;
             HasStrummed = false;
 
+            WasHopoStrummed = false;
             WasNoteGhosted = false;
 
-            StrumLeniencyTimer.Disable();
-            HopoLeniencyTimer.Disable();
-            StarPowerWhammyTimer.Disable();
+            StrumLeniencyTimer.Reset();
+            HopoLeniencyTimer.Reset();
+            StarPowerWhammyTimer.Reset();
 
-            FrontEndExpireTime = 0;
+            FrontEndStartTime = 0;
 
             StarPowerWhammyBaseTick = 0;
         }

--- a/YARG.Core/Engine/Guitar/GuitarEngineState.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineState.cs
@@ -16,10 +16,11 @@
         public byte FretMask;
 
         public bool HasFretted;
+        public bool IsFretPress;
+
         public bool HasStrummed;
         public bool HasWhammied;
 
-        public bool WasHopoStrummed;
         public bool WasNoteGhosted;
 
         /// <summary>
@@ -40,8 +41,6 @@
 
         public EngineTimer StarPowerWhammyTimer;
 
-        public double FrontEndStartTime;
-
         public uint StarPowerWhammyBaseTick;
 
         public void Initialize(GuitarEngineParameters parameters)
@@ -55,19 +54,20 @@
         {
             base.Reset();
 
+            LastFretMask = 0;
             FretMask = 0;
 
             HasFretted = false;
-            HasStrummed = false;
+            IsFretPress = false;
 
-            WasHopoStrummed = false;
+            HasStrummed = false;
+            HasWhammied = false;
+
             WasNoteGhosted = false;
 
             StrumLeniencyTimer.Reset();
             HopoLeniencyTimer.Reset();
             StarPowerWhammyTimer.Reset();
-
-            FrontEndStartTime = 0;
 
             StarPowerWhammyBaseTick = 0;
         }


### PR DESCRIPTION
Lots of testing later, it's finally here (yippe!)

**Firstly, caveats and things I'd like to improve:**
* This reverts to the old timer system, as the replacement of the `IsActive` method with the `IsEnabled` property does not provide consistent results, as the current time is not taken into consideration, and is therefore not properly disabled on time. I may be misunderstanding something with it; I didn't spend too long trying to fix it.
* `InfiniteFrontEndHitTime` is not a timer, and probably should be.
* The current consistency anchor system is slow, as there are a lot of updates queued that are actually not needed most of the time.
* `RunHitLogic` has been reverted to a loop. It should theoretically be possible to keep it as one update call, but I'm yet to figure out why removing the loop causes inconsistency problems.
* A recursive call is used for note skipping. I'm not sure if this is the best way of doing it, but it's certainly the easiest.

All note hitting logic along with all of its leniencies are fully consistent as far as I can tell. The only consistency issues seem to come from sustain points, and star power ending slightly earlier or later than it should.

I've done extensive testing with comparing this version of the engine with the master branch one, and compared inconsistencies between them. All inconsistencies between the engines could be justified properly and ruled out (i.e., fast strumming sections dropping random notes when the strum was clearly present: hit on this engine, not on the old one). Big disclaimer though: I am really bad, so there could be some minor vicissitudes that I have not noticed. Let me know, and these can easily be fixed.

This is a complete engine reimplementation that uses a different ideology (if you will) which is a lot easier to follow through (in my opinion at least). It's a lot easier to visualize the flow structure of everything, which I have discovered is very important for consistency related problems, as it becomes *very* clear what the potential problems are.

P.S. I've also just realized that HOPO leniency should *probably* be reset after a note gets hit. I'll add this on later when I get the chance, if it is actually the case.