### PR TITLE
Deterministic Engine

### DIFF
--- a/YARG.Core.UnitTests/Chart/LyricSymbolsTests.cs
+++ b/YARG.Core.UnitTests/Chart/LyricSymbolsTests.cs
@@ -1,0 +1,61 @@
+using NUnit.Framework;
+using YARG.Core.Chart;
+
+namespace YARG.Core.UnitTests.Chart;
+
+public class LyricSymbolsTests
+{
+    private const string LYRICS_ALLOWED_TAGS = """
+        <b>The</b> <i>quick</i> <color=#774331>brown</color> <u>fox</u><br>
+        <sup>jumped</sup> <voffset=1em>over</voffset> <lowercase>THE</lowercase> <sub>lazy</sub> <s>dog</s>.<br>
+        <mspace=2em>Afterwards</mspace>, <cspace=1em>it let out a</cspace> <smallcaps>hearty</smallcaps> <uppercase>scream</uppercase>.
+        """;
+
+    private const string VOCALS_TAGS_STRIPPED = """
+        The quick brown fox
+        jumped over THE lazy dog.
+        Afterwards, it let out a hearty scream.
+        """;
+
+    private const string DISALLOWED_TAGS = """
+        <align="right"><margin=5em>Lorem <allcaps>ipsum</allcaps> <alpha=#80>dolor</alpha> <font="NotoSans">sit</font> <font-weight=100>amet</font-weight></margin></align>,
+        <indent=15%><gradient="someGradient">consectetur</gradient> <link="someLink">adipiscing</link> <mark=#ffff00aa>elit</mark>.</indent>
+        <line-height=50%><rotate=15.0>Quisque</rotate> <size=50%>ut</size> <space=2em>orci</space> <sprite="someSprite">nec</sprite> <style="Title">neque</style> fringilla pulvinar a id nulla.</line-height>
+        <line-indent=15%>Quisque facilisis ut lorem vestibulum rhoncus.
+        <width=50%>Aenean in volutpat elit.</width></line-indent>
+        <pos=75%><nobr>Sed iaculis</nobr>, ante vel ultricies tristique,</pos>
+        <page>
+        <noparse><><<easrt>>a><uy></noparse>
+        """;
+
+    private const string DISALLOWED_TAGS_REMOVED = """
+        Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit.
+        Quisque ut orci nec neque fringilla pulvinar a id nulla.
+        Quisque facilisis ut lorem vestibulum rhoncus.
+        Aenean in volutpat elit.
+        Sed iaculis, ante vel ultricies tristique,
+        
+        <><<easrt>>a><uy>
+        """;
+
+    [Test]
+    public void LyricsTagStripping()
+    {
+        string allowed = LyricSymbols.StripForLyrics(LYRICS_ALLOWED_TAGS);
+        Assert.That(allowed, Is.EqualTo(LYRICS_ALLOWED_TAGS));
+
+        string disallowed = LyricSymbols.StripForLyrics(DISALLOWED_TAGS);
+        Assert.That(disallowed, Is.EqualTo(DISALLOWED_TAGS_REMOVED));
+    }
+
+    [Test]
+    public void VocalsTagStripping()
+    {
+        string allowed = LyricSymbols.StripForVocals(LYRICS_ALLOWED_TAGS);
+        Assert.That(allowed, Is.EqualTo(VOCALS_TAGS_STRIPPED));
+
+        string disallowed = LyricSymbols.StripForLyrics(DISALLOWED_TAGS);
+        Assert.That(disallowed, Is.EqualTo(DISALLOWED_TAGS_REMOVED));
+    }
+}

--- a/YARG.Core.UnitTests/Utility/RichTextUtilsTests.cs
+++ b/YARG.Core.UnitTests/Utility/RichTextUtilsTests.cs
@@ -45,6 +45,32 @@ namespace YARG.Core.UnitTests.Utility
             ("width",       RichTextTags.Width),
         ];
 
+        internal static List<(string name, string hex)> COLOR_NAMES =
+        [
+            ("aqua",      "#00ffff"),
+            ("black",     "#000000"),
+            ("blue",      "#0000ff"),
+            ("brown",     "#a52a2a"),
+            ("cyan",      "#00ffff"),
+            ("darkblue",  "#0000a0"),
+            ("fuchsia",   "#ff00ff"),
+            ("green",     "#008000"),
+            ("grey",      "#808080"),
+            ("lightblue", "#add8e6"),
+            ("lime",      "#00ff00"),
+            ("magenta",   "#ff00ff"),
+            ("maroon",    "#800000"),
+            ("navy",      "#000080"),
+            ("olive",     "#808000"),
+            ("orange",    "#ffa500"),
+            ("purple",    "#800080"),
+            ("red",       "#ff0000"),
+            ("silver",    "#c0c0c0"),
+            ("teal",      "#008080"),
+            ("white",     "#ffffff"),
+            ("yellow",    "#ffff00"),
+        ];
+
         [TestCase]
         public void ReplacesTags()
         {
@@ -52,11 +78,43 @@ namespace YARG.Core.UnitTests.Utility
             {
                 foreach (var (tagText, tag) in TEXT_TO_TAG)
                 {
-                    const string expectedText = "Some formatting";
-                    string testText = $"Some <{tagText}=50vb>formatting</{tagText}>";
+                    const string expectedText = "Some formatting with trailing text";
+                    string testText = $"Some <{tagText}=50vb>formatting</{tagText}> with trailing text";
 
                     string stripped = RichTextUtils.StripRichTextTags(testText, tag);
                     Assert.That(stripped, Is.EqualTo(expectedText), $"Tag '{tagText}' was not stripped!");
+                }
+            });
+        }
+
+        // Separate test since the implementation is different
+        [TestCase]
+        public void ReplacesAllTags()
+        {
+            string expectedText = "";
+            string testText = "";
+            foreach (var (tagText, tag) in TEXT_TO_TAG)
+            {
+                expectedText += "Some formatting with trailing text\n";
+                testText += $"Some <{tagText}=50vb>formatting</{tagText}> with trailing text\n";
+            }
+
+            string stripped = RichTextUtils.StripRichTextTags(testText);
+            Assert.That(stripped, Is.EqualTo(expectedText), "Some tags were not stripped!");
+        }
+
+        [TestCase]
+        public void ReplacesColors()
+        {
+            Assert.Multiple(() =>
+            {
+                foreach (var (name, hex) in COLOR_NAMES)
+                {
+                    string expectedText = $"Some <color={hex}>formatting</color> with trailing text";
+                    string testText = $"Some <color={name}>formatting</color> with trailing text";
+
+                    string stripped = RichTextUtils.ReplaceColorNames(testText);
+                    Assert.That(stripped, Is.EqualTo(expectedText), $"Color name '{name}' was not replaced!");
                 }
             });
         }

--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -164,7 +164,7 @@ namespace YARG.Core.Chart
             while (closestIndex < count && events[closestIndex].Time <= time)
                 closestIndex++;
 
-            return closestIndex < count ? count : -1;
+            return closestIndex < count ? closestIndex : -1;
         }
 
         public static int GetIndexOfNext<TEvent>(this List<TEvent> events, uint tick)
@@ -179,7 +179,7 @@ namespace YARG.Core.Chart
             while (closestIndex < count && events[closestIndex].Tick <= tick)
                 closestIndex++;
 
-            return closestIndex < count ? count : -1;
+            return closestIndex < count ? closestIndex : -1;
         }
 
         public static bool GetEventRange<TEvent>(this List<TEvent> events, double startTime, double endTime,

--- a/YARG.Core/Chart/Sync/SyncTrack.cs
+++ b/YARG.Core/Chart/Sync/SyncTrack.cs
@@ -266,7 +266,7 @@ namespace YARG.Core.Chart
 
             double timeDelta = timeEnd - timeStart;
             double beatDelta = timeDelta / currentTempo.SecondsPerBeat;
-            uint tickDelta = (uint) (beatDelta * resolution);
+            uint tickDelta = (uint) Math.Round(beatDelta * resolution);
 
             return tickDelta;
         }

--- a/YARG.Core/Chart/Tracks/Lyrics/LyricSymbols.cs
+++ b/YARG.Core/Chart/Tracks/Lyrics/LyricSymbols.cs
@@ -234,26 +234,24 @@ namespace YARG.Core.Chart
             {
                 // Split out segment before the tag
                 var segment = remaining[..tagIndex];
-                remaining = remaining[tagIndex..];
+                var tag = remaining[tagIndex..];
 
                 // Find end of the tag
-                var tag = ReadOnlySpan<char>.Empty;
-                int tagCloseIndex = remaining.IndexOf('>');
-                if (tagCloseIndex >= 0)
-                {
-                    // Include closing in tag split
-                    tagCloseIndex++;
+                int tagCloseIndex = tag.IndexOf('>');
+                if (tagCloseIndex < 0)
+                    break;
 
-                    if (tagCloseIndex >= remaining.Length)
-                    {
-                        tag = remaining;
-                        remaining = ReadOnlySpan<char>.Empty;
-                    }
-                    else
-                    {
-                        tag = remaining[..tagCloseIndex];
-                        remaining = remaining[tagCloseIndex..];
-                    }
+                // Include closing in tag split
+                tagCloseIndex++;
+
+                if (tagCloseIndex >= tag.Length)
+                {
+                    remaining = ReadOnlySpan<char>.Empty;
+                }
+                else
+                {
+                    remaining = tag[tagCloseIndex..];
+                    tag = tag[..tagCloseIndex];
                 }
 
                 // Run through replacements on segment

--- a/YARG.Core/Chart/Tracks/Lyrics/LyricSymbols.cs
+++ b/YARG.Core/Chart/Tracks/Lyrics/LyricSymbols.cs
@@ -223,6 +223,7 @@ namespace YARG.Core.Chart
         public static string StripForLyrics(string lyric)
         {
             lyric = RichTextUtils.StripRichTextTagsExcept(lyric, LYRICS_ALLOWED_TAGS);
+            lyric = RichTextUtils.ReplaceColorNames(lyric);
 
             var lyricBuffer = new StringBuilder();
             var segmentBuffer = new StringBuilder();

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -248,7 +248,7 @@ namespace YARG.Core.Engine
             }
         }
 
-        protected abstract bool CheckForNoteHit();
+        protected abstract void CheckForNoteHit();
 
         /// <summary>
         /// Checks if the given note can be hit with the current input state.

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using YARG.Core.Chart;
 using YARG.Core.Engine.Logging;
-using YARG.Core.Input;
 using YARG.Core.Logging;
+using YARG.Core.Utility;
 
 namespace YARG.Core.Engine
 {
@@ -116,6 +116,47 @@ namespace YARG.Core.Engine
             }
 
             Solos = GetSoloSections();
+        }
+
+        protected override void GenerateQueuedUpdates(double nextTime)
+        {
+            base.GenerateQueuedUpdates(nextTime);
+            var previousTime = BaseState.CurrentTime;
+
+            for (int i = State.NoteIndex; i < Notes.Count; i++)
+            {
+                var note = Notes[i];
+
+                var hitWindow = EngineParameters.HitWindow.CalculateHitWindow(GetAverageNoteDistance(note));
+
+                var noteFrontEnd = note.Time + EngineParameters.HitWindow.GetFrontEnd(hitWindow);
+                var noteBackEnd = note.Time + EngineParameters.HitWindow.GetBackEnd(hitWindow);
+
+                // Note will not reach front end yet
+                if (nextTime < noteFrontEnd)
+                {
+                    //YargLogger.LogFormatInfo("Note {0} front end will not be reached at {1}", i, nextTime);
+                    break;
+                }
+
+                // Earliest the note can be hit
+                if(IsTimeBetween(noteFrontEnd, previousTime, nextTime))
+                {
+                    YargLogger.LogFormatInfo("Queuing note {0} front end hit time at {1}", i, noteFrontEnd);
+                    QueueUpdateTime(noteFrontEnd);
+                }
+
+                // Note will not be out of time on the exact back end
+                // So we increment the back end by 1 bit exactly
+                // (essentially just 1 epsilon bigger)
+                var noteBackEndIncrement = MathUtil.BitIncrement(noteBackEnd);
+
+                if (IsTimeBetween(noteBackEndIncrement, previousTime, nextTime))
+                {
+                    YargLogger.LogFormatInfo("Queuing note {0} back end miss time at {1} (back end time is {2})", i, noteBackEndIncrement, noteBackEnd);
+                    QueueUpdateTime(noteBackEndIncrement);
+                }
+            }
         }
 
         protected void UpdateTimeVariables(double time)
@@ -259,11 +300,13 @@ namespace YARG.Core.Engine
 
         protected virtual void HitNote(TNoteType note)
         {
+            YargLogger.LogFormatInfo("Hit note at {0}", BaseState.CurrentTime);
             AdvanceToNextNote(note);
         }
 
         protected virtual void MissNote(TNoteType note)
         {
+            YargLogger.LogFormatInfo("Missed note at {0}", BaseState.CurrentTime);
             AdvanceToNextNote(note);
         }
 
@@ -590,12 +633,14 @@ namespace YARG.Core.Engine
             double frontend = EngineParameters.HitWindow.GetFrontEnd(hitWindow);
             double backend = EngineParameters.HitWindow.GetBackEnd(hitWindow);
 
-            if (note.Time + frontend > State.CurrentTime)
+            // Time has not reached the front end of this note
+            if (State.CurrentTime < note.Time + frontend)
             {
                 return false;
             }
 
-            if (note.Time + backend <= State.CurrentTime)
+            // Time has surpassed the back end of this note
+            if (State.CurrentTime > note.Time + backend)
             {
                 missed = true;
                 return false;
@@ -606,32 +651,32 @@ namespace YARG.Core.Engine
 
         private void AdvanceToNextNote(TNoteType note)
         {
+            State.NoteIndex++;
+
             if (note.NextNote is null)
             {
                 return;
             }
 
-            note = note.NextNote;
+            //note = note.NextNote;
 
-            double dist = GetAverageNoteDistance(note);
-            double fullWindow = EngineParameters.HitWindow.CalculateHitWindow(dist);
-
-            double frontEnd = EngineParameters.HitWindow.GetFrontEnd(fullWindow);
-            double backEnd = EngineParameters.HitWindow.GetBackEnd(fullWindow);
-
-            // This is the time when the note will enter the hit window in the front end. Engine will update at this time
-            double frontEndTime = note.Time + frontEnd;
-            // Only queue if the note is not already in the hit window, happens if
-            // multiple notes are in the hit window and the back-most one gets hit/missed
-            if (frontEndTime > State.CurrentTime) QueueUpdateTime(frontEndTime);
-
-            // This is the time when the note will leave the hit window in the back end (miss)
-            double backEndTime = note.Time + backEnd;
-            // Only queue if note has not already been missed
-            // Very rare case; only happens when lagging enough to make a note skip the hit window entirely
-            if (backEndTime > State.CurrentTime) QueueUpdateTime(backEndTime);
-
-            State.NoteIndex++;
+            // double dist = GetAverageNoteDistance(note);
+            // double fullWindow = EngineParameters.HitWindow.CalculateHitWindow(dist);
+            //
+            // double frontEnd = EngineParameters.HitWindow.GetFrontEnd(fullWindow);
+            // double backEnd = EngineParameters.HitWindow.GetBackEnd(fullWindow);
+            //
+            // // This is the time when the note will enter the hit window in the front end. Engine will update at this time
+            // double frontEndTime = note.Time + frontEnd;
+            // // Only queue if the note is not already in the hit window, happens if
+            // // multiple notes are in the hit window and the back-most one gets hit/missed
+            // if (frontEndTime > State.CurrentTime) QueueUpdateTime(frontEndTime);
+            //
+            // // This is the time when the note will leave the hit window in the back end (miss)
+            // double backEndTime = note.Time + backEnd;
+            // // Only queue if note has not already been missed
+            // // Very rare case; only happens when lagging enough to make a note skip the hit window entirely
+            // if (backEndTime > State.CurrentTime) QueueUpdateTime(backEndTime);
         }
 
         public double GetAverageNoteDistance(TNoteType note)

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -153,7 +153,7 @@ namespace YARG.Core.Engine
 
                 if (IsTimeBetween(noteBackEndIncrement, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatTrace("Queuing note {0} back end miss time at {1} (back end time is {2})", i, noteBackEndIncrement, noteBackEnd);
+                    YargLogger.LogFormatTrace("Queuing note {0} back end miss time at {1}", i, noteBackEndIncrement);
                     QueueUpdateTime(noteBackEndIncrement);
                 }
             }
@@ -300,13 +300,11 @@ namespace YARG.Core.Engine
 
         protected virtual void HitNote(TNoteType note)
         {
-            YargLogger.LogFormatTrace("Hit note at {0}", BaseState.CurrentTime);
             AdvanceToNextNote(note);
         }
 
         protected virtual void MissNote(TNoteType note)
         {
-            YargLogger.LogFormatTrace("Missed note at {0}", BaseState.CurrentTime);
             AdvanceToNextNote(note);
         }
 

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -135,14 +135,14 @@ namespace YARG.Core.Engine
                 // Note will not reach front end yet
                 if (nextTime < noteFrontEnd)
                 {
-                    //YargLogger.LogFormatInfo("Note {0} front end will not be reached at {1}", i, nextTime);
+                    //YargLogger.LogFormatTrace("Note {0} front end will not be reached at {1}", i, nextTime);
                     break;
                 }
 
                 // Earliest the note can be hit
                 if(IsTimeBetween(noteFrontEnd, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatInfo("Queuing note {0} front end hit time at {1}", i, noteFrontEnd);
+                    YargLogger.LogFormatTrace("Queuing note {0} front end hit time at {1}", i, noteFrontEnd);
                     QueueUpdateTime(noteFrontEnd);
                 }
 
@@ -153,7 +153,7 @@ namespace YARG.Core.Engine
 
                 if (IsTimeBetween(noteBackEndIncrement, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatInfo("Queuing note {0} back end miss time at {1} (back end time is {2})", i, noteBackEndIncrement, noteBackEnd);
+                    YargLogger.LogFormatTrace("Queuing note {0} back end miss time at {1} (back end time is {2})", i, noteBackEndIncrement, noteBackEnd);
                     QueueUpdateTime(noteBackEndIncrement);
                 }
             }
@@ -300,13 +300,13 @@ namespace YARG.Core.Engine
 
         protected virtual void HitNote(TNoteType note)
         {
-            YargLogger.LogFormatInfo("Hit note at {0}", BaseState.CurrentTime);
+            YargLogger.LogFormatTrace("Hit note at {0}", BaseState.CurrentTime);
             AdvanceToNextNote(note);
         }
 
         protected virtual void MissNote(TNoteType note)
         {
-            YargLogger.LogFormatInfo("Missed note at {0}", BaseState.CurrentTime);
+            YargLogger.LogFormatTrace("Missed note at {0}", BaseState.CurrentTime);
             AdvanceToNextNote(note);
         }
 

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -139,11 +139,22 @@ namespace YARG.Core.Engine
                     break;
                 }
 
-                // Earliest the note can be hit
-                if(IsTimeBetween(noteFrontEnd, previousTime, nextTime))
+                if (!IsBot)
                 {
-                    YargLogger.LogFormatTrace("Queuing note {0} front end hit time at {1}", i, noteFrontEnd);
-                    QueueUpdateTime(noteFrontEnd);
+                    // Earliest the note can be hit
+                    if(IsTimeBetween(noteFrontEnd, previousTime, nextTime))
+                    {
+                        YargLogger.LogFormatTrace("Queuing note {0} front end hit time at {1}", i, noteFrontEnd);
+                        QueueUpdateTime(noteFrontEnd, "Note Front End");
+                    }
+                }
+                else
+                {
+                    if (IsTimeBetween(note.Time, previousTime, nextTime))
+                    {
+                        YargLogger.LogFormatTrace("Queuing bot note {0} at {1}", i, note.Time);
+                        QueueUpdateTime(note.Time, "Bot Note Time");
+                    }
                 }
 
                 // Note will not be out of time on the exact back end
@@ -154,7 +165,7 @@ namespace YARG.Core.Engine
                 if (IsTimeBetween(noteBackEndIncrement, previousTime, nextTime))
                 {
                     YargLogger.LogFormatTrace("Queuing note {0} back end miss time at {1}", i, noteBackEndIncrement);
-                    QueueUpdateTime(noteBackEndIncrement);
+                    QueueUpdateTime(noteBackEndIncrement, "Note Back End");
                 }
             }
         }

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -650,6 +650,7 @@ namespace YARG.Core.Engine
         private void AdvanceToNextNote(TNoteType note)
         {
             State.NoteIndex++;
+            ReRunHitLogic = true;
 
             if (note.NextNote is null)
             {

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -202,7 +202,6 @@ namespace YARG.Core.Engine
             }
 
             _scheduledUpdates.Add(time);
-            _scheduledUpdates.Sort();
         }
 
         internal void QueueManyUpdateTimesNoChecks(IEnumerable<double> times)

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -77,6 +77,7 @@ namespace YARG.Core.Engine
 
                 RunQueuedUpdates(input.Time);
                 MutateStateWithInput(input);
+                YargLogger.LogFormatInfo("Processing input at {0}", input.Time);
                 UpdateHitLogic(input.Time);
 
                 // Skip non-input update if possible
@@ -210,18 +211,6 @@ namespace YARG.Core.Engine
             _scheduledUpdates.Sort();
         }
 
-        protected void StartTimer(ref EngineTimer timer, double startTime, double offset = 0)
-        {
-            if (offset > 0)
-            {
-                timer.StartWithOffset(startTime, offset);
-            }
-            else
-            {
-                timer.Start(startTime);
-            }
-        }
-
         public abstract void Reset(bool keepCurrentButtons = false);
 
         protected abstract void MutateStateWithInput(GameInput gameInput);
@@ -263,6 +252,18 @@ namespace YARG.Core.Engine
         public abstract void UpdateBot(double songTime);
 
         public abstract (double FrontEnd, double BackEnd) CalculateHitWindow();
+
+        protected static void StartTimer(ref EngineTimer timer, double startTime, double offset = 0)
+        {
+            if (offset > 0)
+            {
+                timer.StartWithOffset(startTime, offset);
+            }
+            else
+            {
+                timer.Start(startTime);
+            }
+        }
 
         protected static bool IsTimeBetween(double time, double prevTime, double nextTime)
         {

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -57,6 +57,8 @@ namespace YARG.Core.Engine
 
         public void Update(double time)
         {
+            YargLogger.LogFormatTrace("---- Starting update loop with time {0} ----", time);
+
             while (InputQueue.TryDequeue(out var input))
             {
                 // Skip inputs that are in the past
@@ -76,8 +78,8 @@ namespace YARG.Core.Engine
                 }
 
                 RunQueuedUpdates(input.Time);
+                YargLogger.LogFormatTrace("Processing input {0} ({1}) update at {2}", input.GetAction<GuitarAction>(), input.Button, input.Time);
                 MutateStateWithInput(input);
-                YargLogger.LogFormatTrace("Processing input {0} ({1}) at {2}", input.GetAction<GuitarAction>(), input.Button, input.Time);
                 UpdateHitLogic(input.Time);
 
                 // Skip non-input update if possible
@@ -96,6 +98,7 @@ namespace YARG.Core.Engine
             {
                 YargLogger.LogWarning("Input queue was not fully cleared!");
             }
+            YargLogger.LogFormatTrace("Running frame update at {0}", time);
             RunQueuedUpdates(time);
             UpdateHitLogic(time);
         }
@@ -110,7 +113,7 @@ namespace YARG.Core.Engine
 
             if (_scheduledUpdates.Count > 0)
             {
-                YargLogger.LogFormatTrace("{0} updates ready to be simulated", _scheduledUpdates.Count);
+                YargLogger.LogFormatTrace("-- {0} updates ready to be simulated --", _scheduledUpdates.Count);
             }
             int i = 0;
             for (; i < _scheduledUpdates.Count; i++)
@@ -142,7 +145,7 @@ namespace YARG.Core.Engine
 
         protected virtual void GenerateQueuedUpdates(double nextTime)
         {
-
+            YargLogger.LogFormatTrace("Generating queued updates up to {0}", nextTime);
         }
 
         /// <summary>

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -78,7 +78,7 @@ namespace YARG.Core.Engine
 
                 RunQueuedUpdates(input.Time);
                 MutateStateWithInput(input);
-                RunHitLogic(input.Time);
+                UpdateHitLogic(input.Time);
 
                 // Skip non-input update if possible
                 if (input.Time == time)
@@ -92,7 +92,7 @@ namespace YARG.Core.Engine
             // Update to the given time
             YargLogger.Assert(InputQueue.Count == 0, "Input queue was not fully cleared!");
             RunQueuedUpdates(time);
-            RunHitLogic(time);
+            UpdateHitLogic(time);
         }
 
         private void RunQueuedUpdates(double time)
@@ -124,7 +124,7 @@ namespace YARG.Core.Engine
                     break;
                 }
 
-                RunHitLogic(updateTime);
+                UpdateHitLogic(updateTime);
             }
 
             // Remove all processed updates
@@ -198,11 +198,6 @@ namespace YARG.Core.Engine
             _scheduledUpdates.Sort();
         }
 
-        protected void RunHitLogic(double time)
-        {
-            UpdateEngineLogic(time);
-        }
-
         protected void StartTimer(ref EngineTimer timer, double startTime, double offset = 0)
         {
             if (offset > 0)
@@ -226,7 +221,7 @@ namespace YARG.Core.Engine
         /// </summary>
         /// <param name="time">The time in which to simulate hit logic at.</param>
         /// <returns>True if a note was updated (hit or missed). False if no changes.</returns>
-        protected abstract bool UpdateEngineLogic(double time);
+        protected abstract void UpdateHitLogic(double time);
 
         /// <summary>
         /// Resets the engine's state back to default and then processes the list of inputs up to the given time.

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -253,5 +253,10 @@ namespace YARG.Core.Engine
         public abstract void UpdateBot(double songTime);
 
         public abstract (double FrontEnd, double BackEnd) CalculateHitWindow();
+
+        protected static bool IsTimeBetween(double time, double prevTime, double nextTime)
+        {
+            return time > prevTime && time < nextTime;
+        }
     }
 }

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -77,7 +77,7 @@ namespace YARG.Core.Engine
 
                 RunQueuedUpdates(input.Time);
                 MutateStateWithInput(input);
-                YargLogger.LogFormatInfo("Processing input at {0}", input.Time);
+                YargLogger.LogFormatTrace("Processing input {0} ({1}) at {2}", input.GetAction<GuitarAction>(), input.Button, input.Time);
                 UpdateHitLogic(input.Time);
 
                 // Skip non-input update if possible
@@ -110,7 +110,7 @@ namespace YARG.Core.Engine
 
             if (_scheduledUpdates.Count > 0)
             {
-                YargLogger.LogFormatInfo("{0} updates ready to be simulated", _scheduledUpdates.Count);
+                YargLogger.LogFormatTrace("{0} updates ready to be simulated", _scheduledUpdates.Count);
             }
             int i = 0;
             for (; i < _scheduledUpdates.Count; i++)
@@ -132,7 +132,7 @@ namespace YARG.Core.Engine
                     continue;
                 }
 
-                YargLogger.LogFormatInfo("Running scheduled update at {0}", updateTime);
+                YargLogger.LogFormatTrace("Running scheduled update at {0}", updateTime);
                 UpdateHitLogic(updateTime);
             }
 

--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -18,7 +18,7 @@ namespace YARG.Core.Engine.Drums.Engines
             }
         }
 
-        protected override bool UpdateEngineLogic(double time)
+        protected override void UpdateHitLogic(double time)
         {
             UpdateTimeVariables(time);
             UpdateStarPower();
@@ -26,7 +26,7 @@ namespace YARG.Core.Engine.Drums.Engines
             // Quit early if there are no notes left
             if (State.NoteIndex >= Notes.Count)
             {
-                return false;
+                return;
             }
 
             var note = Notes[State.NoteIndex];
@@ -54,7 +54,7 @@ namespace YARG.Core.Engine.Drums.Engines
                     MissNote(chordNote);
                 }
 
-                return true;
+                return;
             }
 
             // Check for note hit
@@ -75,11 +75,11 @@ namespace YARG.Core.Engine.Drums.Engines
 
                 if (inputEaten)
                 {
-                    return true;
+                    return;
                 }
             }
 
-            return false;
+            return;
         }
 
         private bool ProcessNoteHit(DrumNote note)
@@ -127,7 +127,7 @@ namespace YARG.Core.Engine.Drums.Engines
             throw new System.NotImplementedException();
         }
 
-        protected override bool CheckForNoteHit() => throw new System.NotImplementedException();
+        protected override void CheckForNoteHit() => throw new System.NotImplementedException();
 
         protected override bool CanNoteBeHit(DrumNote note) => throw new System.NotImplementedException();
     }

--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -122,7 +122,7 @@ namespace YARG.Core.Engine.Drums.Engines
             return false;
         }
 
-        public override void UpdateBot(double songTime)
+        protected override void UpdateBot(double songTime)
         {
             throw new System.NotImplementedException();
         }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -156,7 +156,8 @@ namespace YARG.Core.Engine.Guitar.Engines
                     if (missed)
                     {
                         MissNote(note);
-                        YargLogger.LogFormatTrace("Missed note (Index: {0}, Mask: {1}) at {2}", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
+                        YargLogger.LogFormatTrace("Missed note (Index: {0}, Mask: {1}) at {2}", i,
+                            note.NoteMask, State.CurrentTime);
                     }
 
                     break;
@@ -165,10 +166,13 @@ namespace YARG.Core.Engine.Guitar.Engines
                 // Cannot hit the note
                 if (!CanNoteBeHit(note))
                 {
+                    YargLogger.LogFormatTrace("Cant hit note (Index: {0}, Mask {1}) at {2}. Buttons: {3}", i,
+                        note.NoteMask, State.CurrentTime, State.ButtonMask);
                     // This does nothing special, it's just logging strum leniency
                     if (IsFirstNoteInWindow() && State is { HasStrummed: true, StrumLeniencyTimer: { IsActive: true } })
                     {
-                        YargLogger.LogFormatTrace("Starting strum leniency at {0}, will end at {1}", State.CurrentTime, State.StrumLeniencyTimer.EndTime);
+                        YargLogger.LogFormatTrace("Starting strum leniency at {0}, will end at {1}", State.CurrentTime,
+                            State.StrumLeniencyTimer.EndTime);
                     }
 
                     // Note skipping not allowed on the first note if hopo/tap
@@ -183,34 +187,40 @@ namespace YARG.Core.Engine.Guitar.Engines
 
                 // Handles hitting a hopo notes
                 // If first note is a hopo then it can be hit without combo (for practice mode)
-                bool hopoCondition = note.IsHopo && IsFirstNoteInWindow() && (EngineStats.Combo > 0 || State.NoteIndex == 0);
+                bool hopoCondition = note.IsHopo && IsFirstNoteInWindow() &&
+                    (EngineStats.Combo > 0 || State.NoteIndex == 0);
 
                 // If a note is a tap then it can be hit only if it is the closest note, unless
                 // the combo is 0 then it can be hit regardless of the distance (note skipping)
                 bool tapCondition = note.IsTap && (IsFirstNoteInWindow() || EngineStats.Combo == 0);
 
                 bool frontEndIsExpired = note.Time > State.FrontEndExpireTime;
-                bool canUseInfFrontEnd = EngineParameters.InfiniteFrontEnd || !frontEndIsExpired || State.NoteIndex == 0;
+                bool canUseInfFrontEnd =
+                    EngineParameters.InfiniteFrontEnd || !frontEndIsExpired || State.NoteIndex == 0;
 
                 // Attempt to hit with hopo/tap rules
                 if (State.HasTapped && (hopoCondition || tapCondition) && canUseInfFrontEnd && !State.WasNoteGhosted)
                 {
                     HitNote(note);
-                    YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with hopo rules", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
+                    YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with hopo rules",
+                        i, note.NoteMask, State.CurrentTime);
                     break;
                 }
 
                 // If hopo/tap checks failed then the note can be hit if it was strummed
-                if ((State.HasStrummed || State.StrumLeniencyTimer.IsActive) && (IsFirstNoteInWindow() || (State.NoteIndex > 0 && EngineStats.Combo == 0)))
+                if ((State.HasStrummed || State.StrumLeniencyTimer.IsActive) &&
+                    (IsFirstNoteInWindow() || (State.NoteIndex > 0 && EngineStats.Combo == 0)))
                 {
                     HitNote(note);
                     if (State.HasStrummed)
                     {
-                        YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with strum input", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
+                        YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with strum input",
+                            i, note.NoteMask, State.CurrentTime);
                     }
                     else
                     {
-                        YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with strum leniency", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
+                        YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with strum leniency",
+                            i, note.NoteMask, State.CurrentTime);
                     }
 
                     break;

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -156,6 +156,10 @@ namespace YARG.Core.Engine.Guitar.Engines
             // Note skipping, useful for combo regain
             if (!CanNoteBeHit(note))
             {
+                if (State is { HasStrummed: true, StrumLeniencyTimer: { IsActive: true } })
+                {
+                    YargLogger.LogFormatTrace("Starting strum leniency at {0}, will end at {1}", State.CurrentTime, State.StrumLeniencyTimer.EndTime);
+                }
                 // TODO Add note skipping logic
                 return;
             }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -2,6 +2,7 @@
 using YARG.Core.Chart;
 using YARG.Core.Engine.Logging;
 using YARG.Core.Input;
+using YARG.Core.Logging;
 
 namespace YARG.Core.Engine.Guitar.Engines
 {
@@ -38,6 +39,7 @@ namespace YARG.Core.Engine.Guitar.Engines
 
                 ToggleFret(gameInput.Action, gameInput.Button);
             }
+            YargLogger.LogFormatTrace("Mutated input state: Button Mask: {0}, HasFretted: {1}, HasStrummed: {2}", State.FretMask, State.HasFretted, State.HasStrummed);
         }
 
         protected override void UpdateHitLogic(double time)
@@ -145,6 +147,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 if (missed)
                 {
                     MissNote(note);
+                    YargLogger.LogFormatTrace("Missed note (Index: {0}, Mask: {1}) at {2}", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
                     return;
                 }
 
@@ -175,12 +178,10 @@ namespace YARG.Core.Engine.Guitar.Engines
             if (State.HasTapped && (hopoCondition || note.IsTap) && canUseInfFrontEnd && !State.WasNoteGhosted)
             {
                 HitNote(note);
-
-                EventLogger.LogEvent(new ConsistentEngineEvent(State.CurrentTime)
+                if (State.HasStrummed)
                 {
-                    Message = $"Note ({State.NoteIndex}) hit via tap"
-                });
-
+                    YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with hopo rules", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
+                }
                 return;
             }
 
@@ -188,20 +189,13 @@ namespace YARG.Core.Engine.Guitar.Engines
             if (State.HasStrummed || State.StrumLeniencyTimer.IsActive)
             {
                 HitNote(note);
-
                 if (State.HasStrummed)
                 {
-                    EventLogger.LogEvent(new ConsistentEngineEvent(State.CurrentTime)
-                    {
-                        Message = $"Note ({State.NoteIndex}) hit via strum input"
-                    });
+                    YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with strum input", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
                 }
                 else
                 {
-                    EventLogger.LogEvent(new ConsistentEngineEvent(State.CurrentTime)
-                    {
-                        Message = $"Note ({State.NoteIndex}) hit via strum leniency"
-                    });
+                    YargLogger.LogFormatTrace("Hit note (Index: {0}, Mask: {1}) at {2} with strum leniency", State.NoteIndex - 1, note.NoteMask, State.CurrentTime);
                 }
             }
         }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -62,6 +62,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                     State.HopoLeniencyTimer.Disable();
 
                     strumEatenByHopo = true;
+                    ReRunHitLogic = true;
                 }
                 else
                 {
@@ -96,6 +97,8 @@ namespace YARG.Core.Engine.Guitar.Engines
 
                 // Start the strum leniency timer at full value
                 StartTimer(ref State.StrumLeniencyTimer, State.CurrentTime, offset);
+
+                ReRunHitLogic = true;
             }
 
             if (State.HasFretted)
@@ -328,6 +331,8 @@ namespace YARG.Core.Engine.Guitar.Engines
             if (State.HopoLeniencyTimer.IsActive && State.HopoLeniencyTimer.IsExpired(State.CurrentTime))
             {
                 State.HopoLeniencyTimer.Disable();
+
+                ReRunHitLogic = true;
             }
 
             if (State.StrumLeniencyTimer.IsActive)
@@ -338,6 +343,8 @@ namespace YARG.Core.Engine.Guitar.Engines
                     //YargTrace.LogInfo("Strum Leniency: Expired. Overstrumming");
                     Overstrum();
                     State.StrumLeniencyTimer.Disable();
+
+                    ReRunHitLogic = true;
                 }
             }
         }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -40,7 +40,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             }
         }
 
-        protected override bool UpdateEngineLogic(double time)
+        protected override void UpdateHitLogic(double time)
         {
             UpdateTimeVariables(time);
             UpdateStarPower();
@@ -79,7 +79,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 State.HasFretted = false;
                 State.IsFretPress = false;
                 State.HasWhammied = false;
-                return false;
+                return;
             }
 
             var note = Notes[State.NoteIndex];
@@ -117,15 +117,13 @@ namespace YARG.Core.Engine.Guitar.Engines
                 }
             }
 
-            bool isNoteHit = CheckForNoteHit();
-
+            CheckForNoteHit();
             UpdateSustains();
 
             State.HasStrummed = false;
             State.HasFretted = false;
             State.IsFretPress = false;
             State.HasWhammied = false;
-            return isNoteHit;
         }
 
         public override void UpdateBot(double songTime)
@@ -133,13 +131,13 @@ namespace YARG.Core.Engine.Guitar.Engines
             throw new NotImplementedException();
         }
 
-        protected override bool CheckForNoteHit()
+        protected override void CheckForNoteHit()
         {
             var note = Notes[State.NoteIndex];
 
             if (note.WasFullyHitOrMissed())
             {
-                return false;
+                return;
             }
 
             if (!IsNoteInWindow(note, out bool missed))
@@ -147,10 +145,10 @@ namespace YARG.Core.Engine.Guitar.Engines
                 if (missed)
                 {
                     MissNote(note);
-                    return true;
+                    return;
                 }
 
-                return false;
+                return;
             }
 
             //State.HopoLeniencyTimer.Disable();
@@ -159,7 +157,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             if (!CanNoteBeHit(note))
             {
                 // TODO Add note skipping logic
-                return false;
+                return;
             }
 
             // Handles hitting a hopo/tap notes
@@ -179,7 +177,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                     Message = $"Note ({State.NoteIndex}) hit via tap"
                 });
 
-                return true;
+                return;
             }
 
             // If hopo/tap checks failed then the note can be hit if it was strummed
@@ -201,12 +199,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                         Message = $"Note ({State.NoteIndex}) hit via strum leniency"
                     });
                 }
-
-
-                return true;
             }
-
-            return false;
         }
 
         protected override bool CanNoteBeHit(GuitarNote note)

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using YARG.Core.Chart;
-using YARG.Core.Engine.Logging;
 using YARG.Core.Input;
 using YARG.Core.Logging;
 
@@ -33,13 +32,15 @@ namespace YARG.Core.Engine.Guitar.Engines
             }
             else if (IsFretInput(gameInput))
             {
-                State.LastFretMask = State.FretMask;
+                State.LastButtonMask = State.ButtonMask;
                 State.HasFretted = true;
                 State.IsFretPress = gameInput.Button;
 
                 ToggleFret(gameInput.Action, gameInput.Button);
             }
-            YargLogger.LogFormatTrace("Mutated input state: Button Mask: {0}, HasFretted: {1}, HasStrummed: {2}", State.FretMask, State.HasFretted, State.HasStrummed);
+
+            YargLogger.LogFormatTrace("Mutated input state: Button Mask: {0}, HasFretted: {1}, HasStrummed: {2}",
+                State.ButtonMask, State.HasFretted, State.HasStrummed);
         }
 
         protected override void UpdateHitLogic(double time)
@@ -219,98 +220,93 @@ namespace YARG.Core.Engine.Guitar.Engines
 
         protected override bool CanNoteBeHit(GuitarNote note)
         {
-            byte fretMask = State.FretMask;
+            byte buttonsMasked = State.ButtonMask;
             foreach (var sustain in ActiveSustains)
             {
                 var sustainNote = sustain.Note;
 
-                // Don't want to mask off the note we're checking otherwise it'll always return false lol
-                if (note == sustainNote)
+                if (sustainNote.IsExtendedSustain)
                 {
-                    continue;
-                }
-
-                // Mask off the disjoint mask if its disjointed or extended disjointed
-                // This removes just the single fret of the disjoint note
-                if ((sustainNote.IsExtendedSustain && sustainNote.IsDisjoint) || sustainNote.IsDisjoint)
-                {
-                    fretMask -= (byte) sustainNote.DisjointMask;
-                }
-                else if (sustainNote.IsExtendedSustain)
-                {
-                    // Remove the entire note mask if its an extended sustain
+                    // Remove the note mask if its an extended sustain
                     // Difference between NoteMask and DisjointMask is that DisjointMask is only a single fret
                     // while NoteMask is the entire chord
-                    fretMask -= (byte) sustainNote.NoteMask;
+
+                    var maskToRemove = sustainNote.IsDisjoint ? sustainNote.DisjointMask : sustainNote.NoteMask;
+                    buttonsMasked -= (byte) maskToRemove;
                 }
             }
 
-            // Only used for sustain logic
-            bool useDisjointMask = note is { IsDisjoint: true, WasHit: true };
+            return IsNoteHittable(note, buttonsMasked);
 
-            // Use the DisjointMask for comparison if disjointed and was hit (for sustain logic)
-            int noteMask = useDisjointMask ? note.DisjointMask : note.NoteMask;
-
-            // If disjointed and is sustain logic (was hit), can hit if disjoint mask matches
-            if (useDisjointMask && (note.DisjointMask & fretMask) != 0)
+            static bool IsNoteHittable(GuitarNote note, byte buttonsMasked)
             {
-                return true;
-            }
+                // Only used for sustain logic
+                bool useDisjointMask = note is { IsDisjoint: true, WasHit: true };
 
-            // If open, must not hold any frets
-            // If not open, must be holding at least 1 fret
-            if (noteMask == 0 && fretMask != 0 || noteMask != 0 && fretMask == 0)
-            {
-                return false;
-            }
+                // Use the DisjointMask for comparison if disjointed and was hit (for sustain logic)
+                int noteMask = useDisjointMask ? note.DisjointMask : note.NoteMask;
 
-            // If holding exact note mask, can hit
-            if (fretMask == noteMask)
-            {
-                return true;
-            }
-
-            // Anchoring
-
-            // XORing the two masks will give the anchor (held frets) around the note.
-            int anchorButtons = fretMask ^ noteMask;
-
-            // Chord logic
-            if (note.IsChord)
-            {
-                if (note.IsStrum)
+                // If disjointed and is sustain logic (was hit), can hit if disjoint mask matches
+                if (useDisjointMask && (note.DisjointMask & buttonsMasked) != 0)
                 {
-                    // Buttons must match note mask exactly for strum chords
-                    return fretMask == noteMask;
+                    return true;
                 }
 
-                // Anchoring hopo/tap chords
-
-                // Gets the lowest fret of the chord.
-                var chordMask = 0;
-                for (var fret = GuitarAction.GreenFret; fret <= GuitarAction.OrangeFret; fret++)
+                // If open, must not hold any frets
+                // If not open, must be holding at least 1 fret
+                if (noteMask == 0 && buttonsMasked != 0 || noteMask != 0 && buttonsMasked == 0)
                 {
-                    chordMask = 1 << (int) fret;
+                    return false;
+                }
 
-                    // If the current fret mask is part of the chord, break
-                    if ((chordMask & note.NoteMask) == chordMask)
+                // If holding exact note mask, can hit
+                if (buttonsMasked == noteMask)
+                {
+                    return true;
+                }
+
+                // Anchoring
+
+                // XORing the two masks will give the anchor (held frets) around the note.
+                int anchorButtons = buttonsMasked ^ noteMask;
+
+                // Chord logic
+                if (note.IsChord)
+                {
+                    if (note.IsStrum)
                     {
-                        break;
+                        // Buttons must match note mask exactly for strum chords
+                        return buttonsMasked == noteMask;
                     }
+
+                    // Anchoring hopo/tap chords
+
+                    // Gets the lowest fret of the chord.
+                    var chordMask = 0;
+                    for (var fret = GuitarAction.GreenFret; fret <= GuitarAction.OrangeFret; fret++)
+                    {
+                        chordMask = 1 << (int) fret;
+
+                        // If the current fret mask is part of the chord, break
+                        if ((chordMask & note.NoteMask) == chordMask)
+                        {
+                            break;
+                        }
+                    }
+
+                    // Anchor part:
+                    // Lowest fret of chord must be bigger or equal to anchor buttons
+                    // (can't hold note higher than the highest fret of chord)
+
+                    // Button mask subtract the anchor must equal chord mask (all frets of chord held)
+                    return chordMask >= anchorButtons && buttonsMasked - anchorButtons == note.NoteMask;
                 }
 
-                // Anchor part:
-                // Lowest fret of chord must be bigger or equal to anchor buttons
-                // (can't hold note higher than the highest fret of chord)
+                // Anchoring single notes
 
-                // Button mask subtract the anchor must equal chord mask (all frets of chord held)
-                return chordMask >= anchorButtons && fretMask - anchorButtons == note.NoteMask;
+                // Anchor buttons held are lower than the note mask
+                return anchorButtons < noteMask;
             }
-
-            // Anchoring single notes
-
-            // Anchor buttons held are lower than the note mask
-            return anchorButtons < noteMask;
         }
 
         protected override void HitNote(GuitarNote note)
@@ -378,10 +374,10 @@ namespace YARG.Core.Engine.Guitar.Engines
             }
 
             // Input is a hammer-on if the highest fret held is higher than the highest fret of the previous mask
-            bool isHammerOn = GetMostSignificantBit(State.FretMask) > GetMostSignificantBit(State.LastFretMask);
+            bool isHammerOn = GetMostSignificantBit(State.ButtonMask) > GetMostSignificantBit(State.LastButtonMask);
 
             // Input is a hammer-on and the button pressed is not part of the note mask (incorrect fret)
-            if (isHammerOn && (State.FretMask & note.NoteMask) == 0)
+            if (isHammerOn && (State.ButtonMask & note.NoteMask) == 0)
             {
                 return true;
             }

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -110,14 +110,14 @@ namespace YARG.Core.Engine.Guitar
 
         public override void Reset(bool keepCurrentButtons = false)
         {
-            byte buttons = State.FretMask;
+            byte buttons = State.ButtonMask;
             ActiveSustains.Clear();
 
             base.Reset(keepCurrentButtons);
 
             if (keepCurrentButtons)
             {
-                State.FretMask = buttons;
+                State.ButtonMask = buttons;
             }
         }
 
@@ -508,12 +508,12 @@ namespace YARG.Core.Engine.Guitar
 
         protected void ToggleFret(int fret, bool active)
         {
-            State.FretMask = (byte) (active ? State.FretMask | (1 << fret) : State.FretMask & ~(1 << fret));
+            State.ButtonMask = (byte) (active ? State.ButtonMask | (1 << fret) : State.ButtonMask & ~(1 << fret));
         }
 
         public bool IsFretHeld(GuitarAction fret)
         {
-            return (State.FretMask & (1 << (int) fret)) != 0;
+            return (State.ButtonMask & (1 << (int) fret)) != 0;
         }
 
         protected static bool IsFretInput(GameInput input)

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -62,7 +62,7 @@ namespace YARG.Core.Engine.Guitar
                 // Burst time is for scoring, so that scoring finishes at the correct time
                 if (IsTimeBetween(burstTime, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatInfo("Queuing sustain (mask: {0}) burst time at {1}", sustain.Note.NoteMask,
+                    YargLogger.LogFormatTrace("Queuing sustain (mask: {0}) burst time at {1}", sustain.Note.NoteMask,
                         burstTime);
                     QueueUpdateTime(burstTime);
                 }
@@ -71,7 +71,7 @@ namespace YARG.Core.Engine.Guitar
                 // also be handled.
                 if (IsTimeBetween(endTime, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatInfo("Queuing sustain (mask: {0}) end time at {1}", sustain.Note.NoteMask,
+                    YargLogger.LogFormatTrace("Queuing sustain (mask: {0}) end time at {1}", sustain.Note.NoteMask,
                         endTime);
                     QueueUpdateTime(endTime);
                 }
@@ -82,7 +82,7 @@ namespace YARG.Core.Engine.Guitar
             {
                 if (IsTimeBetween(State.HopoLeniencyTimer.EndTime, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatInfo("Queuing hopo leniency end time at {0}", State.HopoLeniencyTimer.EndTime);
+                    YargLogger.LogFormatTrace("Queuing hopo leniency end time at {0}", State.HopoLeniencyTimer.EndTime);
                     QueueUpdateTime(State.HopoLeniencyTimer.EndTime);
                 }
             }
@@ -91,7 +91,7 @@ namespace YARG.Core.Engine.Guitar
             {
                 if (IsTimeBetween(State.StrumLeniencyTimer.EndTime, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatInfo("Queuing strum leniency end time at {0}",
+                    YargLogger.LogFormatTrace("Queuing strum leniency end time at {0}",
                         State.StrumLeniencyTimer.EndTime);
                     QueueUpdateTime(State.StrumLeniencyTimer.EndTime);
                 }
@@ -101,7 +101,7 @@ namespace YARG.Core.Engine.Guitar
             {
                 if (IsTimeBetween(State.StarPowerWhammyTimer.EndTime, previousTime, nextTime))
                 {
-                    YargLogger.LogFormatInfo("Queuing star power whammy end time at {0}",
+                    YargLogger.LogFormatTrace("Queuing star power whammy end time at {0}",
                         State.StarPowerWhammyTimer.EndTime);
                     QueueUpdateTime(State.StarPowerWhammyTimer.EndTime);
                 }
@@ -135,14 +135,14 @@ namespace YARG.Core.Engine.Guitar
                 return;
             }
 
-            YargLogger.LogFormatInfo("Overstrummed at {0}", State.CurrentTime);
+            YargLogger.LogFormatTrace("Overstrummed at {0}", State.CurrentTime);
 
             // Break all active sustains
             for (int i = 0; i < ActiveSustains.Count; i++)
             {
                 var sustain = ActiveSustains[i];
                 ActiveSustains.RemoveAt(i);
-                YargLogger.LogFormatInfo("Ended sustain at {0}", State.CurrentTime);
+                YargLogger.LogFormatTrace("Ended sustain at {0}", State.CurrentTime);
                 i--;
 
                 double finalScore = CalculateSustainPoints(sustain, State.CurrentTick);
@@ -382,7 +382,7 @@ namespace YARG.Core.Engine.Guitar
 
             ActiveSustains.Add(sustain);
 
-            YargLogger.LogFormatInfo("Started sustain at {0} (tick len: {1}, time len: {2})", State.CurrentTime, note.TickLength, note.TimeLength);
+            YargLogger.LogFormatTrace("Started sustain at {0} (tick len: {1}, time len: {2})", State.CurrentTime, note.TickLength, note.TimeLength);
 
             OnSustainStart?.Invoke(note);
         }
@@ -422,7 +422,7 @@ namespace YARG.Core.Engine.Guitar
                     // Sustain has ended, so commit the points
                     if (dropped || isBurst)
                     {
-                        YargLogger.LogFormatInfo("Finished scoring sustain at {0} (dropped: {1}, burst: {2})", State.CurrentTime, dropped, isBurst);
+                        YargLogger.LogFormatTrace("Finished scoring sustain at {0} (dropped: {1}, burst: {2})", State.CurrentTime, dropped, isBurst);
                         double finalScore = CalculateSustainPoints(sustain, sustainTick);
                         AddScore((int) Math.Ceiling(finalScore));
                     }
@@ -435,7 +435,7 @@ namespace YARG.Core.Engine.Guitar
                 // Only remove the sustain if its dropped or has reached the final tick
                 if (dropped || isEndOfSustain)
                 {
-                    YargLogger.LogFormatInfo("Ended sustain at {0} (dropped: {1}, end: {2})", State.CurrentTime, dropped, isEndOfSustain);
+                    YargLogger.LogFormatTrace("Ended sustain at {0} (dropped: {1}, end: {2})", State.CurrentTime, dropped, isEndOfSustain);
                     ActiveSustains.RemoveAt(i);
                     i--;
                     OnSustainEnd?.Invoke(note, State.CurrentTime, sustain.HasFinishedScoring);

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -387,7 +387,7 @@ namespace YARG.Core.Engine.Guitar
 
                 // If we're close enough to the end of the sustain, finish it
                 // Provides leniency for sustains with no gap (and just in general)
-                bool isBurst = (int) (note.TickEnd - State.CurrentTick) <= SustainBurstThreshold;
+                bool isBurst = (int) State.CurrentTick >= note.TickEnd - SustainBurstThreshold;
                 bool isEndOfSustain = State.CurrentTick >= note.TickEnd;
 
                 uint sustainTick = isBurst || isEndOfSustain ? note.TickEnd : State.CurrentTick;

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -64,7 +64,7 @@ namespace YARG.Core.Engine.Guitar
                 {
                     YargLogger.LogFormatTrace("Queuing sustain (mask: {0}) burst time at {1}", sustain.Note.NoteMask,
                         burstTime);
-                    QueueUpdateTime(burstTime);
+                    QueueUpdateTime(burstTime, "Sustain Burst");
                 }
 
                 // The true end of the sustain is for hit logic. Sustains are "kept" even after the burst ticks so must
@@ -73,7 +73,7 @@ namespace YARG.Core.Engine.Guitar
                 {
                     YargLogger.LogFormatTrace("Queuing sustain (mask: {0}) end time at {1}", sustain.Note.NoteMask,
                         endTime);
-                    QueueUpdateTime(endTime);
+                    QueueUpdateTime(endTime, "Sustain End");
                 }
             }
 
@@ -83,7 +83,7 @@ namespace YARG.Core.Engine.Guitar
                 if (IsTimeBetween(State.HopoLeniencyTimer.EndTime, previousTime, nextTime))
                 {
                     YargLogger.LogFormatTrace("Queuing hopo leniency end time at {0}", State.HopoLeniencyTimer.EndTime);
-                    QueueUpdateTime(State.HopoLeniencyTimer.EndTime);
+                    QueueUpdateTime(State.HopoLeniencyTimer.EndTime, "HOPO Leniency End");
                 }
             }
 
@@ -93,7 +93,7 @@ namespace YARG.Core.Engine.Guitar
                 {
                     YargLogger.LogFormatTrace("Queuing strum leniency end time at {0}",
                         State.StrumLeniencyTimer.EndTime);
-                    QueueUpdateTime(State.StrumLeniencyTimer.EndTime);
+                    QueueUpdateTime(State.StrumLeniencyTimer.EndTime, "Strum Leniency End");
                 }
             }
 
@@ -103,7 +103,7 @@ namespace YARG.Core.Engine.Guitar
                 {
                     YargLogger.LogFormatTrace("Queuing star power whammy end time at {0}",
                         State.StarPowerWhammyTimer.EndTime);
-                    QueueUpdateTime(State.StarPowerWhammyTimer.EndTime);
+                    QueueUpdateTime(State.StarPowerWhammyTimer.EndTime, "Star Power Whammy End");
                 }
             }
         }
@@ -349,7 +349,7 @@ namespace YARG.Core.Engine.Guitar
 
         protected void StartSustain(GuitarNote note)
         {
-            return;
+            //return;
             var sustain = new ActiveSustain(note);
 
             ActiveSustains.Add(sustain);

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -178,16 +178,7 @@ namespace YARG.Core.Engine.Guitar
             {
                 skipped = true;
                 MissNote(prevNote);
-
-                EventLogger.LogEvent(new NoteEngineEvent(State.CurrentTime)
-                {
-                    NoteTime = prevNote.Time,
-                    NoteLength = prevNote.TimeLength,
-                    NoteIndex = State.NoteIndex,
-                    NoteMask = prevNote.NoteMask,
-                    WasHit = false,
-                    WasSkipped = true,
-                });
+                YargLogger.LogFormatTrace("Missed note {0} due to note skip at {1}", State.NoteIndex - 1, State.CurrentTime);
 
                 prevNote = prevNote.PreviousNote;
             }
@@ -245,16 +236,6 @@ namespace YARG.Core.Engine.Guitar
 
             State.WasNoteGhosted = false;
 
-            EventLogger.LogEvent(new NoteEngineEvent(State.CurrentTime)
-            {
-                NoteTime = note.Time,
-                NoteLength = note.TimeLength,
-                NoteIndex = State.NoteIndex,
-                NoteMask = note.NoteMask,
-                WasHit = true,
-                WasSkipped = skipped,
-            });
-
             OnNoteHit?.Invoke(State.NoteIndex, note);
             base.HitNote(note);
         }
@@ -283,16 +264,6 @@ namespace YARG.Core.Engine.Guitar
             EngineStats.Combo = 0;
 
             UpdateMultiplier();
-
-            EventLogger.LogEvent(new NoteEngineEvent(State.CurrentTime)
-            {
-                NoteTime = note.Time,
-                NoteLength = note.TimeLength,
-                NoteIndex = State.NoteIndex,
-                NoteMask = note.NoteMask,
-                WasHit = false,
-                WasSkipped = false,
-            });
 
             OnNoteMissed?.Invoke(State.NoteIndex, note);
             base.MissNote(note);
@@ -378,6 +349,7 @@ namespace YARG.Core.Engine.Guitar
 
         protected void StartSustain(GuitarNote note)
         {
+            return;
             var sustain = new ActiveSustain(note);
 
             ActiveSustains.Add(sustain);

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -142,7 +142,7 @@ namespace YARG.Core.Engine.Guitar
             {
                 var sustain = ActiveSustains[i];
                 ActiveSustains.RemoveAt(i);
-                YargLogger.LogFormatTrace("Ended sustain at {0}", State.CurrentTime);
+                YargLogger.LogFormatTrace("Ended sustain (end time: {0}) at {1}", sustain.GetEndTime(SyncTrack, 0), State.CurrentTime);
                 i--;
 
                 double finalScore = CalculateSustainPoints(sustain, State.CurrentTick);

--- a/YARG.Core/Engine/Guitar/GuitarEngineState.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngineState.cs
@@ -2,11 +2,8 @@
 {
     public class GuitarEngineState : BaseEngineState
     {
-        // Dummy variable for now
+        public byte LastButtonMask;
         public byte ButtonMask;
-
-        public byte LastFretMask;
-        public byte FretMask;
 
         public bool HasFretted;
         public bool HasStrummed;
@@ -46,7 +43,7 @@
         {
             base.Reset();
 
-            FretMask = 0;
+            ButtonMask = 0;
 
             HasFretted = false;
             HasStrummed = false;

--- a/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
@@ -16,14 +16,14 @@ namespace YARG.Core.Engine.Vocals.Engines
             throw new NotImplementedException();
         }
 
-        protected override bool UpdateEngineLogic(double time) => throw new NotImplementedException();
+        protected override void UpdateHitLogic(double time) => throw new NotImplementedException();
 
         public override void UpdateBot(double songTime)
         {
             throw new NotImplementedException();
         }
 
-        protected override bool CheckForNoteHit() => throw new NotImplementedException();
+        protected override void CheckForNoteHit() => throw new NotImplementedException();
 
         protected override bool CanNoteBeHit(VocalNote note) => throw new NotImplementedException();
         protected override void HitNote(VocalNote note) => throw new NotImplementedException();

--- a/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
@@ -18,7 +18,7 @@ namespace YARG.Core.Engine.Vocals.Engines
 
         protected override void UpdateHitLogic(double time) => throw new NotImplementedException();
 
-        public override void UpdateBot(double songTime)
+        protected override void UpdateBot(double songTime)
         {
             throw new NotImplementedException();
         }

--- a/YARG.Core/Extensions/UnsafeExtensions.cs
+++ b/YARG.Core/Extensions/UnsafeExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace YARG.Core.Extensions
+{
+    // Not actually extensions, just backported functions from Unsafe and BitConverter
+    public static class UnsafeExtensions
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static TTo BitCast<TFrom, TTo>(TFrom source)
+            where TFrom : struct
+            where TTo : struct
+        {
+            if (Unsafe.SizeOf<TFrom>() != Unsafe.SizeOf<TTo>())
+                throw new NotSupportedException("Cannot cast between types of different sizes.");
+
+            return Unsafe.ReadUnaligned<TTo>(ref Unsafe.As<TFrom, byte>(ref source));
+        }
+
+        public static ulong DoubleToUInt64Bits(double value)
+        {
+            return BitCast<double, ulong>(value);
+        }
+
+        public static double UInt64BitsToDouble(ulong value)
+        {
+            return BitCast<ulong, double>(value);
+        }
+    }
+}

--- a/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
+++ b/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
@@ -197,13 +197,29 @@ namespace YARG.Core.Replays.Analyzer
                 original.SoloBonuses, result.SoloBonuses,
                 original.StarPowerPhrasesHit, result.StarPowerPhrasesHit);
 
-            return original.CommittedScore == result.CommittedScore &&
+            bool instrumentPass = true;
+
+            if(original is GuitarStats originalGuitar && result is GuitarStats resultGuitar)
+            {
+                instrumentPass = originalGuitar.Overstrums == resultGuitar.Overstrums &&
+                    originalGuitar.GhostInputs == resultGuitar.GhostInputs &&
+                    originalGuitar.HoposStrummed == resultGuitar.HoposStrummed;
+
+                YargLogger.LogFormatDebug("Guitar:\nOverstrums: {0} == {1}\nGhost Inputs: {2} == {3}\nHOPOs Strummed: {4} == {5}",
+                    originalGuitar.Overstrums, resultGuitar.Overstrums,
+                    originalGuitar.GhostInputs, resultGuitar.GhostInputs,
+                    originalGuitar.HoposStrummed, resultGuitar.HoposStrummed);
+            }
+
+            bool generalPass = original.CommittedScore == result.CommittedScore &&
                 original.NotesHit == result.NotesHit &&
                 original.NotesMissed == result.NotesMissed &&
                 original.Combo == result.Combo &&
                 original.MaxCombo == result.MaxCombo &&
                 original.SoloBonuses == result.SoloBonuses &&
                 original.StarPowerPhrasesHit == result.StarPowerPhrasesHit;
+
+            return generalPass && instrumentPass;
         }
     }
 }

--- a/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
+++ b/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
@@ -186,6 +186,17 @@ namespace YARG.Core.Replays.Analyzer
 
         private static bool IsPassResult(BaseStats original, BaseStats result)
         {
+            YargLogger.LogFormatDebug("Score: {0} == {1}\nHit: {2} == {3}\nMissed: {4} == {5}\nCombo: {6} == {7}\nMaxCombo: {8} == {9}\n",
+                original.CommittedScore, result.CommittedScore,
+                original.NotesHit, result.NotesHit,
+                original.NotesMissed, result.NotesMissed,
+                original.Combo, result.Combo,
+                original.MaxCombo, result.MaxCombo);
+
+            YargLogger.LogFormatDebug("Solo: {0} == {1}\nSP: {2} == {3}",
+                original.SoloBonuses, result.SoloBonuses,
+                original.StarPowerPhrasesHit, result.StarPowerPhrasesHit);
+
             return original.CommittedScore == result.CommittedScore &&
                 original.NotesHit == result.NotesHit &&
                 original.NotesMissed == result.NotesMissed &&

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -141,7 +141,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 24_03_08_01;
+        public const int CACHE_VERSION = 24_03_22_01;
 
         protected readonly SongCache cache = new();
 

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -141,7 +141,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 24_03_22_01;
+        public const int CACHE_VERSION = 24_03_23_01;
 
         protected readonly SongCache cache = new();
 

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -602,8 +602,22 @@ namespace YARG.Core.Song
                                     if (!nodeName.StartsWith("UGC_"))
                                         _metadata.Source = "customs";
                                 }
+                                else if (str == "#ifdef")
+                                {
+                                    string conditional = reader.ExtractText();
+                                    if (conditional == "CUSTOMSOURCE")
+                                    {
+                                        _metadata.Source = reader.ExtractText();
+                                    }
+                                    else
+                                    {
+                                        _metadata.Source = "customs";
+                                    }
+                                }
                                 else
+                                {
                                     _metadata.Source = str;
+                                }
 
                                 //// if the source is any official RB game or its DLC, charter = Harmonix
                                 //if (SongSources.GetSource(str).Type == SongSources.SourceType.RB)

--- a/YARG.Core/Song/Entries/Types/SortString.cs
+++ b/YARG.Core/Song/Entries/Types/SortString.cs
@@ -22,7 +22,7 @@ namespace YARG.Core.Song
 
         public SortString(string str)
         {
-            Str = str;
+            Str = RichTextUtils.ReplaceColorNames(str);
             Length = Str.Length;
             SortStr = RemoveDiacritics(RichTextUtils.StripRichTextTags(str));
             HashCode = SortStr.GetHashCode();

--- a/YARG.Core/Utility/MathUtil.cs
+++ b/YARG.Core/Utility/MathUtil.cs
@@ -1,0 +1,37 @@
+using YARG.Core.Extensions;
+
+namespace YARG.Core.Utility
+{
+    public static class MathUtil
+    {
+        // Backported from newer .NET
+        public static double BitIncrement(double x)
+        {
+            ulong bits = UnsafeExtensions.DoubleToUInt64Bits(x);
+
+            const ulong negativeZeroBits = 0x8000_0000_0000_0000;
+            const ulong negativeInfinityBits = 0xFFF0_0000_0000_0000;
+
+            if (!double.IsFinite(x))
+            {
+                return bits == negativeInfinityBits ? double.MinValue : x;
+            }
+
+            if (bits == negativeZeroBits)
+            {
+                return double.Epsilon;
+            }
+
+            if (double.IsNegative(x))
+            {
+                bits -= 1;
+            }
+            else
+            {
+                bits += 1;
+            }
+
+            return UnsafeExtensions.UInt64BitsToDouble(bits);
+        }
+    }
+}


### PR DESCRIPTION
PR for the changes to the engine which ensure it will be deterministic in simulated runs.

This is done by only changing how the hit logic is actually called:
- The upcoming frame time is passed in through a singular function, Update()
- Any inputs queued are processed first
- Simulated updates up to the frame time are then processed
- The frame time is processed

Simulated updates are created as and when they are needed for the next execution (instead of ahead-of-time). This is done by checking if the time of the event (timer end, note front end time etc) is between the last update and the next time (input time or frame time usually). If it's between those times, it is scheduled to be ran in the update loop.

Very minimal changes to the hit logic code should be required, except where systems are flawed to begin with (such as the current star power tick system)