### PR TITLE
Added None as a LightingType

### DIFF
--- a/YARG.Core/Chart/Venue/LightingEvent.cs
+++ b/YARG.Core/Chart/Venue/LightingEvent.cs
@@ -70,5 +70,7 @@ namespace YARG.Core.Chart
         //YARG internal
         Menu,
         Score,
+        //None to be used instead of checks against null
+        None,
     }
 }


### PR DESCRIPTION
There is quite a few checks against CurrentLightingCue being null, this will allow it to always be set to something, removing costly null checks.