### PR TITLE
FILETABLEBLOCKCOUNT wrong endianness

### DIFF
--- a/YARG.Core/IO/ConHandler/CONFile.cs
+++ b/YARG.Core/IO/ConHandler/CONFile.cs
@@ -61,7 +61,7 @@ namespace YARG.Core.IO
             if (stream.Read(int32Buffer[..BYTES_16BIT]) != BYTES_16BIT)
                 return null;
 
-            int length = BYTES_PER_BLOCK * (int32Buffer[0] << 8 | int32Buffer[1]);
+            int length = BYTES_PER_BLOCK * (int32Buffer[0] | int32Buffer[1] << 8);
 
             stream.Seek(FILETABLEFIRSTBLOCK_POSITION, SeekOrigin.Begin);
             if (stream.Read(int32Buffer[..BYTES_24BIT]) != BYTES_24BIT)

--- a/YARG.Core/IO/ConHandler/CONFileListing.cs
+++ b/YARG.Core/IO/ConHandler/CONFileListing.cs
@@ -34,7 +34,7 @@ namespace YARG.Core.IO
             Filename = Encoding.UTF8.GetString(data[..0x28]).TrimEnd('\0');
             flags = (CONFileListingFlag) data[0x28];
 
-            numBlocks = data[0x29] << 16 | data[0x2A] << 8 | data[0x2B];
+            numBlocks = data[0x2B] << 16 | data[0x2A] << 8 | data[0x29];
             firstBlock = data[0x31] << 16 | data[0x30] << 8 | data[0x2F];
             pathIndex = (short) (data[0x32] << 8 | data[0x33]);
             size = data[0x34] << 24 | data[0x35] << 16 | data[0x36] << 8 | data[0x37];


### PR DESCRIPTION
The `FILETABLEBLOCKCOUNT` of CON files is stored as a little-endian int16, but it is being read as a big-endian number.

This causes the following error when loading some multi-song CON files, like the part 1 of the `Guitar Hero Series Main` pack from RB3DX's spreadsheet.

> [Error] [2024-05-04 22:41:05 CONFile.cs:TryParseListings:87] Error while parsing *\yarg\songs\gh\GHRB3main01 - Filelisting blocks constructed out of spec
