### PR TITLE
Add phrase end to X drums chart if X+ phrase ends on 2x kick

### DIFF
--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -194,6 +194,12 @@ namespace YARG.Core.Chart
             CopyFlags(other);
         }
 
+        public void ActivateFlag(NoteFlags noteFlag)
+        {
+            _flags |= noteFlag;
+            Flags |= noteFlag;
+        }
+
         protected abstract void CopyFlags(TNote other);
         protected abstract TNote CloneNote();
 

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Melanchall.DryWetMidi.Core;
+using YARG.Core.Logging;
 using YARG.Core.Parsing;
 
 namespace YARG.Core.Chart
@@ -101,6 +102,8 @@ namespace YARG.Core.Chart
             }
         }
 
+        private delegate bool PhraseEndSelector(DrumNote n);
+
         // public InstrumentTrack<DjNote> Dj { get; set; } = new(Instrument.Dj);
 
         // To explicitly allow creation without going through a file
@@ -144,6 +147,7 @@ namespace YARG.Core.Chart
             // Dj = loader.LoadDjTrack(Instrument.Dj);
 
             PostProcessSections();
+            FixDrumPhraseEnds();
 
             // Ensure beatlines are present
             if (SyncTrack.Beatlines is null or { Count: < 1 })
@@ -164,7 +168,7 @@ namespace YARG.Core.Chart
                 ReadOnlySpan<double> factors = stackalloc double[AUTO_GEN_SECTION_COUNT]{
                     0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0
                 };
-                
+
                 uint startTick = 0;
                 double startTime = SyncTrack.TickToTime(0);
 
@@ -195,6 +199,38 @@ namespace YARG.Core.Chart
                 var lastSection = Sections[^1];
                 lastSection.TickLength = lastTick - lastSection.Tick;
                 lastSection.TimeLength = SyncTrack.TickToTime(lastTick) - lastSection.Time;
+            }
+        }
+
+        private void FixDrumPhraseEnds()
+        {
+            foreach (var drumTrack in new List<InstrumentTrack<DrumNote>>() {ProDrums, FiveLaneDrums, FourLaneDrums})
+            {
+                FixDrumPhraseEnds(drumTrack, n => n.IsSoloEnd, NoteFlags.SoloEnd);
+                FixDrumPhraseEnds(drumTrack, n => n.IsStarPowerEnd, NoteFlags.StarPowerEnd);
+            }
+        }
+
+        private void FixDrumPhraseEnds(InstrumentTrack<DrumNote> drumTrack, PhraseEndSelector isPhraseEnd, NoteFlags phraseEndFlag)
+        {
+            var notesXP = drumTrack.Difficulties[Difficulty.ExpertPlus]?.Notes;
+            var notesX = drumTrack.Difficulties[Difficulty.Expert]?.Notes;
+
+            if (notesXP is null || notesX is null)
+                return;
+
+            var phraseEndsXP = notesXP.Where(n => isPhraseEnd(n));
+            var phraseEndsX = notesX.Where(n => isPhraseEnd(n));
+            if (phraseEndsXP.Count() > phraseEndsX.Count())
+            {
+                foreach (var phraseEndXP in phraseEndsXP)
+                {
+                    var phraseEndX = notesX.Where(n => n.Tick <= phraseEndXP.Tick).Last();
+                    if (!isPhraseEnd(phraseEndX))
+                    {
+                        phraseEndX.ActivateFlag(phraseEndFlag);
+                    }
+                }
             }
         }
 

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -223,13 +223,15 @@ namespace YARG.Core.Chart
             var phraseEndsX = notesX.Where(n => isPhraseEnd(n));
             if (phraseEndsXP.Count() > phraseEndsX.Count())
             {
+                var i = 1;
                 foreach (var phraseEndXP in phraseEndsXP)
                 {
-                    var phraseEndX = notesX.Where(n => n.Tick <= phraseEndXP.Tick).Last();
+                    while (i < notesX.Count() && notesX[i].Tick <= phraseEndXP.Tick)
+                        i++;
+
+                    var phraseEndX = notesX[i - 1];
                     if (!isPhraseEnd(phraseEndX))
-                    {
                         phraseEndX.ActivateFlag(phraseEndFlag);
-                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes issues [237](https://yarg.youtrack.cloud/issue/YARG-237/Solos-or-SP-phrases-ending-on-a-note-only-present-in-Expert-cause-the-phrase-to-not-be-finishable-on-Expert) and https://discord.com/channels/1086048856678084609/1215702320352858164

Maybe [214](https://yarg.youtrack.cloud/issue/YARG-214/Some-solos-do-not-end-correctly) is also the same issue but I couldn't find that chart to test it out.

https://github.com/YARC-Official/YARG.Core/assets/141366895/5a34b051-1765-41fe-93fe-68ac00bce06f

https://github.com/YARC-Official/YARG.Core/assets/141366895/ade28039-763a-4e88-8398-876faf27b85f

Only unsure if there's a more desirable way to flip the flag as we need to go in and change the private _flags field after the object is constructed.