### PR TITLE
Reimplement drums bot

### DIFF
--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -26,7 +26,7 @@ namespace YARG.Core.Engine.Drums.Engines
             UpdateStarPower();
 
             // Update bot (will return if not enabled)
-            // UpdateBot(time);
+            UpdateBot(time);
 
             // Quit early if there are no notes left
             if (State.NoteIndex >= Notes.Count)
@@ -102,9 +102,25 @@ namespace YARG.Core.Engine.Drums.Engines
             return note.Pad == State.PadHit;
         }
 
-        protected override void UpdateBot(double songTime)
+        protected override void UpdateBot(double time)
         {
-            throw new System.NotImplementedException();
+            if (!IsBot || State.NoteIndex >= Notes.Count)
+            {
+                return;
+            }
+
+            var note = Notes[State.NoteIndex];
+
+            if (time < note.Time)
+            {
+                return;
+            }
+
+            // Each note in the "chord" is hit separately on drums
+            foreach (var chordNote in note.ChordEnumerator())
+            {
+                HitNote(chordNote);
+            }
         }
     }
 }

--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -119,7 +119,8 @@ namespace YARG.Core.Engine.Drums.Engines
             // Each note in the "chord" is hit separately on drums
             foreach (var chordNote in note.ChordEnumerator())
             {
-                HitNote(chordNote);
+                    State.PadHit = chordNote.Pad;
+                    CheckForNoteHit();
             }
         }
     }


### PR DESCRIPTION
This adds back the drums bot which was removed when the rewrite happened.
This is implemented in pretty much the same way as the guitar, just with no sustain code.