### PR TITLE
Change points awarded per vocals phrase for lower difficulties

### DIFF
--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -171,9 +171,15 @@ namespace YARG.Core.Engine.Vocals
             }
         }
 
+        /// <remarks>
+        /// Because this method is called in the constructor of
+        /// <see cref="BaseEngine{TNoteType,TEngineParams,TEngineStats,TEngineState}"/>,
+        /// it must use the value in EngineParameters instead of the property
+        /// POINTS_PER_PHRASE as it is not yet set.
+        /// </remarks>
         protected sealed override int CalculateBaseScore()
         {
-            return Notes.Where(note => note.ChildNotes.Count > 0).Sum(_ => POINTS_PER_PHRASE);
+            return Notes.Where(note => note.ChildNotes.Count > 0).Sum(_ => EngineParameters.PointsPerPhrase);
         }
     }
 }

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Linq;
 using YARG.Core.Chart;
-using YARG.Core.Logging;
 
 namespace YARG.Core.Engine.Vocals
 {

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -7,8 +7,6 @@ namespace YARG.Core.Engine.Vocals
     public abstract class VocalsEngine :
         BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats, VocalsEngineState>
     {
-        protected int POINTS_PER_PHRASE;
-
         public delegate void TargetNoteChangeEvent(VocalNote targetNote);
 
         public delegate void PhraseHitEvent(double hitPercentAfterParams, bool fullPoints);
@@ -21,7 +19,6 @@ namespace YARG.Core.Engine.Vocals
             VocalsEngineParameters engineParameters)
             : base(chart, syncTrack, engineParameters, false)
         {
-            POINTS_PER_PHRASE = engineParameters.PointsPerPhrase;
         }
 
         protected override bool HitNote(VocalNote note)
@@ -152,12 +149,12 @@ namespace YARG.Core.Engine.Vocals
 
         protected override void AddScore(VocalNote note)
         {
-            AddScore(POINTS_PER_PHRASE * EngineStats.ScoreMultiplier);
+            AddScore(EngineParameters.PointsPerPhrase * EngineStats.ScoreMultiplier);
         }
 
         protected void AddPartialScore(double hitPercent)
         {
-            int score = (int) ((double) POINTS_PER_PHRASE * EngineStats.ScoreMultiplier * hitPercent);
+            int score = (int) ((double) EngineParameters.PointsPerPhrase * EngineStats.ScoreMultiplier * hitPercent);
             AddScore(score);
         }
 
@@ -171,12 +168,6 @@ namespace YARG.Core.Engine.Vocals
             }
         }
 
-        /// <remarks>
-        /// Because this method is called in the constructor of
-        /// <see cref="BaseEngine{TNoteType,TEngineParams,TEngineStats,TEngineState}"/>,
-        /// it must use the value in EngineParameters instead of the property
-        /// POINTS_PER_PHRASE as it is not yet set.
-        /// </remarks>
         protected sealed override int CalculateBaseScore()
         {
             return Notes.Where(note => note.ChildNotes.Count > 0).Sum(_ => EngineParameters.PointsPerPhrase);

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Linq;
 using YARG.Core.Chart;
+using YARG.Core.Logging;
 
 namespace YARG.Core.Engine.Vocals
 {
     public abstract class VocalsEngine :
         BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats, VocalsEngineState>
     {
-        protected const int POINTS_PER_PHRASE = 2000;
+        protected int POINTS_PER_PHRASE;
 
         public delegate void TargetNoteChangeEvent(VocalNote targetNote);
 
@@ -21,6 +22,7 @@ namespace YARG.Core.Engine.Vocals
             VocalsEngineParameters engineParameters)
             : base(chart, syncTrack, engineParameters, false)
         {
+            POINTS_PER_PHRASE = engineParameters.PointsPerPhrase;
         }
 
         protected override bool HitNote(VocalNote note)

--- a/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
@@ -19,6 +19,9 @@ namespace YARG.Core.Engine.Vocals
         /// </summary>
         public bool SingToActivateStarPower { get; private set; }
 
+        /// <summary>
+        /// Base score awarded per complete vocal phrase.
+        /// </summary>
         public int PointsPerPhrase { get; private set; }
 
         public VocalsEngineParameters()
@@ -42,6 +45,7 @@ namespace YARG.Core.Engine.Vocals
             writer.Write(PhraseHitPercent);
             writer.Write(ApproximateVocalFps);
             writer.Write(SingToActivateStarPower);
+            writer.Write(PointsPerPhrase);
         }
 
         public override void Deserialize(BinaryReader reader, int version = 0)
@@ -51,6 +55,7 @@ namespace YARG.Core.Engine.Vocals
             PhraseHitPercent = reader.ReadDouble();
             ApproximateVocalFps = reader.ReadDouble();
             SingToActivateStarPower = reader.ReadBoolean();
+            PointsPerPhrase = reader.ReadInt32();
         }
     }
 }

--- a/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngineParameters.cs
@@ -19,17 +19,20 @@ namespace YARG.Core.Engine.Vocals
         /// </summary>
         public bool SingToActivateStarPower { get; private set; }
 
+        public int PointsPerPhrase { get; private set; }
+
         public VocalsEngineParameters()
         {
         }
 
         public VocalsEngineParameters(HitWindowSettings hitWindow, int maxMultiplier, float[] starMultiplierThresholds,
-            double phraseHitPercent, bool singToActivateStarPower, double approximateVocalFps)
+            double phraseHitPercent, bool singToActivateStarPower, double approximateVocalFps, int pointsPerPhrase)
             : base(hitWindow, maxMultiplier, starMultiplierThresholds)
         {
             PhraseHitPercent = phraseHitPercent;
             ApproximateVocalFps = approximateVocalFps;
             SingToActivateStarPower = singToActivateStarPower;
+            PointsPerPhrase = pointsPerPhrase;
         }
 
         public override void Serialize(BinaryWriter writer)

--- a/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
+++ b/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
@@ -169,6 +169,15 @@ namespace YARG.Core.Game
                     Difficulty.Expert => HitPercentX,
                     _ => throw new InvalidOperationException("Unreachable")
                 };
+
+                int pointsPerPhrase = difficulty switch
+                {
+                    Difficulty.Easy   => 400,
+                    Difficulty.Medium => 800,
+                    Difficulty.Hard   => 1600,
+                    Difficulty.Expert => 2000,
+                    _ => throw new InvalidOperationException("Unreachable")
+                };
                 var hitWindow = new HitWindowSettings(windowSize, 0.03, 1, false);
                 return new VocalsEngineParameters(
                     hitWindow, 
@@ -176,7 +185,8 @@ namespace YARG.Core.Game
                     starMultiplierThresholds, 
                     hitPercent, 
                     true, 
-                    updatesPerSecond);
+                    updatesPerSecond,
+                    pointsPerPhrase);
             }
         }
     }


### PR DESCRIPTION
Up to now we've been awarding 2000 base points per completed phrase regardless of difficulty, this PR scales the values for lower difficulties similarly to how RB's scoring works.