### PR TITLE
feat(ci): stb2csharp mac lib builder

### DIFF
--- a/.github/workflows/build-stb2csharp.yml
+++ b/.github/workflows/build-stb2csharp.yml
@@ -1,0 +1,26 @@
+name: 🔨 Build STB2CSharp
+
+on:
+    workflow_dispatch:
+
+jobs:
+    stb2csharp-mac-builder:
+        name: 🔨 Build - MacOS
+        runs-on: macos-latest
+        timeout-minutes: 90
+
+        steps:
+            - name: "Checkout project"
+              uses: actions/checkout@v4
+
+            - name: "Build"
+              run: |
+                  cd STB2CSharp
+                  clang -arch arm64 -arch x86_64 -O3 -dynamiclib STB2CSharp.cpp -o STB2CSharp.dylib
+
+            - name: "Upload to artifacts"
+              uses: actions/upload-artifact@v4
+              with:
+                  name: "STB2CSharp - MacOS"
+                  path: STB2CSharp/STB2CSharp.dylib
+


### PR DESCRIPTION
**Summary:**

- Created a new workflow for building `STB2CSharp`.
- Currently only MacOS for now (x86_64 and arm64).
- File outputs goes to the workflow run artifacts.