### PR TITLE
Localize HashWrapper Inner Values Within The Structure

### DIFF
--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -1,84 +1,117 @@
 ﻿using System;
-using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
 using YARG.Core.Extensions;
-using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {
     [Serializable]
-    public readonly struct HashWrapper : IComparable<HashWrapper>, IEquatable<HashWrapper>
+    public unsafe struct HashWrapper : IComparable<HashWrapper>, IEquatable<HashWrapper>
     {
         public static HashAlgorithm Algorithm => SHA1.Create();
 
         public const int HASH_SIZE_IN_BYTES = 20;
         public const int HASH_SIZE_IN_INTS = HASH_SIZE_IN_BYTES / sizeof(int);
 
-        private readonly FixedArray<byte> _hash;
-        private readonly int          _hashcode;
+        private fixed byte _hash[HASH_SIZE_IN_BYTES];
+        private int _hashcode;
 
         public byte[] HashBytes
         {
             get
             {
-                return _hash.ToArray();
+                var bytes = new byte[HASH_SIZE_IN_BYTES];
+                for (var i = 0; i < HASH_SIZE_IN_BYTES; i++)
+                {
+                    bytes[i] = _hash[i];
+                }
+                return bytes;
             }
         }
 
         public static HashWrapper Deserialize(BinaryReader reader)
         {
-            using var hash = DisposableCounter.Wrap(FixedArray<byte>.Alloc(HASH_SIZE_IN_BYTES));
-            if (reader.Read(hash.Value.Span) != HASH_SIZE_IN_BYTES)
+            var wrapper = new HashWrapper();
+            var span = new Span<byte>(wrapper._hash, HASH_SIZE_IN_BYTES);
+            if (reader.Read(span) != HASH_SIZE_IN_BYTES)
             {
                 throw new EndOfStreamException();
             }
-            return new HashWrapper(hash.Release());
+
+            int* integers = (int*) wrapper._hash;
+            for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
+            {
+                wrapper._hashcode ^= integers[i];
+            }
+            return wrapper;
         }
 
         public static HashWrapper Hash(ReadOnlySpan<byte> span)
         {
+            var wrapper = new HashWrapper();
+            var hashSpan = new Span<byte>(wrapper._hash, HASH_SIZE_IN_BYTES);
+
             using var algo = Algorithm;
-            using var hash = DisposableCounter.Wrap(FixedArray<byte>.Alloc(HASH_SIZE_IN_BYTES));
-            if (!algo.TryComputeHash(span, hash.Value.Span, out int written))
+            if (!algo.TryComputeHash(span, hashSpan, out int written))
             {
                 throw new Exception("fucking how??? Hash generation error");
             }
-            return new HashWrapper(hash.Release());
+
+            int* integers = (int*) wrapper._hash;
+            for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
+            {
+                wrapper._hashcode ^= integers[i];
+            }
+            return wrapper;
         }
 
-        public HashWrapper(byte[] hash)
-            : this(FixedArray<byte>.Pin(hash)) { }
-
-        private HashWrapper(FixedArray<byte> hash)
+        public static HashWrapper Create(byte[] hash)
         {
-            _hash = hash;
-            _hashcode = 0;
-
-            unsafe
+            var wrapper = new HashWrapper();
+            for (var i = 0; i < HASH_SIZE_IN_BYTES; i++)
             {
-                int* integers = (int*) hash.Ptr;
-                for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
-                {
-                    _hashcode ^= integers[i];
-                }
+                wrapper._hash[i] = hash[i];
             }
+
+            int* integers = (int*) wrapper._hash;
+            for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
+            {
+                wrapper._hashcode ^= integers[i];
+            }
+            return wrapper;
         }
 
         public void Serialize(BinaryWriter writer)
         {
-            writer.Write(_hash.ReadOnlySpan);
+            fixed (byte* ptr = _hash)
+            {
+                var span = new ReadOnlySpan<byte>(ptr, HASH_SIZE_IN_BYTES);
+                writer.Write(span);
+            }
         }
 
         public int CompareTo(HashWrapper other)
         {
-            return _hash.ReadOnlySpan.SequenceCompareTo(other._hash.ReadOnlySpan);
+            for (int i = 0; i < HASH_SIZE_IN_BYTES; ++i)
+            {
+                if (_hash[i] != other._hash[i])
+                {
+                    return _hash[i] - other._hash[i];
+                }
+            }
+            return 0;
         }
 
         public bool Equals(HashWrapper other)
         {
-            return _hash.ReadOnlySpan.SequenceEqual(other._hash.ReadOnlySpan);
+            for (int i = 0; i < HASH_SIZE_IN_BYTES; ++i)
+            {
+                if (_hash[i] != other._hash[i])
+                {
+                    return false;
+                }
+            }
+            return true;
         }
 
         public override int GetHashCode()
@@ -88,7 +121,11 @@ namespace YARG.Core.Song
 
         public override string ToString()
         {
-            return _hash.ReadOnlySpan.ToHexString(dashes: false);
+            fixed (byte* ptr = _hash)
+            {
+                var span = new ReadOnlySpan<byte>(ptr, HASH_SIZE_IN_BYTES);
+                return span.ToHexString(dashes: false);
+            }
         }
     }
 }

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -67,7 +67,7 @@ namespace YARG.Core.Song
             return wrapper;
         }
 
-        public void Serialize(BinaryWriter writer)
+        public readonly void Serialize(BinaryWriter writer)
         {
             fixed (int* ptr = _hash)
             {
@@ -76,7 +76,7 @@ namespace YARG.Core.Song
             }
         }
 
-        public int CompareTo(HashWrapper other)
+        public readonly int CompareTo(HashWrapper other)
         {
             for (int i = 0; i < HASH_SIZE_IN_INTS; ++i)
             {
@@ -88,7 +88,7 @@ namespace YARG.Core.Song
             return 0;
         }
 
-        public bool Equals(HashWrapper other)
+        public readonly bool Equals(HashWrapper other)
         {
             for (int i = 0; i < HASH_SIZE_IN_INTS; ++i)
             {
@@ -105,7 +105,7 @@ namespace YARG.Core.Song
             return _hash[0] ^ _hash[1] ^ _hash[2] ^ _hash[3];
         }
 
-        public override string ToString()
+        public readonly override string ToString()
         {
             fixed (int* ptr = _hash)
             {

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Security.Cryptography;
+using YARG.Core.Logging;
 
 namespace YARG.Core.Song
 {
@@ -62,6 +64,23 @@ namespace YARG.Core.Song
             for (var i = 0; i < HASH_SIZE_IN_BYTES; i++)
             {
                 bytes[i] = hash[i];
+            }
+            return wrapper;
+        }
+
+        public static HashWrapper FromString(ReadOnlySpan<char> str)
+        {
+            var wrapper = new HashWrapper();
+            try
+            {
+                for (int i = 0; i < HASH_SIZE_IN_BYTES; i++)
+                {
+                    wrapper._hash[i] = byte.Parse(str.Slice(i * 2, 2), NumberStyles.AllowHexSpecifier);
+                }
+            }
+            catch (Exception e)
+            {
+                YargLogger.LogException(e, "Failed to read song hash");
             }
             return wrapper;
         }

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -60,11 +60,8 @@ namespace YARG.Core.Song
         public static HashWrapper Create(ReadOnlySpan<byte> hash)
         {
             var wrapper = new HashWrapper();
-            var bytes = (byte*)wrapper._hash;
-            for (var i = 0; i < HASH_SIZE_IN_BYTES; i++)
-            {
-                bytes[i] = hash[i];
-            }
+            var span = new Span<byte>(wrapper._hash, HASH_SIZE_IN_BYTES);
+            hash.CopyTo(span);
             return wrapper;
         }
 

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -14,7 +14,6 @@ namespace YARG.Core.Song
         public const int HASH_SIZE_IN_INTS = HASH_SIZE_IN_BYTES / sizeof(int);
 
         private fixed int _hash[HASH_SIZE_IN_INTS];
-        private int _hashcode;
 
         public byte[] HashBytes
         {
@@ -41,11 +40,6 @@ namespace YARG.Core.Song
             {
                 throw new EndOfStreamException();
             }
-
-            for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
-            {
-                wrapper._hashcode ^= wrapper._hash[i];
-            }
             return wrapper;
         }
 
@@ -59,11 +53,6 @@ namespace YARG.Core.Song
             {
                 throw new Exception("fucking how??? Hash generation error");
             }
-
-            for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
-            {
-                wrapper._hashcode ^= wrapper._hash[i];
-            }
             return wrapper;
         }
 
@@ -74,11 +63,6 @@ namespace YARG.Core.Song
             for (var i = 0; i < HASH_SIZE_IN_BYTES; i++)
             {
                 bytes[i] = hash[i];
-            }
-
-            for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
-            {
-                wrapper._hashcode ^= wrapper._hash[i];
             }
             return wrapper;
         }
@@ -118,7 +102,7 @@ namespace YARG.Core.Song
 
         public readonly override int GetHashCode()
         {
-            return _hashcode;
+            return _hash[0] ^ _hash[1] ^ _hash[2] ^ _hash[3];
         }
 
         public override string ToString()

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Security.Cryptography;
-using YARG.Core.Extensions;
 
 namespace YARG.Core.Song
 {
@@ -69,10 +68,9 @@ namespace YARG.Core.Song
 
         public readonly void Serialize(BinaryWriter writer)
         {
-            fixed (int* ptr = _hash)
+            for (int i = 0; i < HASH_SIZE_IN_INTS; ++i)
             {
-                var span = new ReadOnlySpan<byte>(ptr, HASH_SIZE_IN_BYTES);
-                writer.Write(span);
+                writer.Write(_hash[i]);
             }
         }
 
@@ -102,16 +100,22 @@ namespace YARG.Core.Song
 
         public readonly override int GetHashCode()
         {
-            return _hash[0] ^ _hash[1] ^ _hash[2] ^ _hash[3];
+            int hashcode = 0;
+            for (int i = 0; i < HASH_SIZE_IN_INTS; ++i)
+            {
+                hashcode ^= _hash[i];
+            }
+            return hashcode;
         }
 
         public readonly override string ToString()
         {
-            fixed (int* ptr = _hash)
+            string str = string.Empty;
+            for (int i = 0; i < HASH_SIZE_IN_INTS; ++i)
             {
-                var span = new ReadOnlySpan<byte>(ptr, HASH_SIZE_IN_BYTES);
-                return span.ToHexString(dashes: false);
+                str += _hash[i].ToString("X8");
             }
+            return str;
         }
     }
 }

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -55,7 +55,7 @@ namespace YARG.Core.Song
             return wrapper;
         }
 
-        public static HashWrapper Create(byte[] hash)
+        public static HashWrapper Create(ReadOnlySpan<byte> hash)
         {
             var wrapper = new HashWrapper();
             var bytes = (byte*)wrapper._hash;

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -14,7 +14,7 @@ namespace YARG.Core.Song
 
         private fixed int _hash[HASH_SIZE_IN_INTS];
 
-        public byte[] HashBytes
+        public readonly byte[] HashBytes
         {
             get
             {

--- a/YARG.Core/Song/Entries/Types/HashWrapper.cs
+++ b/YARG.Core/Song/Entries/Types/HashWrapper.cs
@@ -70,9 +70,9 @@ namespace YARG.Core.Song
             var wrapper = new HashWrapper();
             try
             {
-                for (int i = 0; i < HASH_SIZE_IN_BYTES; i++)
+                for (int i = 0; i < HASH_SIZE_IN_INTS; i++)
                 {
-                    wrapper._hash[i] = byte.Parse(str.Slice(i * 2, 2), NumberStyles.AllowHexSpecifier);
+                    wrapper._hash[i] = byte.Parse(str.Slice(i * sizeof(int), sizeof(int)), NumberStyles.AllowHexSpecifier);
                 }
             }
             catch (Exception e)

--- a/YARG.Core/Utility/JsonHashWrapperConverter.cs
+++ b/YARG.Core/Utility/JsonHashWrapperConverter.cs
@@ -31,7 +31,7 @@ namespace YARG.Core.Utility
                     hashBytes[i] = b;
                 }
 
-                return new HashWrapper(hashBytes);
+                return HashWrapper.Create(hashBytes);
             }
             catch
             {

--- a/YARG.Core/Utility/JsonHashWrapperConverter.cs
+++ b/YARG.Core/Utility/JsonHashWrapperConverter.cs
@@ -15,27 +15,7 @@ namespace YARG.Core.Utility
         public override HashWrapper ReadJson(JsonReader reader, Type objectType, HashWrapper existingValue,
             bool hasExistingValue, JsonSerializer serializer)
         {
-            if (reader.Value == null)
-            {
-                return new HashWrapper();
-            }
-
-            try
-            {
-                var hashString = reader.Value.ToString().AsSpan();
-                Span<byte> hashBytes = stackalloc byte[HashWrapper.HASH_SIZE_IN_BYTES];
-
-                for (int i = 0; i < hashBytes.Length; i++)
-                {
-                    hashBytes[i] = byte.Parse(hashString.Slice(i * 2, 2), NumberStyles.AllowHexSpecifier);
-                }
-
-                return HashWrapper.Create(hashBytes);
-            }
-            catch
-            {
-                return new HashWrapper();
-            }
+            return reader.Value != null ? HashWrapper.FromString(reader.Value.ToString().AsSpan()) : default;
         }
     }
 }

--- a/YARG.Core/Utility/JsonHashWrapperConverter.cs
+++ b/YARG.Core/Utility/JsonHashWrapperConverter.cs
@@ -23,12 +23,11 @@ namespace YARG.Core.Utility
             try
             {
                 var hashString = reader.Value.ToString().AsSpan();
-                var hashBytes = new byte[HashWrapper.HASH_SIZE_IN_BYTES];
+                Span<byte> hashBytes = stackalloc byte[HashWrapper.HASH_SIZE_IN_BYTES];
 
                 for (int i = 0; i < hashBytes.Length; i++)
                 {
-                    var b = byte.Parse(hashString.Slice(i * 2, 2), NumberStyles.AllowHexSpecifier);
-                    hashBytes[i] = b;
+                    hashBytes[i] = byte.Parse(hashString.Slice(i * 2, 2), NumberStyles.AllowHexSpecifier);
                 }
 
                 return HashWrapper.Create(hashBytes);


### PR DESCRIPTION
Utilizes fixed integer arrays to keep all the values in local memory to the actual struct. This means we no longer need special disposal functionality.

+ Restricts access to creation (outside of default construction) to static functions of the class.