### PR TITLE
Convert SngMask to a struct

### DIFF
--- a/YARG.Core/IO/SngHandler/SngFile.cs
+++ b/YARG.Core/IO/SngHandler/SngFile.cs
@@ -12,7 +12,7 @@ namespace YARG.Core.IO
     /// <summary>
     /// <see href="https://github.com/mdsitton/SngFileFormat">Documentation of SNG file type</see>
     /// </summary>
-    public class SngFile : IDisposable, IEnumerable<KeyValuePair<string, SngFileListing>>
+    public class SngFile : IEnumerable<KeyValuePair<string, SngFileListing>>
     {
         public readonly AbridgedFileInfo Info;
         public readonly uint Version;
@@ -55,11 +55,6 @@ namespace YARG.Core.IO
         IEnumerator IEnumerable.GetEnumerator()
         {
             return _listings.GetEnumerator();
-        }
-
-        public void Dispose()
-        {
-            Mask.Dispose();
         }
 
 

--- a/YARG.Core/IO/SngHandler/SngFileListing.cs
+++ b/YARG.Core/IO/SngHandler/SngFileListing.cs
@@ -19,13 +19,13 @@ namespace YARG.Core.IO
         public byte[] LoadAllBytes(SngFile sngFile)
         {
             var stream = sngFile.LoadFileStream();
-            return SngFileStream.LoadFile(stream, sngFile.Mask.Clone(), Length, Position);
+            return SngFileStream.LoadFile(stream, sngFile.Mask, Length, Position);
         }
 
         public SngFileStream CreateStream(SngFile sngFile)
         {
             var stream = sngFile.LoadFileStream();
-            return new SngFileStream(Name, stream, sngFile.Mask.Clone(), Length, Position);
+            return new SngFileStream(Name, stream, sngFile.Mask, Length, Position);
         }
     }
 }

--- a/YARG.Core/IO/SngHandler/SngMask.cs
+++ b/YARG.Core/IO/SngHandler/SngMask.cs
@@ -22,8 +22,6 @@ namespace YARG.Core.IO
         public SngMask(Stream stream)
         {
             byte* mask = stackalloc byte[MASKLENGTH];
-            // Do the read first just incase some error occurs
-            // and we need to exit.
             stream.Read(new Span<byte>(mask, MASKLENGTH));
 
             for (int i = 0; i < NUM_KEYBYTES;)

--- a/YARG.Core/IO/SngHandler/SngMask.cs
+++ b/YARG.Core/IO/SngHandler/SngMask.cs
@@ -21,8 +21,8 @@ namespace YARG.Core.IO
 
         public SngMask(Stream stream)
         {
-            byte* mask = stackalloc byte[MASKLENGTH];
-            stream.Read(new Span<byte>(mask, MASKLENGTH));
+            Span<byte> mask = stackalloc byte[MASKLENGTH];
+            stream.Read(mask);
 
             for (int i = 0; i < NUM_KEYBYTES;)
             {

--- a/YARG.Core/IO/SngHandler/SngMask.cs
+++ b/YARG.Core/IO/SngHandler/SngMask.cs
@@ -10,58 +10,29 @@ namespace YARG.Core.IO
     /// Handles the buffer of decryption keys, while also providing easy access
     /// to SIMD vector operations through pointers and fixed array behavior.
     /// </summary>
-    public class SngMask : IDisposable
+    public unsafe struct SngMask
     {
         public const int NUM_KEYBYTES = 256;
         public const int MASKLENGTH = 16;
         public static readonly int VECTORBYTE_COUNT = Vector<byte>.Count;
         public static readonly int NUMVECTORS = NUM_KEYBYTES / VECTORBYTE_COUNT;
 
-        private readonly DisposableCounter<FixedArray<byte>> _counter;
-
-        public readonly FixedArray<byte> Keys;
-        public readonly unsafe Vector<byte>* Vectors;
+        public fixed byte Keys[NUM_KEYBYTES];
 
         public SngMask(Stream stream)
         {
-            unsafe
-            {
-                byte* mask = stackalloc byte[MASKLENGTH];
-                // Do the read first just incase some error occurs
-                // and we need to exit.
-                stream.Read(new Span<byte>(mask, MASKLENGTH));
+            byte* mask = stackalloc byte[MASKLENGTH];
+            // Do the read first just incase some error occurs
+            // and we need to exit.
+            stream.Read(new Span<byte>(mask, MASKLENGTH));
 
-                Keys = FixedArray<byte>.Alloc(NUM_KEYBYTES);
-                _counter = DisposableCounter.Wrap(Keys);
-                for (int i = 0; i < NUM_KEYBYTES;)
+            for (int i = 0; i < NUM_KEYBYTES;)
+            {
+                for (int j = 0; j < MASKLENGTH; i++, j++)
                 {
-                    for (int j = 0; j < MASKLENGTH; i++, j++)
-                    {
-                        Keys.Ptr[i] = (byte) (mask[j] ^ i);
-                    }
+                    Keys[i] = (byte) (mask[j] ^ i);
                 }
-                Vectors = (Vector<byte>*) Keys.Ptr;
             }
-        }
-
-        public SngMask Clone()
-        {
-            return new SngMask(this);
-        }
-
-        private SngMask(SngMask other)
-        {
-            _counter = other._counter.AddRef();
-            Keys = other.Keys;
-            unsafe
-            {
-                Vectors = other.Vectors;
-            }
-        }
-
-        public void Dispose()
-        {
-            _counter.Dispose();
         }
     }
 }


### PR DESCRIPTION
Utilizing an unsafe fixed buffer simplifies the basic functionality of the type. Firstly, it removes the need to have some tracker count how many references to the fixed buffer exist. This means SngMask (and thus SngFile) no longer have to be disposable.

Secondly, making it a struct provides inherent cloning behavior. We don't need to add a special function to mimic it when the values will be memcopied by default.