### PR TITLE
Utilize A Hierarchy Of FixedArray Types To Enhance Memory Usage (Part 1)

### DIFF
--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -4,83 +4,74 @@ using YARG.Core.Extensions;
 
 namespace YARG.Core.IO
 {
+    public interface IAbridgedInfo
+    {
+        public string FullName { get; }
+        public DateTime LastUpdatedTime { get; }
+    }
+
     /// <summary>
     /// A FileInfo structure that only contains the filename and time last added
     /// </summary>
-    public sealed class AbridgedFileInfo
+    public readonly struct AbridgedFileInfo : IAbridgedInfo
     {
         public const FileAttributes RECALL_ON_DATA_ACCESS = (FileAttributes)0x00400000;
 
         /// <summary>
         /// The flie path
         /// </summary>
-        public readonly string FullName;
+        public readonly string _fullname;
 
         /// <summary>
         /// The time the file was last written or created on OS - whichever came later
         /// </summary>
-        public readonly DateTime LastUpdatedTime;
+        public readonly DateTime _lastUpdatedTime;
 
-        /// <summary>
-        /// The length of the file in bytes
-        /// </summary>
-        public readonly long Length;
+        public string FullName => _fullname;
+        public DateTime LastUpdatedTime => _lastUpdatedTime;
 
         public AbridgedFileInfo(string file, bool checkCreationTime = true)
             : this(new FileInfo(file), checkCreationTime) { }
 
         public AbridgedFileInfo(FileInfo info, bool checkCreationTime = true)
         {
-            FullName = info.FullName;
-            LastUpdatedTime = info.LastWriteTime;
-            if (checkCreationTime && info.CreationTime > LastUpdatedTime)
+            _fullname = info.FullName;
+            _lastUpdatedTime = info.LastWriteTime;
+            if (checkCreationTime && info.CreationTime > _lastUpdatedTime)
             {
-                LastUpdatedTime = info.CreationTime;
+                _lastUpdatedTime = info.CreationTime;
             }
-            Length = info.Length;
         }
 
         /// <summary>
         /// Only used when validation of the underlying file is not required
         /// </summary>
-        public AbridgedFileInfo(BinaryReader reader, bool readLength)
-            : this(reader.ReadString(), reader, readLength) { }
+        public AbridgedFileInfo(BinaryReader reader)
+            : this(reader.ReadString(), reader) { }
 
         /// <summary>
         /// Only used when validation of the underlying file is not required
         /// </summary>
-        public AbridgedFileInfo(string filename, BinaryReader reader, bool readLength)
+        public AbridgedFileInfo(string filename, BinaryReader reader)
         {
-            FullName = filename;
-            LastUpdatedTime = DateTime.FromBinary(reader.ReadInt64());
-            Length = readLength ? reader.ReadInt64() : 0;
+            _fullname = filename;
+            _lastUpdatedTime = DateTime.FromBinary(reader.ReadInt64());
         }
 
-        public AbridgedFileInfo(string fullname, DateTime timeAdded, long length)
+        public void Serialize(BinaryWriter writer)
         {
-            FullName = fullname;
-            LastUpdatedTime = timeAdded;
-            Length = length;
-        }
-
-        public void Serialize(BinaryWriter writer, bool writeLength)
-        {
-            writer.Write(FullName);
-            writer.Write(LastUpdatedTime.ToBinary());
-            if (writeLength)
-            {
-                writer.Write(Length);
-            }
+            writer.Write(_fullname);
+            writer.Write(_lastUpdatedTime.ToBinary());
         }
 
         public bool Exists()
         {
-            return File.Exists(FullName);
+            return File.Exists(_fullname);
         }
 
         public bool IsStillValid(bool checkCreationTime = true)
         {
-            var info = new FileInfo(FullName);
+            var info = new FileInfo(_fullname);
             if (!info.Exists)
             {
                 return false;
@@ -91,21 +82,21 @@ namespace YARG.Core.IO
             {
                 timeToCompare = info.CreationTime;
             }
-            return timeToCompare == LastUpdatedTime;
+            return timeToCompare == _lastUpdatedTime;
         }
 
         /// <summary>
         /// Used for cache validation
         /// </summary>
-        public static AbridgedFileInfo? TryParseInfo(BinaryReader reader, bool hasLength, bool checkCreationTime = true)
+        public static AbridgedFileInfo? TryParseInfo(BinaryReader reader, bool checkCreationTime = true)
         {
-            return TryParseInfo(reader.ReadString(), reader, hasLength, checkCreationTime);
+            return TryParseInfo(reader.ReadString(), reader, checkCreationTime);
         }
 
         /// <summary>
         /// Used for cache validation
         /// </summary>
-        public static AbridgedFileInfo? TryParseInfo(string file, BinaryReader reader, bool hasLength, bool checkCreationTime = true)
+        public static AbridgedFileInfo? TryParseInfo(string file, BinaryReader reader, bool checkCreationTime = true)
         {
             var info = new FileInfo(file);
             if (!info.Exists)
@@ -115,16 +106,94 @@ namespace YARG.Core.IO
             }
 
             var abridged = new AbridgedFileInfo(info, checkCreationTime);
-            if (abridged.LastUpdatedTime != DateTime.FromBinary(reader.ReadInt64()))
+            if (abridged._lastUpdatedTime != DateTime.FromBinary(reader.ReadInt64()))
             {
                 return null;
             }
-
-            if (hasLength)
-            {
-                reader.BaseStream.Position += sizeof(long);
-            }
             return abridged;
+        }
+    }
+
+    public readonly struct AbridgedFileInfo_Length : IAbridgedInfo
+    {
+        private readonly AbridgedFileInfo _base;
+
+        /// <summary>
+        /// The length of the file in bytes
+        /// </summary>
+        public readonly long Length;
+
+        public string FullName => _base.FullName;
+        public DateTime LastUpdatedTime => _base.LastUpdatedTime;
+
+        public AbridgedFileInfo_Length(string file, bool checkCreationTime = true)
+            : this(new FileInfo(file), checkCreationTime) { }
+
+        public AbridgedFileInfo_Length(FileInfo info, bool checkCreationTime = true)
+        {
+            _base = new AbridgedFileInfo(info, checkCreationTime);
+            Length = info.Length;
+        }
+
+        /// <summary>
+        /// Only used when validation of the underlying file is not required
+        /// </summary>
+        public AbridgedFileInfo_Length(BinaryReader reader)
+        {
+            _base = new AbridgedFileInfo(reader);
+            Length = reader.ReadInt64();
+        }
+
+        /// <summary>
+        /// Only used when validation of the underlying file is not required
+        /// </summary>
+        public AbridgedFileInfo_Length(string filename, BinaryReader reader)
+        {
+            _base = new AbridgedFileInfo(filename, reader);
+            Length = reader.ReadInt64();
+        }
+
+        private AbridgedFileInfo_Length(in AbridgedFileInfo info, long length)
+        {
+            _base = info;
+            Length = length;
+        }
+
+        public void Serialize(BinaryWriter writer)
+        {
+            _base.Serialize(writer);
+            writer.Write(Length);
+        }
+
+        public bool Exists()
+        {
+            return File.Exists(_base.FullName);
+        }
+
+        public bool IsStillValid(bool checkCreationTime = true)
+        {
+            return _base.IsStillValid(checkCreationTime);
+        }
+
+        /// <summary>
+        /// Used for cache validation
+        /// </summary>
+        public static AbridgedFileInfo_Length? TryParseInfo(BinaryReader reader, bool checkCreationTime = true)
+        {
+            return TryParseInfo(reader.ReadString(), reader, checkCreationTime);
+        }
+
+        /// <summary>
+        /// Used for cache validation
+        /// </summary>
+        public static AbridgedFileInfo_Length? TryParseInfo(string file, BinaryReader reader, bool checkCreationTime = true)
+        {
+            var info = AbridgedFileInfo.TryParseInfo(file, reader, checkCreationTime);
+            if (info == null)
+            {
+                return null;
+            }
+            return new AbridgedFileInfo_Length(info.Value, reader.ReadInt64());
         }
     }
 }

--- a/YARG.Core/IO/AbridgedFileInfo.cs
+++ b/YARG.Core/IO/AbridgedFileInfo.cs
@@ -18,14 +18,14 @@ namespace YARG.Core.IO
         public const FileAttributes RECALL_ON_DATA_ACCESS = (FileAttributes)0x00400000;
 
         /// <summary>
-        /// The flie path
+        /// The file path
         /// </summary>
-        public readonly string _fullname;
+        private readonly string _fullname;
 
         /// <summary>
         /// The time the file was last written or created on OS - whichever came later
         /// </summary>
-        public readonly DateTime _lastUpdatedTime;
+        private readonly DateTime _lastUpdatedTime;
 
         public string FullName => _fullname;
         public DateTime LastUpdatedTime => _lastUpdatedTime;

--- a/YARG.Core/IO/ConHandler/CONFileListing.cs
+++ b/YARG.Core/IO/ConHandler/CONFileListing.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using YARG.Core.Extensions;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.IO
 {
@@ -53,13 +54,13 @@ namespace YARG.Core.IO
         }
 
         // This overload should only be called during scanning
-        public byte[] LoadAllBytes(Stream stream)
+        public AllocatedArray<byte> LoadAllBytes(Stream stream)
         {
             lock (stream)
                 return CONFileStream.LoadFile(stream, IsContiguous(), Size, FirstBlock, _shift);
         }
 
-        public byte[] LoadAllBytes()
+        public AllocatedArray<byte> LoadAllBytes()
         {
             return CONFileStream.LoadFile(ConFile.FullName, IsContiguous(), Size, FirstBlock, _shift);
         }

--- a/YARG.Core/IO/Disposables/AllocatedArray.cs
+++ b/YARG.Core/IO/Disposables/AllocatedArray.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace YARG.Core.IO.Disposables
+{
+    public sealed unsafe class AllocatedArray<T> : FixedArray<T>
+        where T : unmanaged
+    {
+        public static AllocatedArray<T> Alloc(long length)
+        {
+            var ptr = (T*)Marshal.AllocHGlobal((int)(length * sizeof(T)));
+            return new AllocatedArray<T>(ptr, length);
+        }
+
+        public static AllocatedArray<T> ReAlloc(AllocatedArray<T> original, long length)
+        {
+            GC.SuppressFinalize(original);
+            var ptr = (T*) Marshal.ReAllocHGlobal(original.IntPtr, (IntPtr) (length * sizeof(T)));
+            return new AllocatedArray<T>(ptr, length);
+        }
+
+        public static AllocatedArray<T> Read(Stream stream, long length)
+        {
+            var buffer = Alloc(length);
+            stream.Read(new Span<byte>(buffer.Ptr, (int)(length * sizeof(T))));
+            return buffer;
+        }
+
+        private AllocatedArray(T* ptr, long length)
+            : base(ptr, length) { }
+
+        public Span<T> Span => new(Ptr, (int)Length);
+
+        public Span<T> Slice(long offset, long count)
+        {
+            if (offset < 0 || Length < offset + count)
+            {
+                throw new IndexOutOfRangeException();
+            }
+            return new Span<T>(Ptr + offset, (int) count);
+        }
+
+        public override void Dispose()
+        {
+            Marshal.FreeHGlobal(IntPtr);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/YARG.Core/IO/Disposables/FixedArray.cs
+++ b/YARG.Core/IO/Disposables/FixedArray.cs
@@ -4,8 +4,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using YARG.Core.Logging;
 
-namespace YARG.Core.IO
+namespace YARG.Core.IO.Disposables
 {
     /// <summary>
     /// A wrapper interface over a fixed area of unmanaged memory.
@@ -21,9 +22,14 @@ namespace YARG.Core.IO
     /// <typeparam name="T">The unmanaged type contained in the block of memory</typeparam>
     [DebuggerDisplay("Length = {Length}")]
     [DebuggerTypeProxy(typeof(FixedArray<>.FixedArrayDebugView))]
-    public sealed unsafe class FixedArray<T> : IEnumerable<T>, IDisposable
+    public unsafe class FixedArray<T> : IDisposable
         where T : unmanaged
     {
+        public static FixedArray<T> Alias(T* ptr, long length)
+        {
+            return new FixedArray<T>(ptr, length);
+        }
+
         /// <summary>
         /// Pointer to the beginning of the memory block.<br></br>
         /// DO NOT TOUCH UNLESS YOU ENSURE YOU'RE WITHIN BOUNDS
@@ -33,109 +39,36 @@ namespace YARG.Core.IO
         /// <summary>
         /// Number of elements within the block
         /// </summary>
-        public readonly int Length;
+        public readonly long Length;
 
-        private bool _disposedValue;
-        private readonly GCHandle _handle;
-
-        /// <summary>
-        /// Fully loads the data of a file into a fixed location in memory
-        /// </summary>
-        /// <remarks>Be wary of any file I/O related exceptions. Those will NOT be handled</remarks>
-        /// <param name="path">The file to grab</param>
-        /// <returns>A new FixedArray filled with the file's data</returns>
-        public static FixedArray<T> Load(string path)
-        {
-            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
-            return Load(fs);
-        }
-
-        /// <summary>
-        /// Fully loads the data of a stream (or whatever is leftover in the stream)
-        /// into a fixed location in memory
-        /// </summary>
-        /// <remarks>Any exceptions thrown from attempting to read the stream will NOT be handled</remarks>
-        /// <param name="stream">The stream to read from</param>
-        /// <returns>A new FixedArray filled with the stream's leftover data</returns>
-        public static FixedArray<T> Load(Stream stream)
-        {
-            int length = (int)(stream.Length - stream.Position);
-            return Load(stream, length);
-        }
-
-        /// <summary>
-        /// Loads the given amount of data from a stream at its current position
-        /// into a fixed location in memory
-        /// </summary>
-        /// <remarks>Any exceptions thrown from attempting to read the stream will NOT be handled</remarks>
-        /// <param name="stream">The stream to read from</param>
-        /// <param name="length">The amount of data (in bytes) to read</param>
-        /// <returns>A new FixedArray filled with the requested amount of data</returns>
-        public static FixedArray<T> Load(Stream stream, int length)
-        {
-            if (stream.Position + length > stream.Length)
-                throw new EndOfStreamException();
-
-            byte* buffer = (byte*) Marshal.AllocHGlobal(length);
-            var array = new FixedArray<T>((T*)buffer, length / sizeof(T));
-
-            // Use counter on the chance an exception occurs during read
-            using var counter = DisposableCounter.Wrap(array);
-            stream.Read(new Span<byte>(buffer, length));
-            return counter.Release();
-        }
-
-        /// <summary>
-        /// Allocates an uninitialized block of memory
-        /// </summary>
-        /// <param name="length">The number of elements (of `T`) to allocate for</param>
-        /// <returns>A new FixedArray with the requested amount of allocated memory</returns>
-        /// <exception cref="OutOfMemoryException"></exception>
-        public static FixedArray<T> Alloc(int length)
-        {
-            int bufferLength = length * sizeof(T);
-            var ptr = (T*)Marshal.AllocHGlobal(bufferLength);
-            return new FixedArray<T>(ptr, length);
-        }
-
-        /// <summary>
-        /// Pins a managed array to a fixed location
-        /// </summary>
-        /// <remarks>PREFER STACK-ALLOCATED ARRAYS OVER THIS WHEN POSSIBLE</remarks>
-        /// <param name="array">The managed array to pin</param>
-        /// <returns>A FixedArray that points to the location of the now-pinned array</returns>
-        /// <exception cref="OutOfMemoryException"></exception>
-        public static FixedArray<T> Pin(T[] array)
-        {
-            var handle = GCHandle.Alloc(array, GCHandleType.Pinned);
-            return new FixedArray<T>((T*)handle.AddrOfPinnedObject(), array.Length, handle);
-        }
-
-        /// <param name="disposal">The function to use when the object needs to be disposed</param>
-        private FixedArray(T* ptr, int length, GCHandle handle = default)
+        protected FixedArray(T* ptr, long length)
         {
             Ptr = ptr;
             Length = length;
-            _handle = handle;
         }
+
+        /// <summary>
+        /// Provides the pointer to the block of memory in IntPtr form
+        /// </summary>
+        public IntPtr IntPtr => (IntPtr) Ptr;
+
+        /// <summary>
+        /// Provides a ReadOnlySpan over the block of memory
+        /// </summary>
+        public ReadOnlySpan<T> ReadOnlySpan => new(Ptr, (int)Length);
+
+        public UnmanagedMemoryStream ToStream() => new((byte*)Ptr, (int)(Length * sizeof(T)));
 
         /// <summary>
         /// Indexer into the fixed block of memory
         /// </summary>
         /// <param name="index"></param>
-        /// <returns>A reference to the object at the provided index</returns>
-        /// <exception cref="ObjectDisposedException"></exception>
         /// <exception cref="IndexOutOfRangeException"></exception>
-        public ref T this[int index]
+        public ref T this[long index]
         {
             get
             {
-                if (_disposedValue)
-                {
-                    throw new ObjectDisposedException(GetType().Name);
-                }
-
-                if (index < 0 || Length <= index )
+                if (index < 0 || Length <= index)
                 {
                     throw new IndexOutOfRangeException();
                 }
@@ -143,114 +76,16 @@ namespace YARG.Core.IO
             }
         }
 
-        /// <summary>
-        /// Creates a span over the requested slice of memory
-        /// </summary>
-        /// <param name="offset">Starting position of the slice</param>
-        /// <param name="count">Number of elements in the slice</param>
-        /// <returns></returns>
-        /// <exception cref="ObjectDisposedException"></exception>
-        /// <exception cref="IndexOutOfRangeException"></exception>
-        public Span<T> Slice(int offset, int count)
+        public virtual void Dispose()
         {
-            if (_disposedValue)
-            {
-                throw new ObjectDisposedException(GetType().Name);
-            }
-
-            if (0 <= offset && offset + count <= Length)
-                return new Span<T>(Ptr + offset, count);
-            throw new IndexOutOfRangeException();
-        }
-
-        /// <summary>
-        /// Provides the pointer to the block of memory in IntPtr form
-        /// </summary>
-        /// <exception cref="ObjectDisposedException"></exception>
-        public IntPtr IntPtr
-        {
-            get
-            {
-                if (_disposedValue)
-                {
-                    throw new ObjectDisposedException(GetType().Name);
-                }
-                return (IntPtr)Ptr;
-            }
-        }
-
-        /// <summary>
-        /// Provides a Span over the block of memory
-        /// </summary>
-        /// <exception cref="ObjectDisposedException"></exception>
-        public Span<T> Span
-        {
-            get
-            {
-                if (_disposedValue)
-                {
-                    throw new ObjectDisposedException(GetType().Name);
-                }
-                return new Span<T>(Ptr, Length);
-            }
-        }
-
-        /// <summary>
-        /// Provides a ReadOnlySpan over the block of memory
-        /// </summary>
-        /// <exception cref="ObjectDisposedException"></exception>
-        public ReadOnlySpan<T> ReadOnlySpan
-        {
-            get
-            {
-                if (_disposedValue)
-                {
-                    throw new ObjectDisposedException(GetType().Name);
-                }
-                return new ReadOnlySpan<T>(Ptr, Length);
-            }
-        }
-
-        /// <summary>
-        /// Provides a copy of the block of memory in a managed array
-        /// </summary>
-        /// <returns></returns>
-        /// <exception cref="ObjectDisposedException"></exception>
-        public T[] ToArray()
-        {
-            if (_disposedValue)
-            {
-                throw new ObjectDisposedException(GetType().Name);
-            }
-
-            var array = new T[Length];
-            Span.CopyTo(array);
-            return array;
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (!_handle.IsAllocated)
-                {
-                    Marshal.FreeHGlobal(IntPtr);
-                }
-                else
-                {
-                    _handle.Free();
-                }
-                _disposedValue = true;
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
             GC.SuppressFinalize(this);
         }
 
-        ~FixedArray() { Dispose(false); }
+        ~FixedArray()
+        {
+            YargLogger.LogWarning("Dev warning: only use FixedArray types IF YOU MANUALLY DISPOSE! Not doing so defeats the purpose!");
+            Dispose();
+        }
 
         private sealed class FixedArrayDebugView
         {
@@ -261,46 +96,7 @@ namespace YARG.Core.IO
             }
 
             [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-            public Span<T> Items => array.Span;
-        }
-
-
-        public IEnumerator GetEnumerator() { return new Enumerator(this); }
-
-        IEnumerator<T> IEnumerable<T>.GetEnumerator()
-        {
-            return ((IEnumerable<T>)this).GetEnumerator();
-        }
-
-        public struct Enumerator : IEnumerator<T>, IEnumerator
-        {
-            private readonly FixedArray<T> _arr;
-            private int _index;
-
-            internal Enumerator(FixedArray<T> arr)
-            {
-                _arr = arr;
-                _index = -1;
-            }
-
-            public void Dispose()
-            {
-            }
-
-            public bool MoveNext()
-            {
-                ++_index;
-                return _index < _arr.Length;
-            }
-
-            public readonly T Current => _arr[_index];
-
-            readonly object IEnumerator.Current => Current;
-
-            void IEnumerator.Reset()
-            {
-                _index = -1;
-            }
+            public ReadOnlySpan<T> Items => array.ReadOnlySpan;
         }
     }
 }

--- a/YARG.Core/IO/Disposables/MemoryMappedArray.cs
+++ b/YARG.Core/IO/Disposables/MemoryMappedArray.cs
@@ -14,6 +14,11 @@ namespace YARG.Core.IO.Disposables
             return Load(info.FullName, info.Length);
         }
 
+        public static MemoryMappedArray Load(AbridgedFileInfo info)
+        {
+            return Load(info.FullName, info.Length);
+        }
+
         public static MemoryMappedArray Load(string filename, long length)
         {
             var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);

--- a/YARG.Core/IO/Disposables/MemoryMappedArray.cs
+++ b/YARG.Core/IO/Disposables/MemoryMappedArray.cs
@@ -14,7 +14,7 @@ namespace YARG.Core.IO.Disposables
             return Load(info.FullName, info.Length);
         }
 
-        public static MemoryMappedArray Load(AbridgedFileInfo info)
+        public static MemoryMappedArray Load(in AbridgedFileInfo_Length info)
         {
             return Load(info.FullName, info.Length);
         }

--- a/YARG.Core/IO/Disposables/MemoryMappedArray.cs
+++ b/YARG.Core/IO/Disposables/MemoryMappedArray.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.MemoryMappedFiles;
+using System.Text;
+using YARG.Core.Logging;
+
+namespace YARG.Core.IO.Disposables
+{
+    public sealed unsafe class MemoryMappedArray : FixedArray<byte>
+    {
+        public static MemoryMappedArray Load(FileInfo info)
+        {
+            return Load(info.FullName, info.Length);
+        }
+
+        public static MemoryMappedArray Load(string filename, long length)
+        {
+            var file = MemoryMappedFile.CreateFromFile(filename, FileMode.Open, null, 0, MemoryMappedFileAccess.Read);
+            var accessor = file.CreateViewAccessor(0, 0, MemoryMappedFileAccess.Read);
+            byte* ptr = null;
+            accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
+            return new MemoryMappedArray(file, accessor, ptr, length);
+        }
+
+        private readonly MemoryMappedFile _file;
+        private readonly MemoryMappedViewAccessor _accessor;
+
+        private MemoryMappedArray(MemoryMappedFile file, MemoryMappedViewAccessor accessor, byte* ptr, long length)
+            : base(ptr, length)
+        {
+            _file = file;
+            _accessor = accessor;
+        }
+
+        public override void Dispose()
+        {
+            _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            _accessor.Dispose();
+            _file.Dispose();
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/YARG.Core/IO/Ini/IniModifierCreator.cs
+++ b/YARG.Core/IO/Ini/IniModifierCreator.cs
@@ -140,9 +140,9 @@ namespace YARG.Core.IO.Ini
             return RichTextUtils.ReplaceColorNames(reader.ExtractText(isChartFile));
         }
 
-        private static string ExtractSngString(YARGTextContainer<byte> sngContainer, int length)
+        private static unsafe string ExtractSngString(YARGTextContainer<byte> sngContainer, int length)
         {
-            return RichTextUtils.ReplaceColorNames(Encoding.UTF8.GetString(sngContainer.Data, sngContainer.Position, length));
+            return RichTextUtils.ReplaceColorNames(Encoding.UTF8.GetString(sngContainer.Data.Ptr + sngContainer.Position, length));
         }
     }
 }

--- a/YARG.Core/IO/Ini/SongIniHandler.cs
+++ b/YARG.Core/IO/Ini/SongIniHandler.cs
@@ -1,11 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 
 namespace YARG.Core.IO.Ini
 {
     public static class SongIniHandler
     {
-        public static IniSection ReadSongIniFile(string iniFile)
+        public static IniSection ReadSongIniFile(FileInfo iniFile)
         {
             var modifiers = YARGIniReader.ReadIniFile(iniFile, SONG_INI_DICTIONARY);
             if (modifiers.Count == 0)

--- a/YARG.Core/IO/Ini/YARGIniReader.cs
+++ b/YARG.Core/IO/Ini/YARGIniReader.cs
@@ -2,22 +2,23 @@
 using System.Collections.Generic;
 using System.IO;
 using YARG.Core.Extensions;
+using YARG.Core.IO.Disposables;
 using YARG.Core.Logging;
 
 namespace YARG.Core.IO.Ini
 {
     public static class YARGIniReader
     {
-        public static Dictionary<string, IniSection> ReadIniFile(string iniFile, Dictionary<string, Dictionary<string, IniModifierCreator>> sections)
+        public static Dictionary<string, IniSection> ReadIniFile(FileInfo iniFile, Dictionary<string, Dictionary<string, IniModifierCreator>> sections)
         {
             try
             {
-                var bytes = File.ReadAllBytes(iniFile);
+                using var bytes = MemoryMappedArray.Load(iniFile);
                 var byteReader = YARGTextLoader.TryLoadByteText(bytes);
                 if (byteReader != null)
                     return ProcessIni(byteReader, sections);
 
-                var chars = YARGTextLoader.ConvertToChar(bytes);
+                using var chars = YARGTextLoader.ConvertToChar(bytes);
                 var charReader = new YARGTextReader<char, CharStringDecoder>(chars, 0);
                 return ProcessIni(charReader, sections);
 

--- a/YARG.Core/IO/SngHandler/SngFile.cs
+++ b/YARG.Core/IO/SngHandler/SngFile.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using YARG.Core.Extensions;
+using YARG.Core.IO.Disposables;
 using YARG.Core.IO.Ini;
 using YARG.Core.Logging;
 
@@ -112,25 +113,27 @@ namespace YARG.Core.IO
             }
         }
 
-        private static IniSection ReadMetadata(Stream stream)
+        private static unsafe IniSection ReadMetadata(Stream stream)
         {
             Dictionary<string, List<IniModifier>> modifiers = new();
-            ulong length = stream.Read<ulong>(Endianness.Little) - sizeof(ulong);
+            long length = stream.Read<long>(Endianness.Little) - sizeof(long);
             ulong numPairs = stream.Read<ulong>(Endianness.Little);
 
+            using var bytes = AllocatedArray<byte>.Read(stream, length);
+            var container = new YARGTextContainer<byte>(bytes, 0);
             var validNodes = SongIniHandler.SONG_INI_DICTIONARY["[song]"];
-            var text = new YARGTextContainer<byte>(stream.ReadBytes((int)length), 0);
+
             for (ulong i = 0; i < numPairs; i++)
             {
-                int strLength = GetLength(text);
-                var key = Encoding.UTF8.GetString(text.Data, text.Position, strLength);
-                text.Position += strLength;
+                int strLength = GetLength(container);
+                var key = Encoding.UTF8.GetString(container.Data.Ptr + container.Position, strLength);
+                container.Position += strLength;
 
-                strLength = GetLength(text);
-                var next = text.Position + strLength;
+                strLength = GetLength(container);
+                var next = container.Position + strLength;
                 if (validNodes.TryGetValue(key, out var node))
                 {
-                    var mod = node.CreateSngModifier(text, strLength);
+                    var mod = node.CreateSngModifier(container, strLength);
                     if (modifiers.TryGetValue(node.outputName, out var list))
                     {
                         list.Add(mod);
@@ -140,7 +143,7 @@ namespace YARG.Core.IO
                         modifiers.Add(node.outputName, new() { mod });
                     }
                 }
-                text.Position = next;
+                container.Position = next;
             }
             return new IniSection(modifiers);
         }
@@ -167,9 +170,9 @@ namespace YARG.Core.IO
             return listings;
         }
 
-        private static int GetLength(YARGTextContainer<byte> container)
+        private static unsafe int GetLength(YARGTextContainer<byte> container)
         {
-            int length = BitConverter.ToInt32(container.Data, container.Position);
+            int length = *(int*)(container.Data.Ptr + container.Position);
             container.Position += sizeof(int);
             if (container.Position + length > container.Length)
             {

--- a/YARG.Core/IO/SngHandler/SngFileListing.cs
+++ b/YARG.Core/IO/SngHandler/SngFileListing.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using YARG.Core.Extensions;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.IO
 {
@@ -16,7 +17,7 @@ namespace YARG.Core.IO
             Position = reader.ReadInt64();
         }
 
-        public byte[] LoadAllBytes(SngFile sngFile)
+        public AllocatedArray<byte> LoadAllBytes(SngFile sngFile)
         {
             var stream = sngFile.LoadFileStream();
             return SngFileStream.LoadFile(stream, sngFile.Mask, Length, Position);

--- a/YARG.Core/IO/TextReader/StringDecoder.cs
+++ b/YARG.Core/IO/TextReader/StringDecoder.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using YARG.Core.Extensions;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.IO
 {
@@ -9,31 +10,31 @@ namespace YARG.Core.IO
         private static readonly UTF8Encoding UTF8 = new(true, true);
         private Encoding encoding = UTF8;
 
-        public string Decode(byte[] data, int index, int count)
+        public unsafe string Decode(FixedArray<byte> data, long index, long count)
         {
             try
             {
-                return encoding.GetString(data, index, count);
+                return encoding.GetString(data.Ptr + index, (int)count);
             }
             catch
             {
                 encoding = YARGTextContainer.Latin1;
-                return encoding.GetString(data, index, count);
+                return encoding.GetString(data.Ptr + index, (int)count);
             }
         }
     }
 
     public struct CharStringDecoder : IStringDecoder<char>
     {
-        public string Decode(char[] data, int index, int count)
+        public readonly unsafe string Decode(FixedArray<char> data, long index, long count)
         {
-            return new string(data, index, count);
+            return new string(data.Ptr, (int)index, (int) count);
         }
     }
 
     public interface IStringDecoder<TChar>
         where TChar : unmanaged, IConvertible
     {
-        public string Decode(TChar[] data, int index, int count);
+        public string Decode(FixedArray<TChar> data, long index, long count);
     } 
 }

--- a/YARG.Core/IO/TextReader/YARGTextContainer.cs
+++ b/YARG.Core/IO/TextReader/YARGTextContainer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using YARG.Core.Extensions;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.IO
 {
@@ -13,11 +14,11 @@ namespace YARG.Core.IO
     public sealed class YARGTextContainer<TChar>
         where TChar : unmanaged, IConvertible
     {
-        public readonly TChar[] Data;
-        public readonly int Length;
-        public int Position;
+        public readonly FixedArray<TChar> Data;
+        public readonly long Length;
+        public long Position;
 
-        public YARGTextContainer(TChar[] data, int position)
+        public YARGTextContainer(FixedArray<TChar> data, long position)
         {
             Data = data;
             Length = data.Length;
@@ -39,18 +40,6 @@ namespace YARG.Core.IO
         public bool IsEndOfFile()
         {
             return Position >= Length;
-        }
-
-        public ReadOnlySpan<TChar> Slice(int position, int length)
-        {
-            return new ReadOnlySpan<TChar>(Data, position, length);
-        }
-
-        public ReadOnlySpan<TChar> ExtractSpan(int length)
-        {
-            var span = Slice(Position, length);
-            Position += length;
-            return span;
         }
 
         private const char LAST_DIGIT_SIGNED = '7';

--- a/YARG.Core/IO/TextReader/YARGTextReader.cs
+++ b/YARG.Core/IO/TextReader/YARGTextReader.cs
@@ -1,7 +1,5 @@
-﻿using Melanchall.DryWetMidi.Interaction;
-using System;
+﻿using System;
 using System.Text;
-using YARG.Core.Extensions;
 using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.IO
@@ -19,7 +17,7 @@ namespace YARG.Core.IO
             return new YARGTextReader<byte, ByteStringDecoder>(data, position);
         }
 
-        public static AllocatedArray<char> ConvertToChar(FixedArray<byte> data)
+        public static FixedArray<char> ConvertToChar(FixedArray<byte> data)
         {
             long offset;
             long length;
@@ -28,6 +26,12 @@ namespace YARG.Core.IO
             {
                 offset = 2;
                 length = (data.Length - 2) / 2;
+
+                // UTF-16 encoding, endian-correct, so we can use a basic cast
+                if ((data[0] == 0xFF) == BitConverter.IsLittleEndian) unsafe
+                {
+                    return FixedArray<char>.Alias((char*) (data.Ptr + offset), length);
+                }
                 encoding = data[0] == 0xFF ? Encoding.Unicode : Encoding.BigEndianUnicode;
             }
             else

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -309,8 +309,7 @@ namespace YARG.Core.IO
 
         public bool IsStillCurrentTrack()
         {
-            int position = reader.Container.Position;
-            if (position == reader.Container.Length)
+            if (reader.Container.Position == reader.Container.Length)
                 return false;
 
             if (reader.Container.IsCurrentCharacter('}'))
@@ -340,15 +339,18 @@ namespace YARG.Core.IO
                 ++curr;
             }
 
-            var span = new ReadOnlySpan<TChar>(reader.Container.Data, reader.Container.Position, (curr - reader.Container.Position));
-            reader.Container.Position = curr;
-            foreach (var combo in eventSet)
+            unsafe
             {
-                if (combo.DoesEventMatch(span))
+                var span = new ReadOnlySpan<TChar>(reader.Container.Data.Ptr + reader.Container.Position, (int)(curr - reader.Container.Position));
+                reader.Container.Position = curr;
+                foreach (var combo in eventSet)
                 {
-                    reader.SkipWhitespace();
-                    ev.Type = combo.eventType;
-                    return true;
+                    if (combo.DoesEventMatch(span))
+                    {
+                        reader.SkipWhitespace();
+                        ev.Type = combo.eventType;
+                        return true;
+                    }
                 }
             }
 

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
@@ -6,12 +6,12 @@ namespace YARG.Core.Song.Cache
 {
     public sealed class UnpackedCONGroup : CONGroup
     {
-        public readonly AbridgedFileInfo DTA;
+        public readonly AbridgedFileInfo_Length DTA;
 
         public UnpackedCONGroup(string directory, FileInfo dta, string defaultPlaylist)
             : base(directory, defaultPlaylist)
         {
-            DTA = new AbridgedFileInfo(dta);
+            DTA = new AbridgedFileInfo_Length(dta);
         }
 
         public YARGDTAReader? LoadDTA()

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
@@ -1,12 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using YARG.Core.IO;
+using YARG.Core.IO.Disposables;
+using YARG.Core.Logging;
 
 namespace YARG.Core.Song.Cache
 {
-    public sealed class UnpackedCONGroup : CONGroup
+    public sealed class UnpackedCONGroup : CONGroup, IDisposable
     {
         public readonly AbridgedFileInfo_Length DTA;
+        private MemoryMappedArray? _fileData;
 
         public UnpackedCONGroup(string directory, FileInfo dta, string defaultPlaylist)
             : base(directory, defaultPlaylist)
@@ -16,7 +20,16 @@ namespace YARG.Core.Song.Cache
 
         public YARGDTAReader? LoadDTA()
         {
-            return YARGDTAReader.TryCreate(DTA.FullName);
+            try
+            {
+                _fileData = MemoryMappedArray.Load(DTA);
+                return YARGDTAReader.TryCreate(_fileData);
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogException(ex, $"Error while loading {DTA.FullName}");
+                return null;
+            }
         }
 
         public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
@@ -37,6 +50,11 @@ namespace YARG.Core.Song.Cache
             writer.Write(DTA.LastUpdatedTime.ToBinary());
             Serialize(writer, ref nodes);
             return ms.ToArray();
+        }
+
+        public void Dispose()
+        {
+            _fileData?.Dispose();
         }
     }
 }

--- a/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
@@ -3,20 +3,25 @@ using System.Collections.Generic;
 using System.IO;
 using YARG.Core.Extensions;
 using YARG.Core.IO;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.Song.Cache
 {
-    public sealed class UpdateGroup : IModificationGroup
+    public sealed class UpdateGroup : IModificationGroup, IDisposable
     {
         public readonly DirectoryInfo Directory;
         public readonly DateTime DTALastWrite;
         public readonly Dictionary<string, DirectoryInfo> SubDirectories;
         public readonly Dictionary<string, SongUpdate> Updates = new();
 
-        public UpdateGroup(DirectoryInfo directory, DateTime dtaLastUpdate)
+        private readonly MemoryMappedArray _dtaData;
+
+        public UpdateGroup(DirectoryInfo directory, DateTime dtaLastUpdate, MemoryMappedArray dtaData)
         {
             Directory = directory;
             DTALastWrite = dtaLastUpdate;
+            _dtaData = dtaData;
+            
             SubDirectories = new Dictionary<string, DirectoryInfo>();
             foreach (var dir in directory.EnumerateDirectories())
             {
@@ -38,6 +43,11 @@ namespace YARG.Core.Song.Cache
                 update.Serialize(writer);
             }
             return ms.ToArray();
+        }
+
+        public void Dispose()
+        {
+            _dtaData.Dispose();
         }
     }
 

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -513,7 +513,7 @@ namespace YARG.Core.Song.Cache
         private void QuickReadExtractedCONGroup(BinaryReader reader, List<Task> entryTasks, CategoryCacheStrings strings, ParallelExceptionTracker tracker)
         {
             string directory = reader.ReadString();
-            var dta = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, "songs.dta"), reader, false);
+            var dta = new AbridgedFileInfo_Length(Path.Combine(directory, "songs.dta"), reader);
             // Lack of null check of `dta` by design
 
             int count = reader.ReadInt32();

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -80,9 +80,22 @@ namespace YARG.Core.Song.Cache
                     var reader = group.LoadSongs();
                     if (reader != null)
                     {
-                        ScanCONGroup(group, reader, ScanPackedCONNode);
+                        try
+                        {
+                            List<Task> tasks = new();
+                            TraverseCONGroup(reader, (string name, int index) =>
+                            {
+                                var node = reader.Clone();
+                                tasks.Add(Task.Run(() => ScanPackedCONNode(group, name, index, node)));
+                            });
+                            Task.WaitAll(tasks.ToArray());
+                        }
+                        catch (Exception e)
+                        {
+                            YargLogger.LogException(e, $"Error while scanning CON group {group.Location}!");
+                        }
                     }
-                    group.Stream?.Dispose();
+                    group.DisposeStreamAndSongDTA();
                 }
                 );
             }
@@ -94,13 +107,31 @@ namespace YARG.Core.Song.Cache
                     var reader = group.LoadDTA();
                     if (reader != null)
                     {
-                        ScanCONGroup(group, reader, ScanUnpackedCONNode);
+                        try
+                        {
+                            List<Task> tasks = new();
+                            TraverseCONGroup(reader, (string name, int index) =>
+                            {
+                                var node = reader.Clone();
+                                tasks.Add(Task.Run(() => ScanUnpackedCONNode(group, name, index, node)));
+                            });
+                            Task.WaitAll(tasks.ToArray());
+                        }
+                        catch (Exception e)
+                        {
+                            YargLogger.LogException(e, $"Error while scanning CON group {group.Location}!");
+                        }
                     }
+                    group.Dispose();
                 }
                 );
             }
 
             Task.WaitAll(conTasks);
+            foreach (var group in conGroups)
+            {
+                group.DisposeUpgradeDTA();
+            }
         }
 
         protected override void TraverseDirectory(FileCollector collector, IniGroup group, PlaylistTracker tracker)
@@ -162,20 +193,7 @@ namespace YARG.Core.Song.Cache
         private void ScanCONGroup<TGroup>(TGroup group, YARGDTAReader reader, Action<TGroup, string, int, YARGDTAReader> func)
             where TGroup : CONGroup
         {
-            try
-            {
-                List<Task> tasks = new();
-                TraverseCONGroup(reader, (string name, int index) =>
-                {
-                    var node = reader.Clone();
-                    tasks.Add(Task.Run(() => func(group, name, index, node)));
-                });
-                Task.WaitAll(tasks.ToArray());
-            }
-            catch (Exception e)
-            {
-                YargLogger.LogException(e, $"Error while scanning CON group {group.Location}!");
-            }
+            
         }
 
         protected override void SortEntries()

--- a/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Parallel.cs
@@ -513,7 +513,7 @@ namespace YARG.Core.Song.Cache
         private void QuickReadExtractedCONGroup(BinaryReader reader, List<Task> entryTasks, CategoryCacheStrings strings, ParallelExceptionTracker tracker)
         {
             string directory = reader.ReadString();
-            var dta = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, "songs.dta"), reader);
+            var dta = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, "songs.dta"), reader, false);
             // Lack of null check of `dta` by design
 
             int count = reader.ReadInt32();

--- a/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Scanning.cs
@@ -278,8 +278,7 @@ namespace YARG.Core.Song.Cache
                 FileInfo dta = new(Path.Combine(directory, "songs_updates.dta"));
                 if (dta.Exists)
                 {
-                    var abridged = new AbridgedFileInfo(dta, false);
-                    CreateUpdateGroup(dirInfo, abridged, true);
+                    CreateUpdateGroup(dirInfo, dta, true);
                     return false;
                 }
             }
@@ -288,8 +287,7 @@ namespace YARG.Core.Song.Cache
                 FileInfo dta = new(Path.Combine(directory, "upgrades.dta"));
                 if (dta.Exists)
                 {
-                    var abridged = new AbridgedFileInfo(dta, false);
-                    CreateUpgradeGroup(directory, abridged, true);
+                    CreateUpgradeGroup(directory, dta, true);
                     return false;
                 }
             }

--- a/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
@@ -276,8 +276,7 @@ namespace YARG.Core.Song.Cache
         private void QuickReadExtractedCONGroup(BinaryReader reader, CategoryCacheStrings strings)
         {
             string directory = reader.ReadString();
-            var dta = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, "songs.dta"), reader, false);
-            // Lack of null check of dta by design
+            var dta = new AbridgedFileInfo_Length(Path.Combine(directory, "songs.dta"), reader);
 
             int count = reader.ReadInt32();
             for (int i = 0; i < count; ++i)

--- a/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
@@ -42,7 +42,7 @@ namespace YARG.Core.Song.Cache
                         YargLogger.LogException(e, $"Error while scanning packed CON group {group.Location}!");
                     }
                 }
-                group.Stream?.Dispose();
+                group.DisposeStreamAndSongDTA();
             }
 
             foreach (var group in extractedConGroups)
@@ -59,6 +59,12 @@ namespace YARG.Core.Song.Cache
                         YargLogger.LogException(e, $"Error while scanning unpacked CON group {group.Location}!");
                     }
                 }
+                group.Dispose();
+            }
+
+            foreach (var group in conGroups)
+            {
+                group.DisposeUpgradeDTA();
             }
         }
 

--- a/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Sequential.cs
@@ -276,7 +276,7 @@ namespace YARG.Core.Song.Cache
         private void QuickReadExtractedCONGroup(BinaryReader reader, CategoryCacheStrings strings)
         {
             string directory = reader.ReadString();
-            var dta = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, "songs.dta"), reader);
+            var dta = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, "songs.dta"), reader, false);
             // Lack of null check of dta by design
 
             int count = reader.ReadInt32();

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -362,18 +362,13 @@ namespace YARG.Core.Song.Cache
             var dtaLastUpdated = DateTime.FromBinary(reader.ReadInt64());
             int count = reader.ReadInt32();
 
-            var group = new UpgradeGroup(directory, dtaLastUpdated);
-            AddUpgradeGroup(group);
-
             for (int i = 0; i < count; i++)
             {
                 string name = reader.ReadString();
                 string filename = Path.Combine(directory, $"{name}_plus.mid");
 
                 var info = new AbridgedFileInfo_Length(filename, reader);
-                var upgrade = new UnpackedRBProUpgrade(info);
-                group.Upgrades.Add(name, upgrade);
-                AddUpgrade(name, null, upgrade);
+                AddUpgrade(name, null, new UnpackedRBProUpgrade(info));
             }
         }
 

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -372,7 +372,7 @@ namespace YARG.Core.Song.Cache
                 string name = reader.ReadString();
                 string filename = Path.Combine(directory, $"{name}_plus.mid");
 
-                var info = new AbridgedFileInfo(filename, reader);
+                var info = new AbridgedFileInfo(filename, reader, true);
                 var upgrade = new UnpackedRBProUpgrade(info);
                 group.Upgrades.Add(name, upgrade);
                 AddUpgrade(name, null, upgrade);

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -139,10 +139,9 @@ namespace YARG.Core.Song.Cache
                 {
                     FindOrMarkDirectory(directory);
 
-                    var abridged = new AbridgedFileInfo(dtaInfo, false);
                     var dirInfo = new DirectoryInfo(directory);
-                    var group = CreateUpdateGroup(dirInfo, abridged, false);
-                    if (group != null && abridged.LastUpdatedTime == dtaLastWritten)
+                    var group = CreateUpdateGroup(dirInfo, dtaInfo, false);
+                    if (group != null && dtaInfo.LastWriteTime == dtaLastWritten)
                     {
                         for (int i = 0; i < count; i++)
                         {
@@ -186,9 +185,8 @@ namespace YARG.Core.Song.Cache
                 {
                     FindOrMarkDirectory(directory);
 
-                    var abridged = new AbridgedFileInfo(dtaInfo, false);
-                    var group = CreateUpgradeGroup(directory, abridged, false);
-                    if (group != null && abridged.LastUpdatedTime == dtaLastWrritten)
+                    var group = CreateUpgradeGroup(directory, dtaInfo, false);
+                    if (group != null && dtaInfo.LastWriteTime == dtaLastWrritten)
                     {
                         for (int i = 0; i < count; i++)
                         {
@@ -372,7 +370,7 @@ namespace YARG.Core.Song.Cache
                 string name = reader.ReadString();
                 string filename = Path.Combine(directory, $"{name}_plus.mid");
 
-                var info = new AbridgedFileInfo(filename, reader, true);
+                var info = new AbridgedFileInfo_Length(filename, reader);
                 var upgrade = new UnpackedRBProUpgrade(info);
                 group.Upgrades.Add(name, upgrade);
                 AddUpgrade(name, null, upgrade);

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -142,7 +142,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 24_06_12_01;
+        public const int CACHE_VERSION = 24_06_13_01;
 
         protected readonly SongCache cache = new();
 

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using YARG.Core.Audio;
 using YARG.Core.IO;
+using YARG.Core.IO.Disposables;
 using YARG.Core.Logging;
 
 namespace YARG.Core.Song.Cache
@@ -45,6 +46,7 @@ namespace YARG.Core.Song.Cache
             {
                 YargLogger.LogException(ex, "Unknown error while running song scan!");
             }
+            handler.DisposeDTAData();
             GlobalAudioHandler.LogMixerStatus = true;
             return handler.cache;
         }
@@ -142,7 +144,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 24_06_13_01;
+        public const int CACHE_VERSION = 24_06_13_02;
 
         protected readonly SongCache cache = new();
 
@@ -177,6 +179,19 @@ namespace YARG.Core.Song.Cache
                 {
                     iniGroups.Add(new IniGroup(dir));
                 }
+            }
+        }
+
+        private void DisposeDTAData()
+        {
+            foreach(var group in upgradeGroups)
+            {
+                group.Dispose();
+            }
+
+            foreach (var group in updateGroups)
+            {
+                group.Dispose();
             }
         }
 
@@ -347,11 +362,25 @@ namespace YARG.Core.Song.Cache
 
         private UpgradeGroup? CreateUpgradeGroup(string directory, FileInfo dta, bool removeEntries)
         {
-            var reader = YARGDTAReader.TryCreate(dta.FullName);
-            if (reader == null)
-                return null;
+            MemoryMappedArray? fileData = null;
+            YARGDTAReader? reader = null;
+            try
+            {
+                fileData = MemoryMappedArray.Load(dta);
+                reader = YARGDTAReader.TryCreate(fileData);
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogException(ex, $"Error while loading {dta.FullName}");
+            }
 
-            var group = new UpgradeGroup(directory, dta.LastWriteTime);
+            if (reader == null)
+            {
+                fileData?.Dispose();
+                return null;
+            }
+
+            var group = new UpgradeGroup(directory, dta.LastWriteTime, fileData!);
             try
             {
                 while (reader.StartNode())
@@ -393,22 +422,23 @@ namespace YARG.Core.Song.Cache
 
         private UpdateGroup? CreateUpdateGroup(DirectoryInfo dirInfo, FileInfo dta, bool removeEntries)
         {
-            var nodes = FindUpdateNodes(dirInfo.FullName, dta);
-            if (nodes == null)
+            MemoryMappedArray? fileData = null;
+            YARGDTAReader? reader = null;
+            try
             {
-                return null;
+                fileData = MemoryMappedArray.Load(dta);
+                reader = YARGDTAReader.TryCreate(fileData);
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogException(ex, $"Error while loading {dta.FullName}");
             }
 
-            var group = new UpdateGroup(dirInfo, dta.LastUpdatedTime);
-            AddUpdates(group, nodes, removeEntries);
-            return group;
-        }
-
-        private Dictionary<string, List<YARGDTAReader>>? FindUpdateNodes(string directory, AbridgedFileInfo dta)
-        {
-            var reader = YARGDTAReader.TryCreate(dta.FullName);
             if (reader == null)
+            {
+                fileData?.Dispose();
                 return null;
+            }
 
             var nodes = new Dictionary<string, List<YARGDTAReader>>();
             try
@@ -427,16 +457,19 @@ namespace YARG.Core.Song.Cache
             }
             catch (Exception ex)
             {
-                YargLogger.LogException(ex, $"Error while scanning CON update folder {directory}!");
-                return null;
+                YargLogger.LogException(ex, $"Error while scanning CON update folder {dirInfo.FullName}!");
             }
 
             if (nodes.Count == 0)
             {
-                YargLogger.LogFormatWarning("{0} .dta file possibly malformed", directory);
+                YargLogger.LogFormatWarning("{0} .dta file possibly malformed", dirInfo.FullName);
+                fileData!.Dispose();
                 return null;
             }
-            return nodes;
+
+            var group = new UpdateGroup(dirInfo, dta.LastWriteTime, fileData!);
+            AddUpdates(group, nodes, removeEntries);
+            return group;
         }
 
         private bool TryParseUpgrades(string filename, PackedCONGroup group)

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -345,13 +345,13 @@ namespace YARG.Core.Song.Cache
             }
         }
 
-        private UpgradeGroup? CreateUpgradeGroup(string directory, AbridgedFileInfo dta, bool removeEntries)
+        private UpgradeGroup? CreateUpgradeGroup(string directory, FileInfo dta, bool removeEntries)
         {
             var reader = YARGDTAReader.TryCreate(dta.FullName);
             if (reader == null)
                 return null;
 
-            var group = new UpgradeGroup(directory, dta.LastUpdatedTime);
+            var group = new UpgradeGroup(directory, dta.LastWriteTime);
             try
             {
                 while (reader.StartNode())
@@ -360,7 +360,7 @@ namespace YARG.Core.Song.Cache
                     FileInfo info = new(Path.Combine(directory, $"{name}_plus.mid"));
                     if (info.Exists)
                     {
-                        var abridged = new AbridgedFileInfo(info, false);
+                        var abridged = new AbridgedFileInfo_Length(info, false);
                         if (CanAddUpgrade(name, abridged.LastUpdatedTime))
                         {
                             var upgrade = new UnpackedRBProUpgrade(abridged);
@@ -391,7 +391,7 @@ namespace YARG.Core.Song.Cache
             return group;
         }
 
-        private UpdateGroup? CreateUpdateGroup(DirectoryInfo dirInfo, AbridgedFileInfo dta, bool removeEntries)
+        private UpdateGroup? CreateUpdateGroup(DirectoryInfo dirInfo, FileInfo dta, bool removeEntries)
         {
             var nodes = FindUpdateNodes(dirInfo.FullName, dta);
             if (nodes == null)

--- a/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using YARG.Core.Chart;
 using YARG.Core.IO;
+using YARG.Core.IO.Disposables;
 using YARG.Core.IO.Ini;
 using YARG.Core.Song.Cache;
 using YARG.Core.Song.Preparsers;
@@ -163,12 +164,12 @@ namespace YARG.Core.Song
             return SongChart.FromDotChart(_parseSettings, reader.ReadToEnd());
         }
 
-        public override byte[]? LoadMiloData()
+        public override FixedArray<byte>? LoadMiloData()
         {
             return null;
         }
 
-        protected static (ScanResult Result, AvailableParts Parts) ScanIniChartFile(byte[] file, ChartType chartType, IniSection modifiers)
+        protected static (ScanResult Result, AvailableParts Parts) ScanIniChartFile(FixedArray<byte> file, ChartType chartType, IniSection modifiers)
         {
             DrumPreparseHandler drums = new()
             {
@@ -183,7 +184,7 @@ namespace YARG.Core.Song
                     ParseDotChart<byte, ByteStringDecoder, DotChartByte>(byteReader, modifiers, ref parts, drums);
                 else
                 {
-                    var chars = YARGTextLoader.ConvertToChar(file);
+                    using var chars = YARGTextLoader.ConvertToChar(file);
                     var charReader = new YARGTextReader<char, CharStringDecoder>(chars, 0);
                     ParseDotChart<char, CharStringDecoder, DotChartChar>(charReader, modifiers, ref parts, drums);
                 }
@@ -225,7 +226,7 @@ namespace YARG.Core.Song
                 drums.Type = DrumsType.FourLane;
         }
 
-        private static bool ParseDotMidi(byte[] file, IniSection modifiers, ref AvailableParts parts, DrumPreparseHandler drums)
+        private static bool ParseDotMidi(FixedArray<byte> file, IniSection modifiers, ref AvailableParts parts, DrumPreparseHandler drums)
         {
             bool usePro = !modifiers.TryGet("pro_drums", out bool proDrums) || proDrums;
             if (drums.Type == DrumsType.Unknown)

--- a/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
@@ -284,7 +284,7 @@ namespace YARG.Core.Song
         public static IniSubEntry? TryLoadFromCache(string baseDirectory, BinaryReader reader, CategoryCacheStrings strings)
         {
             string sngPath = Path.Combine(baseDirectory, reader.ReadString());
-            var sngInfo = AbridgedFileInfo.TryParseInfo(sngPath, reader);
+            var sngInfo = AbridgedFileInfo.TryParseInfo(sngPath, reader, false);
             if (sngInfo == null)
                 return null;
 
@@ -307,7 +307,7 @@ namespace YARG.Core.Song
         public static IniSubEntry? LoadFromCache_Quick(string baseDirectory, BinaryReader reader, CategoryCacheStrings strings)
         {
             string sngPath = Path.Combine(baseDirectory, reader.ReadString());
-            AbridgedFileInfo sngInfo = new(sngPath, DateTime.FromBinary(reader.ReadInt64()));
+            var sngInfo = new AbridgedFileInfo(sngPath, reader, false);
 
             uint version = reader.ReadUInt32();
             byte chartTypeIndex = reader.ReadByte();

--- a/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
@@ -284,12 +284,12 @@ namespace YARG.Core.Song
         public static IniSubEntry? TryLoadFromCache(string baseDirectory, BinaryReader reader, CategoryCacheStrings strings)
         {
             string sngPath = Path.Combine(baseDirectory, reader.ReadString());
-            var sngInfo = AbridgedFileInfo.TryParseInfo(sngPath, reader, false);
+            var sngInfo = AbridgedFileInfo.TryParseInfo(sngPath, reader);
             if (sngInfo == null)
                 return null;
 
             uint version = reader.ReadUInt32();
-            var sngFile = SngFile.TryLoadFromFile(sngInfo);
+            var sngFile = SngFile.TryLoadFromFile(sngInfo.Value);
             if (sngFile == null || sngFile.Version != version)
             {
                 // TODO: Implement Update-in-place functionality
@@ -301,13 +301,13 @@ namespace YARG.Core.Song
             {
                 return null;
             }
-            return new SngEntry(sngFile.Version, sngInfo, CHART_FILE_TYPES[chartTypeIndex], reader, strings);
+            return new SngEntry(sngFile.Version, sngInfo.Value, CHART_FILE_TYPES[chartTypeIndex], reader, strings);
         }
 
         public static IniSubEntry? LoadFromCache_Quick(string baseDirectory, BinaryReader reader, CategoryCacheStrings strings)
         {
             string sngPath = Path.Combine(baseDirectory, reader.ReadString());
-            var sngInfo = new AbridgedFileInfo(sngPath, reader, false);
+            var sngInfo = new AbridgedFileInfo(sngPath, reader);
 
             uint version = reader.ReadUInt32();
             byte chartTypeIndex = reader.ReadByte();

--- a/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
@@ -26,6 +26,7 @@ namespace YARG.Core.Song
         {
             writer.Write((byte) Type);
             writer.Write(_chartFile.LastUpdatedTime.ToBinary());
+            writer.Write(_chartFile.Length);
             if (_iniFile != null)
             {
                 writer.Write(true);
@@ -275,7 +276,7 @@ namespace YARG.Core.Song
             }
 
             var chart = CHART_FILE_TYPES[chartTypeIndex];
-            var chartInfo = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, chart.File), reader);
+            var chartInfo = AbridgedFileInfo.TryParseInfo(Path.Combine(directory, chart.File), reader, true);
             if (chartInfo == null)
             {
                 return null;
@@ -285,7 +286,7 @@ namespace YARG.Core.Song
             AbridgedFileInfo? iniInfo = null;
             if (reader.ReadBoolean())
             {
-                iniInfo = AbridgedFileInfo.TryParseInfo(iniFile, reader);
+                iniInfo = AbridgedFileInfo.TryParseInfo(iniFile, reader, false);
                 if (iniInfo == null)
                 {
                     return null;
@@ -308,14 +309,11 @@ namespace YARG.Core.Song
             }
 
             var chart = CHART_FILE_TYPES[chartTypeIndex];
-            var lastUpdated = DateTime.FromBinary(reader.ReadInt64());
-
-            var chartInfo = new AbridgedFileInfo(Path.Combine(directory, chart.File), lastUpdated);
+            var chartInfo = new AbridgedFileInfo(Path.Combine(directory, chart.File), reader, true);
             AbridgedFileInfo? iniInfo = null;
             if (reader.ReadBoolean())
             {
-                lastUpdated = DateTime.FromBinary(reader.ReadInt64());
-                iniInfo = new AbridgedFileInfo(Path.Combine(directory, "song.ini"), lastUpdated);
+                iniInfo = new AbridgedFileInfo(Path.Combine(directory, "song.ini"), reader, false);
             }
             return new UnpackedIniEntry(directory, chart.Type, chartInfo, iniInfo, reader, strings);
         }

--- a/YARG.Core/Song/Entries/RBCON/RBProUpgrade.cs
+++ b/YARG.Core/Song/Entries/RBCON/RBProUpgrade.cs
@@ -55,10 +55,10 @@ namespace YARG.Core.Song
     [Serializable]
     public sealed class UnpackedRBProUpgrade : IRBProUpgrade
     {
-        private readonly AbridgedFileInfo _midi;
+        private readonly AbridgedFileInfo_Length _midi;
         public DateTime LastUpdatedTime => _midi.LastUpdatedTime;
 
-        public UnpackedRBProUpgrade(AbridgedFileInfo info)
+        public UnpackedRBProUpgrade(in AbridgedFileInfo_Length info)
         {
             _midi = info;
         }

--- a/YARG.Core/Song/Entries/RBCON/RBProUpgrade.cs
+++ b/YARG.Core/Song/Entries/RBCON/RBProUpgrade.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using YARG.Core.IO;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.Song
 {
@@ -11,7 +12,7 @@ namespace YARG.Core.Song
         public DateTime LastUpdatedTime { get; }
         public void WriteToCache(BinaryWriter writer);
         public Stream? GetUpgradeMidiStream();
-        public byte[]? LoadUpgradeMidi();
+        public FixedArray<byte>? LoadUpgradeMidi();
     }
 
     [Serializable]
@@ -42,7 +43,7 @@ namespace YARG.Core.Song
             return _midiListing.CreateStream();
         }
 
-        public byte[]? LoadUpgradeMidi()
+        public FixedArray<byte>? LoadUpgradeMidi()
         {
             if (_midiListing == null || !_midiListing.ConFile.IsStillValid())
             {
@@ -66,6 +67,7 @@ namespace YARG.Core.Song
         public void WriteToCache(BinaryWriter writer)
         {
             writer.Write(_midi.LastUpdatedTime.ToBinary());
+            writer.Write(_midi.Length);
         }
 
         public Stream? GetUpgradeMidiStream()
@@ -73,9 +75,9 @@ namespace YARG.Core.Song
             return _midi.IsStillValid() ? new FileStream(_midi.FullName, FileMode.Open, FileAccess.Read, FileShare.Read) : null;
         }
 
-        public byte[]? LoadUpgradeMidi()
+        public FixedArray<byte>? LoadUpgradeMidi()
         {
-            return _midi.IsStillValid() ? File.ReadAllBytes(_midi.FullName) : null;
+            return _midi.IsStillValid() ? MemoryMappedArray.Load(_midi) : null;
         }
     }
 }

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
@@ -94,7 +94,7 @@ namespace YARG.Core.Song
             conFile.TryGetListing(midiFilename, out var midiListing);
             var lastMidiWrite = DateTime.FromBinary(reader.ReadInt64());
 
-            var updateMidi = reader.ReadBoolean() ? new AbridgedFileInfo(reader) : null;
+            var updateMidi = reader.ReadBoolean() ? new AbridgedFileInfo(reader, true) : null;
             var upgrade = upgrades.TryGetValue(nodename, out var node) ? node.Item2 : null;
 
             conFile.TryGetListing(Path.ChangeExtension(midiFilename, ".mogg"), out var moggListing);

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
@@ -63,10 +63,10 @@ namespace YARG.Core.Song
                 return null;
             }
 
-            AbridgedFileInfo? updateMidi = null;
+            AbridgedFileInfo_Length? updateMidi = null;
             if (reader.ReadBoolean())
             {
-                updateMidi = AbridgedFileInfo.TryParseInfo(reader, false);
+                updateMidi = AbridgedFileInfo_Length.TryParseInfo(reader, false);
                 if (updateMidi == null)
                 {
                     return null;
@@ -94,7 +94,7 @@ namespace YARG.Core.Song
             conFile.TryGetListing(midiFilename, out var midiListing);
             var lastMidiWrite = DateTime.FromBinary(reader.ReadInt64());
 
-            var updateMidi = reader.ReadBoolean() ? new AbridgedFileInfo(reader, true) : null;
+            AbridgedFileInfo_Length? updateMidi = reader.ReadBoolean() ? new AbridgedFileInfo_Length(reader) : null;
             var upgrade = upgrades.TryGetValue(nodename, out var node) ? node.Item2 : null;
 
             conFile.TryGetListing(Path.ChangeExtension(midiFilename, ".mogg"), out var moggListing);
@@ -134,7 +134,7 @@ namespace YARG.Core.Song
         }
 
         private PackedRBCONEntry(CONFileListing? midi, DateTime midiLastWrite, CONFileListing? moggListing, CONFileListing? miloListing, CONFileListing? imgListing, string directory,
-            AbridgedFileInfo? updateMidi, IRBProUpgrade? upgrade, BinaryReader reader, CategoryCacheStrings strings)
+            AbridgedFileInfo_Length? updateMidi, IRBProUpgrade? upgrade, BinaryReader reader, CategoryCacheStrings strings)
             : base(updateMidi, upgrade, reader, strings)
         {
             _midiListing = midi;

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
@@ -7,6 +7,7 @@ using YARG.Core.IO;
 using YARG.Core.Venue;
 using System.Linq;
 using YARG.Core.Logging;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.Song
 {
@@ -209,10 +210,10 @@ namespace YARG.Core.Song
                     var fileBase = Path.Combine(actualDirectory, name);
                     foreach (var ext in IMAGE_EXTENSIONS)
                     {
-                        string backgroundPath = fileBase + ext;
-                        if (File.Exists(backgroundPath))
+                        var file = new FileInfo(fileBase + ext);
+                        if (file.Exists)
                         {
-                            var image = YARGImage.Load(backgroundPath);
+                            var image = YARGImage.Load(file);
                             if (image != null)
                             {
                                 return new BackgroundResult(image);
@@ -224,7 +225,7 @@ namespace YARG.Core.Song
             return null;
         }
 
-        public override byte[]? LoadMiloData()
+        public override FixedArray<byte>? LoadMiloData()
         {
             var bytes = base.LoadMiloData();
             if (bytes != null)
@@ -241,7 +242,7 @@ namespace YARG.Core.Song
             return _midiListing.CreateStream();
         }
 
-        protected override byte[]? LoadMidiFile(Stream? file)
+        protected override FixedArray<byte>? LoadMidiFile(Stream? file)
         {
             if (_midiListing == null || !_midiListing.IsStillValid(_lastMidiWrite))
             {
@@ -250,7 +251,7 @@ namespace YARG.Core.Song
             return _midiListing.LoadAllBytes(file!);
         }
 
-        protected override byte[]? LoadRawImageData()
+        protected override FixedArray<byte>? LoadRawImageData()
         {
             var bytes = base.LoadRawImageData();
             if (bytes != null)

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -218,7 +218,7 @@ namespace YARG.Core.Song
         public virtual void Serialize(BinaryWriter writer, CategoryCacheWriteNode node)
         {
             writer.Write(_updateMidi != null);
-            _updateMidi?.Serialize(writer);
+            _updateMidi?.Serialize(writer, true);
 
             SerializeMetadata(writer, node);
 

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
@@ -6,6 +6,7 @@ using YARG.Core.Song.Cache;
 using YARG.Core.IO;
 using YARG.Core.Logging;
 using YARG.Core.Venue;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.Song
 {
@@ -162,10 +163,10 @@ namespace YARG.Core.Song
                     var fileBase = Path.Combine(Directory, name);
                     foreach (var ext in IMAGE_EXTENSIONS)
                     {
-                        string imageFile = fileBase + ext;
-                        if (File.Exists(imageFile))
+                        var file = new FileInfo(fileBase + ext);
+                        if (file.Exists)
                         {
-                            var image = YARGImage.Load(imageFile);
+                            var image = YARGImage.Load(file);
                             if (image != null)
                             {
                                 return new BackgroundResult(image);
@@ -177,7 +178,7 @@ namespace YARG.Core.Song
             return null;
         }
 
-        public override byte[]? LoadMiloData()
+        public override FixedArray<byte>? LoadMiloData()
         {
             var bytes = base.LoadMiloData();
             if (bytes != null)
@@ -185,12 +186,12 @@ namespace YARG.Core.Song
                 return bytes;
             }
 
-            string milo = Path.Combine(Directory, "gen", _nodename + ".milo_xbox");
-            if (!File.Exists(milo))
+            var info = new FileInfo(Path.Combine(Directory, "gen", _nodename + ".milo_xbox"));
+            if (!info.Exists)
             {
                 return null;
             }
-            return File.ReadAllBytes(milo);
+            return MemoryMappedArray.Load(info);
         }
 
         protected override Stream? GetMidiStream()
@@ -202,16 +203,16 @@ namespace YARG.Core.Song
             return new FileStream(_midi.Value.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
         }
 
-        protected override byte[]? LoadMidiFile(Stream? file)
+        protected override FixedArray<byte>? LoadMidiFile(Stream? file)
         {
             if (_dta == null || !_dta.Value.IsStillValid() || !_midi!.Value.IsStillValid())
             {
                 return null;
             }
-            return File.ReadAllBytes(_midi.Value.FullName);
+            return MemoryMappedArray.Load(_midi.Value);
         }
 
-        protected override byte[]? LoadRawImageData()
+        protected override FixedArray<byte>? LoadRawImageData()
         {
             var bytes = base.LoadRawImageData();
             if (bytes != null)
@@ -219,12 +220,12 @@ namespace YARG.Core.Song
                 return bytes;
             }
 
-            string image = Path.Combine(Directory, "gen", _nodename + "_keep.png_xbox");
-            if (!File.Exists(image))
+            var info = new FileInfo(Path.Combine(Directory, "gen", _nodename + "_keep.png_xbox"));
+            if (!info.Exists)
             {
                 return null;
             }
-            return File.ReadAllBytes(image);
+            return MemoryMappedArray.Load(info);
         }
 
         protected override Stream? GetMoggStream()

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
@@ -50,7 +50,7 @@ namespace YARG.Core.Song
             string songDirectory = Path.Combine(directory, subname);
 
             string midiPath = Path.Combine(songDirectory, subname + ".mid");
-            var midiInfo = AbridgedFileInfo.TryParseInfo(midiPath, reader);
+            var midiInfo = AbridgedFileInfo.TryParseInfo(midiPath, reader, true);
             if (midiInfo == null)
             {
                 return null;
@@ -76,9 +76,9 @@ namespace YARG.Core.Song
             string songDirectory = Path.Combine(directory, subname);
 
             string midiPath = Path.Combine(songDirectory, subname + ".mid");
-            var midiInfo = new AbridgedFileInfo(midiPath, reader);
+            var midiInfo = new AbridgedFileInfo(midiPath, reader, true);
 
-            var updateMidi = reader.ReadBoolean() ? new AbridgedFileInfo(reader) : null;
+            var updateMidi = reader.ReadBoolean() ? new AbridgedFileInfo(reader, true) : null;
 
             var upgrade = upgrades.TryGetValue(nodename, out var node) ? node.Item2 : null;
             return new UnpackedRBCONEntry(midiInfo, dta, songDirectory, subname, updateMidi, upgrade, reader, strings);
@@ -120,6 +120,7 @@ namespace YARG.Core.Song
         {
             writer.Write(_nodename);
             writer.Write(_midi!.LastUpdatedTime.ToBinary());
+            writer.Write(_midi.Length);
             base.Serialize(writer, node);
         }
 

--- a/YARG.Core/Song/Entries/SongEntry.Loading.cs
+++ b/YARG.Core/Song/Entries/SongEntry.Loading.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.IO;
+using YARG.Core.IO.Disposables;
 using YARG.Core.Logging;
 using YARG.Core.Venue;
 
@@ -43,6 +44,6 @@ namespace YARG.Core.Song
         public abstract StemMixer? LoadPreviewAudio(float speed);
         public abstract YARGImage? LoadAlbumData();
         public abstract BackgroundResult? LoadBackground(BackgroundType options);
-        public abstract byte[]? LoadMiloData();
+        public abstract FixedArray<byte>? LoadMiloData();
     }
 }

--- a/YARG.Core/Song/Entries/SongEntry.Scanning.cs
+++ b/YARG.Core/Song/Entries/SongEntry.Scanning.cs
@@ -4,16 +4,16 @@ using System.IO;
 using System.Text;
 using YARG.Core.Chart;
 using YARG.Core.IO;
+using YARG.Core.IO.Disposables;
 using YARG.Core.Song.Preparsers;
 
 namespace YARG.Core.Song
 {
     public abstract partial class SongEntry
     {
-        protected static bool ParseMidi(byte[] file, DrumPreparseHandler drums, ref AvailableParts parts)
+        protected static bool ParseMidi(FixedArray<byte> file, DrumPreparseHandler drums, ref AvailableParts parts)
         {
-            using var stream = new MemoryStream(file, 0, file.Length, false, true);
-            var midiFile = new YARGMidiFile(stream);
+            var midiFile = new YARGMidiFile(file.ToStream());
             foreach (var track in midiFile)
             {
                 if (midiFile.TrackNumber == 1)


### PR DESCRIPTION
The main aim of these next few sequences of PRs is to tackle some memory usage and GC issues I've observed during scanning. Note: any speed improvements are purely consequential.

To add MemoryMappedFile functionality, it was necessary to split the FixedArray type into pieces. At base, the FixedArray type is just an alias. It's sole function is to hold the pointer and length for a block of memory. The subtypes would handle any allocation or mapping of the block of memory to be represented.

Usage of memory mapped files necessitated holding onto the length of the file - as the MemoryMappedFile might not provide the exactly correct value (this was tested). As such, this also brings along a AbridgedFileInfo_Length struct to coincide with the original.

Through these array types, we can improve parsing strategies for scanning. As the memory for files remains in-place, we have access to pointer logic - which would provide better cache locality and lead to better performance (although, most of that will be in Part 2)