### PR TITLE
Optimize Scanning Around Pointer Arithmetic (Part 2)

### DIFF
--- a/YARG.Core/IO/Ini/IniModifierCreator.cs
+++ b/YARG.Core/IO/Ini/IniModifierCreator.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using YARG.Core.Song;
 using YARG.Core.Utility;
 
@@ -38,63 +35,62 @@ namespace YARG.Core.IO.Ini
             this.type = type;
         }
 
-        public IniModifier CreateModifier<TChar, TDecoder>(YARGTextReader<TChar, TDecoder> reader)
+        public unsafe IniModifier CreateModifier<TChar>(ref YARGTextContainer<TChar> container, in delegate*<TChar*, long, string> decoder)
             where TChar : unmanaged, IConvertible
-            where TDecoder : IStringDecoder<TChar>, new()
         {
             return type switch
             {
-                ModifierCreatorType.SortString       => new IniModifier(SortString.Convert(ExtractIniString(reader, false))),
-                ModifierCreatorType.SortString_Chart => new IniModifier(SortString.Convert(ExtractIniString(reader, true))),
-                ModifierCreatorType.String           => new IniModifier(ExtractIniString(reader, false)),
-                ModifierCreatorType.String_Chart     => new IniModifier(ExtractIniString(reader, true)),
-                _ => CreateNumberModifier(reader.Container),
+                ModifierCreatorType.SortString => new IniModifier(SortString.Convert(ExtractIniString(ref container, decoder, false))),
+                ModifierCreatorType.SortString_Chart => new IniModifier(SortString.Convert(ExtractIniString(ref container, decoder, true))),
+                ModifierCreatorType.String => new IniModifier(ExtractIniString(ref container, decoder, false)),
+                ModifierCreatorType.String_Chart => new IniModifier(ExtractIniString(ref container, decoder, true)),
+                _ => CreateNumberModifier(ref container),
             };
         }
 
-        public IniModifier CreateSngModifier(YARGTextContainer<byte> sngContainer, int length)
+        public IniModifier CreateSngModifier(ref YARGTextContainer<byte> sngContainer, int length)
         {
             return type switch
             {
-                ModifierCreatorType.SortString => new IniModifier(SortString.Convert(ExtractSngString(sngContainer, length))),
-                ModifierCreatorType.String =>     new IniModifier(ExtractSngString(sngContainer, length)),
-                _ => CreateNumberModifier(sngContainer),
+                ModifierCreatorType.SortString => new IniModifier(SortString.Convert(ExtractSngString(ref sngContainer, length))),
+                ModifierCreatorType.String => new IniModifier(ExtractSngString(ref sngContainer, length)),
+                _ => CreateNumberModifier(ref sngContainer),
             };
         }
 
-        private IniModifier CreateNumberModifier<TChar>(YARGTextContainer<TChar> container)
+        private IniModifier CreateNumberModifier<TChar>(ref YARGTextContainer<TChar> container)
             where TChar : unmanaged, IConvertible
         {
             switch (type)
             {
                 case ModifierCreatorType.UInt64:
                     {
-                        container.ExtractUInt64(out ulong value);
+                        container.TryExtractUInt64(out ulong value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.Int64:
                     {
-                        container.ExtractInt64(out long value);
+                        container.TryExtractInt64(out long value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.UInt32:
                     {
-                        container.ExtractUInt32(out uint value);
+                        container.TryExtractUInt32(out uint value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.Int32:
                     {
-                        container.ExtractInt32(out int value);
+                        container.TryExtractInt32(out int value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.UInt16:
                     {
-                        container.ExtractUInt16(out ushort value);
+                        container.TryExtractUInt16(out ushort value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.Int16:
                     {
-                        container.ExtractInt16(out short value);
+                        container.TryExtractInt16(out short value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.Bool:
@@ -103,21 +99,21 @@ namespace YARG.Core.IO.Ini
                     }
                 case ModifierCreatorType.Float:
                     {
-                        container.ExtractFloat(out float value);
+                        container.TryExtractFloat(out float value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.Double:
                     {
-                        container.ExtractDouble(out double value);
+                        container.TryExtractDouble(out double value);
                         return new IniModifier(value);
                     }
                 case ModifierCreatorType.UInt64Array:
                     {
                         long l2 = -1;
-                        if (container.ExtractInt64(out long l1))
+                        if (container.TryExtractInt64(out long l1))
                         {
-                            YARGTextReader.SkipWhitespace(container);
-                            if (!container.ExtractInt64(out l2))
+                            YARGTextReader.SkipWhitespace(ref container);
+                            if (!container.TryExtractInt64(out l2))
                             {
                                 l2 = -1;
                             }
@@ -133,16 +129,15 @@ namespace YARG.Core.IO.Ini
             }
         }
 
-        private static string ExtractIniString<TChar, TDecoder>(YARGTextReader<TChar, TDecoder> reader, bool isChartFile)
+        private static unsafe string ExtractIniString<TChar>(ref YARGTextContainer<TChar> container, in delegate*<TChar*, long, string> decoder, bool isChartFile)
             where TChar : unmanaged, IConvertible
-            where TDecoder : IStringDecoder<TChar>, new()
         {
-            return RichTextUtils.ReplaceColorNames(reader.ExtractText(isChartFile));
+            return RichTextUtils.ReplaceColorNames(YARGTextReader.ExtractText(ref container, decoder, isChartFile));
         }
 
-        private static unsafe string ExtractSngString(YARGTextContainer<byte> sngContainer, int length)
+        private static unsafe string ExtractSngString(ref YARGTextContainer<byte> sngContainer, int length)
         {
-            return RichTextUtils.ReplaceColorNames(Encoding.UTF8.GetString(sngContainer.Data.Ptr + sngContainer.Position, length));
+            return RichTextUtils.ReplaceColorNames(Encoding.UTF8.GetString(sngContainer.Position, length));
         }
     }
 }

--- a/YARG.Core/IO/Midi/YARGMidiFile.cs
+++ b/YARG.Core/IO/Midi/YARGMidiFile.cs
@@ -83,6 +83,7 @@ namespace YARG.Core.IO
 
             public bool MoveNext()
             {
+                _current?.Dispose();
                 _current = file.LoadNextTrack();
                 return _current != null;
             }
@@ -94,7 +95,7 @@ namespace YARG.Core.IO
 
             public void Dispose()
             {
-                //throw new NotImplementedException();
+                _current?.Dispose();
             }
         }
     }

--- a/YARG.Core/IO/Midi/YARGMidiTrack.cs
+++ b/YARG.Core/IO/Midi/YARGMidiTrack.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using YARG.Core.Extensions;
+using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.IO
 {
-    public sealed class YARGMidiTrack
+    public sealed unsafe class YARGMidiTrack : IDisposable
     {
         public static readonly Dictionary<string, MidiTrackType> TRACKNAMES = new()
         {
@@ -51,8 +52,9 @@ namespace YARG.Core.IO
         private MidiEvent _event;
         private MidiEvent _running;
 
-        private readonly ReadOnlyMemory<byte> _data;
-        private int _trackPos;
+        private readonly AllocatedArray<byte>? _buffer;
+        private readonly unsafe byte* _end;
+        private unsafe byte* _position;
 
         public long Position => _tickPosition;
         public MidiEventType Type => _event.Type;
@@ -60,22 +62,25 @@ namespace YARG.Core.IO
 
         public YARGMidiTrack(Stream stream)
         {
-            int count = stream.Read<int>(Endianness.Big);
-            if (stream is MemoryStream mem)
+            int length = stream.Read<int>(Endianness.Big);
+            if (stream is UnmanagedMemoryStream unmem)
             {
-                _data = new ReadOnlyMemory<byte>(mem.GetBuffer(), (int) mem.Position, count);
-                mem.Position += count;
+                _position = unmem.PositionPointer;
+                unmem.Position += length;
             }
             else
             {
-                _data = stream.ReadBytes(count);
+                _buffer = AllocatedArray<byte>.Read(stream, length);
+                _position = _buffer.Ptr;
             }
+            _end = _position + length;
             _event.Type = _running.Type = MidiEventType.Reset_Or_Meta;
         }
 
         public string? FindTrackName(Encoding encoding)
         {
             string trackname = string.Empty;
+            var start = _position;
             while (ParseEvent(true) && _tickPosition == 0)
             {
                 if (_event.Type == MidiEventType.Text_TrackName)
@@ -86,7 +91,11 @@ namespace YARG.Core.IO
                     trackname = ev;
                 }
             }
-            Reset();
+
+            _position = start;
+            _tickPosition = 0;
+            _event.Length = 0;
+            _event.Type = _running.Type = MidiEventType.Reset_Or_Meta;
             return trackname;
         }
 
@@ -95,14 +104,13 @@ namespace YARG.Core.IO
 
         public bool ParseEvent(bool parseVLQ)
         {
-            _trackPos += _event.Length;
+            _position += _event.Length;
             if (!parseVLQ)
                 AbsorbVLQ();
             else
                 _tickPosition += ReadVLQ();
 
-            var span = _data.Span;
-            byte tmp = span[_trackPos];
+            byte tmp = PeekByte();
             var type = (MidiEventType) tmp;
             if (type < MidiEventType.Note_Off)
             {
@@ -112,7 +120,7 @@ namespace YARG.Core.IO
             }
             else
             {
-                _trackPos++;
+                ++_position;
                 if (type < MidiEventType.SysEx)
                 {
                     _event.Channel = _running.Channel = (byte) (tmp & CHANNEL_MASK);
@@ -132,7 +140,7 @@ namespace YARG.Core.IO
                     switch (type)
                     {
                         case MidiEventType.Reset_Or_Meta:
-                            type = (MidiEventType) span[_trackPos++];
+                            type = (MidiEventType) ReadByte();
                             goto case MidiEventType.SysEx_End;
                         case MidiEventType.SysEx:
                         case MidiEventType.SysEx_End:
@@ -154,29 +162,34 @@ namespace YARG.Core.IO
                 }
             }
 
-            if (_trackPos + _event.Length > _data.Length)
+            if (_position + _event.Length > _end)
                 throw new EndOfStreamException();
             return true;
         }
 
+        private byte PeekByte()
+        {
+            if (_position < _end)
+                return *_position;
+            throw new InvalidOperationException();
+        }
+
+        private byte ReadByte()
+        {
+            if (_position < _end)
+                return *_position++;
+            throw new InvalidOperationException();
+        }
+
         public ReadOnlySpan<byte> ExtractTextOrSysEx()
         {
-            return _data.Slice(_trackPos, _event.Length).Span;
+            return new ReadOnlySpan<byte>(_position, _event.Length);
         }
 
         public void ExtractMidiNote(ref MidiNote note)
         {
-            var span = _data.Span;
-            note.value = span[_trackPos];
-            note.velocity = span[_trackPos + 1];
-        }
-
-        public void Reset()
-        {
-            _trackPos = 0;
-            _tickPosition = 0;
-            _event.Length = 0;
-            _event.Type = _running.Type = MidiEventType.Reset_Or_Meta;
+            note.value = _position[0];
+            note.velocity = _position[1];
         }
 
         private const uint EXTENDED_VLQ_FLAG = 0x80;
@@ -189,15 +202,14 @@ namespace YARG.Core.IO
         private const uint VLQ_SHIFTLIMIT = 1 << (VLQ_SHIFT * MAX_SHIFTCOUNT);
         private uint ReadVLQ()
         {
-            var span = _data.Span;
-            uint curr = span[_trackPos++];
+            uint curr = ReadByte();
             uint value = curr & VLQ_MASK;
             while (curr >= EXTENDED_VLQ_FLAG)
             {
                 if (value < VLQ_SHIFTLIMIT)
                 {
                     value <<= VLQ_SHIFT;
-                    curr = span[_trackPos++];
+                    curr = ReadByte();
                     value |= curr & VLQ_MASK;
                 }
                 else
@@ -208,20 +220,24 @@ namespace YARG.Core.IO
 
         private unsafe void AbsorbVLQ()
         {
-            var span = _data.Span;
-            uint b = span[_trackPos++];
+            uint b = ReadByte();
             // Skip zeroes
             while (b == EXTENDED_VLQ_FLAG)
-                b = span[_trackPos++];
+                b = ReadByte();
 
-            int maxPos = _trackPos + MAX_SHIFTCOUNT;
+            var maxPos = _position + MAX_SHIFTCOUNT;
             while (b >= EXTENDED_VLQ_FLAG)
             {
-                if (_trackPos < maxPos)
-                    b = span[_trackPos++];
+                if (_position < maxPos)
+                    b = ReadByte();
                 else
                     throw new Exception("Invalid variable length quantity");
             }
+        }
+
+        public void Dispose()
+        {
+            _buffer?.Dispose();
         }
     }
 

--- a/YARG.Core/IO/SngHandler/SngFile.cs
+++ b/YARG.Core/IO/SngHandler/SngFile.cs
@@ -125,15 +125,15 @@ namespace YARG.Core.IO
 
             for (ulong i = 0; i < numPairs; i++)
             {
-                int strLength = GetLength(container);
-                var key = Encoding.UTF8.GetString(container.Data.Ptr + container.Position, strLength);
+                int strLength = GetLength(ref container);
+                var key = Encoding.UTF8.GetString(container.Position, strLength);
                 container.Position += strLength;
 
-                strLength = GetLength(container);
+                strLength = GetLength(ref container);
                 var next = container.Position + strLength;
                 if (validNodes.TryGetValue(key, out var node))
                 {
-                    var mod = node.CreateSngModifier(container, strLength);
+                    var mod = node.CreateSngModifier(ref container, strLength);
                     if (modifiers.TryGetValue(node.outputName, out var list))
                     {
                         list.Add(mod);
@@ -170,11 +170,11 @@ namespace YARG.Core.IO
             return listings;
         }
 
-        private static unsafe int GetLength(YARGTextContainer<byte> container)
+        private static unsafe int GetLength(ref YARGTextContainer<byte> container)
         {
-            int length = *(int*)(container.Data.Ptr + container.Position);
+            int length = *(int*)(container.Position);
             container.Position += sizeof(int);
-            if (container.Position + length > container.Length)
+            if (container.Position + length > container.End)
             {
                 throw new EndOfStreamException();
             }

--- a/YARG.Core/IO/TextReader/StringDecoder.cs
+++ b/YARG.Core/IO/TextReader/StringDecoder.cs
@@ -1,40 +1,25 @@
-﻿using System;
-using System.Text;
-using YARG.Core.Extensions;
-using YARG.Core.IO.Disposables;
+﻿using System.Text;
 
 namespace YARG.Core.IO
 {
-    public sealed class ByteStringDecoder : IStringDecoder<byte>
+    public static unsafe class StringDecoder
     {
         private static readonly UTF8Encoding UTF8 = new(true, true);
-        private Encoding encoding = UTF8;
-
-        public unsafe string Decode(FixedArray<byte> data, long index, long count)
+        public static string Decode(byte* data, long count)
         {
             try
             {
-                return encoding.GetString(data.Ptr + index, (int)count);
+                return UTF8.GetString(data, (int) count);
             }
             catch
             {
-                encoding = YARGTextContainer.Latin1;
-                return encoding.GetString(data.Ptr + index, (int)count);
+                return YARGTextContainer.Latin1.GetString(data, (int) count);
             }
         }
-    }
 
-    public struct CharStringDecoder : IStringDecoder<char>
-    {
-        public readonly unsafe string Decode(FixedArray<char> data, long index, long count)
+        public static string Decode(char* data, long count)
         {
-            return new string(data.Ptr, (int)index, (int) count);
+            return new string(data, 0, (int) count);
         }
     }
-
-    public interface IStringDecoder<TChar>
-        where TChar : unmanaged, IConvertible
-    {
-        public string Decode(FixedArray<TChar> data, long index, long count);
-    } 
 }

--- a/YARG.Core/IO/TextReader/YARGTextReader.cs
+++ b/YARG.Core/IO/TextReader/YARGTextReader.cs
@@ -4,17 +4,21 @@ using YARG.Core.IO.Disposables;
 
 namespace YARG.Core.IO
 {
-    public static class YARGTextLoader
+    public static unsafe class YARGTextReader
     {
         private static readonly UTF32Encoding UTF32BE = new(true, false);
 
-        public static YARGTextReader<byte, ByteStringDecoder>? TryLoadByteText(FixedArray<byte> data)
+        public static bool TryLoadByteText(FixedArray<byte> data, out YARGTextContainer<byte> container)
         {
             if ((data[0] == 0xFF && data[1] == 0xFE) || (data[0] == 0xFE && data[1] == 0xFF))
-                return null;
+            {
+                container = default;
+                return false;
+            }
 
             int position = data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF ? 3 : 0;
-            return new YARGTextReader<byte, ByteStringDecoder>(data, position);
+            container = new YARGTextContainer<byte>(data, position);
+            return true;
         }
 
         public static FixedArray<char> ConvertToChar(FixedArray<byte> data)
@@ -44,322 +48,318 @@ namespace YARG.Core.IO
             var charData = AllocatedArray<char>.Alloc(length);
             unsafe
             {
-                encoding.GetChars(data.Ptr + offset, (int)(data.Length - offset), charData.Ptr, (int)charData.Length);
+                encoding.GetChars(data.Ptr + offset, (int) (data.Length - offset), charData.Ptr, (int) charData.Length);
             }
             return charData;
         }
-    }
 
-    public static class YARGTextReader
-    {
-        public static char SkipWhitespace<TChar>(YARGTextContainer<TChar> container)
+        public static void SkipPureWhitespace<TChar>(ref YARGTextContainer<TChar> container)
             where TChar : unmanaged, IConvertible
         {
-            while (container.Position < container.Length)
+            while (container.Position < container.End && container.Position->ToChar(null) <= 32)
             {
-                char ch = container.Data[container.Position].ToChar(null);
-                if (ch <= 32)
+                ++container.Position;
+            }
+        }
+
+        /// <summary>
+        /// Skips all whitespace starting at the current position of the provided container,
+        /// until the end of the current line.
+        /// </summary>
+        /// <remarks>"\n" is not included as whitespace in this version</remarks>
+        /// <typeparam name="TChar">Type of data contained</typeparam>
+        /// <param name="container">Buffer of data</param>
+        /// <returns>The current character that halted skipping, or 0 if at EoF</returns>
+        public static char SkipWhitespace<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
+        {
+            while (container.Position < container.End)
+            {
+                char ch = container.Position->ToChar(null);
+                if (ch > 32 || ch == '\n')
                 {
-                    if (ch == '\n')
-                        return ch;
-                }
-                else if (ch != '=')
                     return ch;
+                }
                 ++container.Position;
             }
             return (char) 0;
         }
-    }
 
-    public sealed class YARGTextReader<TChar, TDecoder>
-        where TChar : unmanaged, IConvertible
-        where TDecoder : IStringDecoder<TChar>, new()
-    {
-        private readonly TDecoder decoder = new();
-        public readonly YARGTextContainer<TChar> Container;
-
-        public YARGTextReader(FixedArray<TChar> data, long position)
+        public static void SkipWhitespaceAndEquals<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            Container = new YARGTextContainer<TChar>(data, position);
-            while (Container.Position < Container.Length)
+            if (SkipWhitespace(ref container) == '=')
             {
-                char curr = Container.Data[Container.Position].ToChar(null);
-                if (curr > 32 && curr != '{' && curr != '=')
-                {
-                    break;
-                }
-                ++Container.Position;
+                ++container.Position;
+                SkipWhitespace(ref container);
             }
         }
 
-        public char SkipWhitespace()
+        public static void GotoNextLine<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            return YARGTextReader.SkipWhitespace(Container);
-        }
-
-        public void GotoNextLine()
-        {
-            char curr = default;
-            while (Container.Position < Container.Length)
+            while (container.Position < container.End)
             {
-                curr = Container.Data[Container.Position].ToChar(null);
-                ++Container.Position;
+                char curr = container.Position->ToChar(null);
+                ++container.Position;
                 if (curr == '\n')
                 {
+                    SkipPureWhitespace(ref container);
                     break;
                 }
-            }
-
-            while (Container.Position < Container.Length)
-            {
-                curr = Container.Data[Container.Position].ToChar(null);
-                if (curr > 32 && curr != '{' && curr != '=')
-                {
-                    break;
-
-                }
-                ++Container.Position;
             }
         }
 
-        public void SkipLinesUntil(char stopCharacter)
+        public static bool SkipLinesUntil<TChar>(ref YARGTextContainer<TChar> container, char stopCharacter)
+            where TChar : unmanaged, IConvertible
         {
-            GotoNextLine();
-            while (Container.Position < Container.Length)
+            GotoNextLine(ref container);
+            var pivot = container.Position;
+            while (container.Position < container.End)
             {
-                if (Container.Data[Container.Position].ToChar(null) == stopCharacter)
+                if (container.Position->ToChar(null) == stopCharacter)
                 {
                     // Runs a check to ensure that the character is the start of the line
-                    long test = Container.Position - 1;
-                    char character = Container.Data[test].ToChar(null);
-                    while (test > 0 && character <= 32 && character != '\n')
+                    var test = container.Position - 1;
+                    char character = test->ToChar(null);
+                    while (test > pivot && character <= 32 && character != '\n')
                     {
                         --test;
-                        character = Container.Data[test].ToChar(null);
+                        character = test->ToChar(null);
                     }
 
                     if (character == '\n')
-                        break;
+                    {
+                        return true;
+                    }
+                    pivot = container.Position;
                 }
-                ++Container.Position;
+                ++container.Position;
             }
+            return false;
         }
 
-        public string ExtractModifierName()
+        public static unsafe string ExtractModifierName<TChar>(ref YARGTextContainer<TChar> container, in delegate*<TChar*, long, string> decoder)
+            where TChar : unmanaged, IConvertible
         {
-            long curr = Container.Position;
-            while (curr < Container.Length)
+            var curr = container.Position;
+            while (curr < container.End)
             {
-                char b = Container.Data[curr].ToChar(null);
+                char b = curr->ToChar(null);
                 if (b <= 32 || b == '=')
+                {
                     break;
+                }
                 ++curr;
             }
 
-            string name = decoder.Decode(Container.Data, Container.Position, curr - Container.Position);
-            Container.Position = curr;
-            SkipWhitespace();
+            string name = decoder(container.Position, curr - container.Position);
+            container.Position = curr;
+            SkipWhitespaceAndEquals(ref container);
             return name;
         }
 
-        public string PeekLine()
+        public static unsafe string PeekLine<TChar>(ref YARGTextContainer<TChar> container, in delegate*<TChar*, long, string> decoder)
+            where TChar : unmanaged, IConvertible
         {
-            var curr = Container.Position;
-            while (curr < Container.Length && Container.Data[curr].ToChar(null) != '\n')
+            var curr = container.Position;
+            while (curr < container.End && curr->ToChar(null) != '\n')
             {
                 ++curr;
             }
-            return decoder.Decode(Container.Data, Container.Position, curr - Container.Position).TrimEnd();
+            return decoder(container.Position, curr - container.Position).TrimEnd();
         }
 
-        public string ExtractText(bool isChartFile)
+        public static unsafe string ExtractText<TChar>(ref YARGTextContainer<TChar> container, in delegate*<TChar*, long, string> decoder, bool isChartFile)
+            where TChar : unmanaged, IConvertible
         {
-            var stringBegin = Container.Position;
-            long stringEnd = -1;
-            if (isChartFile && Container.Position < Container.Length && Container.Data[Container.Position].ToChar(null) == '\"')
+            var stringBegin = container.Position;
+            TChar* stringEnd = null;
+            if (isChartFile && container.Position < container.End && container.Position->ToChar(null) == '\"')
             {
                 while (true)
                 {
-                    ++Container.Position;
-                    if (Container.Position == Container.Length)
+                    ++container.Position;
+                    if (container.Position == container.End)
                     {
                         break;
                     }
 
-                    char ch = Container.Data[Container.Position].ToChar(null);
+                    char ch = container.Position->ToChar(null);
                     if (ch == '\n')
                     {
                         break;
                     }
 
-                    if (stringEnd == -1)
+                    if (stringEnd == null)
                     {
-                        if (ch == '\"' && Container.Data[Container.Position - 1].ToChar(null) != '\\')
+                        if (ch == '\"' && container.Position[-1].ToChar(null) != '\\')
                         {
                             ++stringBegin;
-                            stringEnd = Container.Position;
+                            stringEnd = container.Position;
                         }
                         else if (ch == '\r')
                         {
-                            stringEnd = Container.Position;
+                            stringEnd = container.Position;
                         }
                     }
                 }
             }
             else
             {
-                while (Container.Position < Container.Length)
+                while (container.Position < container.End)
                 {
-                    char ch = Container.Data[Container.Position].ToChar(null);
+                    char ch = container.Position->ToChar(null);
                     if (ch == '\n')
                     {
                         break;
                     }
 
-                    if (ch == '\r' && stringEnd == -1)
+                    if (ch == '\r' && stringEnd == null)
                     {
-                        stringEnd = Container.Position;
+                        stringEnd = container.Position;
                     }
-                    ++Container.Position;
+                    ++container.Position;
                 }
             }
 
-            if (stringEnd == -1)
+            if (stringEnd == null)
             {
-                stringEnd = Container.Position;
+                stringEnd = container.Position;
             }
 
-            while (stringBegin < stringEnd && Container.Data[stringEnd - 1].ToChar(null) <= 32)
+            while (stringBegin < stringEnd && stringEnd[-1].ToChar(null) <= 32)
                 --stringEnd;
 
-            return decoder.Decode(Container.Data, stringBegin, stringEnd - stringBegin);
+            return decoder(stringBegin, stringEnd - stringBegin);
         }
 
-        public bool ExtractBoolean()
+        /// <summary>
+        /// Extracts a short and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The short</returns>
+        public static short ExtractInt16<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            bool result = Container.ExtractBoolean();
-            SkipWhitespace();
-            return result;
+            if (!container.TryExtractInt16(out short value))
+            {
+                throw new Exception("Data for Int16 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
 
-        public short ExtractInt16()
+        /// <summary>
+        /// Extracts a ushort and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The ushort</returns>
+        public static ushort ExtractUInt16<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            short result = Container.ExtractInt16();
-            SkipWhitespace();
-            return result;
+            if (!container.TryExtractUInt16(out ushort value))
+            {
+                throw new Exception("Data for UInt16 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
 
-        public ushort ExtractUInt16()
+        /// <summary>
+        /// Extracts a int and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The int</returns>
+        public static int ExtractInt32<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            ushort result = Container.ExtractUInt16();
-            SkipWhitespace();
-            return result;
+            if (!container.TryExtractInt32(out int value))
+            {
+                throw new Exception("Data for Int32 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
 
-        public int ExtractInt32()
+        /// <summary>
+        /// Extracts a uint and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The uint</returns>
+        public static uint ExtractUInt32<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            int result = Container.ExtractInt32();
-            SkipWhitespace();
-            return result;
+            if (!container.TryExtractUInt32(out uint value))
+            {
+                throw new Exception("Data for UInt32 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
 
-        public uint ExtractUInt32()
+        /// <summary>
+        /// Extracts a long and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The long</returns>
+        public static long ExtractInt64<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            uint result = Container.ExtractUInt32();
-            SkipWhitespace();
-            return result;
+            if (!container.TryExtractInt64(out long value))
+            {
+                throw new Exception("Data for Int64 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
 
-        public long ExtractInt64()
+        /// <summary>
+        /// Extracts a ulong and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The ulong</returns>
+        public static ulong ExtractUInt64<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            long result = Container.ExtractInt64();
-            SkipWhitespace();
-            return result;
+            if (!container.TryExtractUInt64(out ulong value))
+            {
+                throw new Exception("Data for UInt64 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
 
-        public ulong ExtractUInt64()
+        /// <summary>
+        /// Extracts a float and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The float</returns>
+        public static float ExtractFloat<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            ulong result = Container.ExtractUInt64();
-            SkipWhitespace();
-            return result;
+            if (!container.TryExtractFloat(out float value))
+            {
+                throw new Exception("Data for Int16 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
 
-        public float ExtractFloat()
+        /// <summary>
+        /// Extracts a double and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The double</returns>
+        public static double ExtractDouble<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IConvertible
         {
-            float result = Container.ExtractFloat();
-            SkipWhitespace();
-            return result;
-        }
-
-        public double ExtractDouble()
-        {
-            double result = Container.ExtractDouble();
-            SkipWhitespace();
-            return result;
-        }
-
-        public bool ExtractInt16(out short value)
-        {
-            if (!Container.ExtractInt16(out value))
-                return false;
-            SkipWhitespace();
-            return true;
-        }
-
-        public bool ExtractUInt16(out ushort value)
-        {
-            if (!Container.ExtractUInt16(out value))
-                return false;
-            SkipWhitespace();
-            return true;
-        }
-
-        public bool ExtractInt32(out int value)
-        {
-            if (!Container.ExtractInt32(out value))
-                return false;
-            SkipWhitespace();
-            return true;
-        }
-
-        public bool ExtractUInt32(out uint value)
-        {
-            if (!Container.ExtractUInt32(out value))
-                return false;
-            SkipWhitespace();
-            return true;
-        }
-
-        public bool ExtractInt64(out long value)
-        {
-            if (!Container.ExtractInt64(out value))
-                return false;
-            SkipWhitespace();
-            return true;
-        }
-
-        public bool ExtractUInt64(out ulong value)
-        {
-            if (!Container.ExtractUInt64(out value))
-                return false;
-            SkipWhitespace();
-            return true;
-        }
-
-        public bool ExtractFloat(out float value)
-        {
-            if (!Container.ExtractFloat(out value))
-                return false;
-            SkipWhitespace();
-            return true;
-        }
-
-        public bool ExtractDouble(out double value)
-        {
-            if (!Container.ExtractDouble(out value))
-                return false;
-            SkipWhitespace();
-            return true;
+            if (!container.TryExtractDouble(out double value))
+            {
+                throw new Exception("Data for Int16 not present");
+            }
+            SkipWhitespace(ref container);
+            return value;
         }
     }
 }

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -35,303 +35,155 @@ namespace YARG.Core.IO
 
     public struct DotChartEvent
     {
-        private long _position;
-
+        public long Position;
         public ChartEventType Type;
-        public long Position
+    }
+
+    public static class YARGChartFileReader
+    {
+        public const string HEADERTRACK = "[Song]";
+        public const string SYNCTRACK = "[SyncTrack]";
+        public const string EVENTTRACK = "[Events]";
+
+        internal static readonly (string name, Difficulty difficulty)[] DIFFICULTIES =
         {
-            get { return _position; }
-            set
+            ("[Easy", Difficulty.Easy),
+            ("[Medium", Difficulty.Medium),
+            ("[Hard", Difficulty.Hard),
+            ("[Expert", Difficulty.Expert),
+        };
+
+        internal static readonly (string, Instrument)[] NOTETRACKS =
+        {
+            new("Single]",       Instrument.FiveFretGuitar),
+            new("DoubleGuitar]", Instrument.FiveFretCoopGuitar),
+            new("DoubleBass]",   Instrument.FiveFretBass),
+            new("DoubleRhythm]", Instrument.FiveFretRhythm),
+            new("Drums]",        Instrument.FourLaneDrums),
+            new("Keyboard]",     Instrument.Keys),
+            new("GHLGuitar]",    Instrument.SixFretGuitar),
+            new("GHLBass]",      Instrument.SixFretBass),
+            new("GHLRhythm]",    Instrument.SixFretRhythm),
+            new("GHLCoop]",      Instrument.SixFretCoopGuitar),
+        };
+
+        internal static readonly (string Descriptor, ChartEventType Type)[] EVENTS =
+        {
+            new("B",  ChartEventType.Bpm),
+            new("TS", ChartEventType.Time_Sig),
+            new("A",  ChartEventType.Anchor),
+            new("E",  ChartEventType.Text),
+            new("N",  ChartEventType.Note),
+            new("S",  ChartEventType.Special),
+        };
+
+        public static bool IsStartOfTrack<TChar>(in YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
+        {
+            return !container.IsAtEnd() && container.IsCurrentCharacter('[');
+        }
+
+        public static bool ValidateTrack<TChar>(ref YARGTextContainer<TChar> container, string track)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
+        {
+            if (!DoesStringMatch(ref container, track))
+                return false;
+
+            YARGTextReader.GotoNextLine(ref container);
+            return true;
+        }
+
+        public static bool ValidateInstrument<TChar>(ref YARGTextContainer<TChar> container, out Instrument instrument, out Difficulty difficulty)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
+        {
+            if (ValidateDifficulty(ref container, out difficulty))
             {
-                if (_position <= value)
-                    _position = value;
-                else
-                    throw new Exception($".chart position out of order (previous: {_position})");
-            }
-        }
-    }
-
-    public struct DotChartNote
-    {
-        public int Lane;
-        public long Duration;
-    }
-
-    public readonly struct DotChartEventCombo<T>
-        where T : unmanaged, IEquatable<T>
-    {
-        public readonly T[] descriptor;
-        public readonly ChartEventType eventType;
-        public DotChartEventCombo(ReadOnlySpan<T> descriptor, ChartEventType eventType)
-        {
-            this.descriptor = descriptor.ToArray();
-            this.eventType = eventType;
-        }
-
-        public bool DoesEventMatch(ReadOnlySpan<T> span)
-        {
-            if (span.Length != descriptor.Length)
-                return false;
-
-            for (int i = 0; i < descriptor.Length; i++)
-                if (!span[i].Equals(descriptor[i]))
-                    return false;
-            return true;
-        }
-    }
-
-    public interface IDotChartBases<T>
-        where T : unmanaged, IEquatable<T>
-    {
-        public ReadOnlySpan<T> HEADERTRACK { get; }
-        public ReadOnlySpan<T> SYNCTRACK { get; }
-        public ReadOnlySpan<T> EVENTTRACK { get; }
-        public DotChartEventCombo<T> TEMPO { get; }
-        public DotChartEventCombo<T> TIMESIG { get; }
-        public DotChartEventCombo<T> ANCHOR { get; }
-        public DotChartEventCombo<T> TEXT { get; }
-        public DotChartEventCombo<T> NOTE { get; }
-        public DotChartEventCombo<T> SPECIAL { get; }
-
-        public (T[], Difficulty)[] DIFFICULTIES { get; }
-        public (T[], NoteTracks_Chart)[] NOTETRACKS { get; }
-        public DotChartEventCombo<T>[] EVENTS_SYNC { get; }
-        public DotChartEventCombo<T>[] EVENTS_EVENTS { get; }
-        public DotChartEventCombo<T>[] EVENTS_DIFF { get; }
-    }
-
-    public readonly struct DotChartByte : IDotChartBases<byte>
-    {
-        private static readonly byte[] _HEADERTRACK = Encoding.ASCII.GetBytes("[Song]");
-        private static readonly byte[] _SYNCTRACK = Encoding.ASCII.GetBytes("[SyncTrack]");
-        private static readonly byte[] _EVENTTRACK = Encoding.ASCII.GetBytes("[Events]");
-        private static readonly DotChartEventCombo<byte> _TEMPO = new(Encoding.ASCII.GetBytes("B"), ChartEventType.Bpm);
-        private static readonly DotChartEventCombo<byte> _TIMESIG = new(Encoding.ASCII.GetBytes("TS"), ChartEventType.Time_Sig);
-        private static readonly DotChartEventCombo<byte> _ANCHOR = new(Encoding.ASCII.GetBytes("A"), ChartEventType.Anchor);
-        private static readonly DotChartEventCombo<byte> _TEXT = new(Encoding.ASCII.GetBytes("E"), ChartEventType.Text);
-        private static readonly DotChartEventCombo<byte> _NOTE = new(Encoding.ASCII.GetBytes("N"), ChartEventType.Note);
-        private static readonly DotChartEventCombo<byte> _SPECIAL = new(Encoding.ASCII.GetBytes("S"), ChartEventType.Special);
-
-        private static readonly (byte[] name, Difficulty difficulty)[] _DIFFICULTIES =
-        {
-            (Encoding.ASCII.GetBytes("[Easy"), Difficulty.Easy),
-            (Encoding.ASCII.GetBytes("[Medium"), Difficulty.Medium),
-            (Encoding.ASCII.GetBytes("[Hard"), Difficulty.Hard),
-            (Encoding.ASCII.GetBytes("[Expert"), Difficulty.Expert),
-        };
-
-        private static readonly (byte[], NoteTracks_Chart)[] _NOTETRACKS =
-        {
-            new(Encoding.ASCII.GetBytes("Single]"),       NoteTracks_Chart.Single ),
-            new(Encoding.ASCII.GetBytes("DoubleGuitar]"), NoteTracks_Chart.DoubleGuitar ),
-            new(Encoding.ASCII.GetBytes("DoubleBass]"),   NoteTracks_Chart.DoubleBass ),
-            new(Encoding.ASCII.GetBytes("DoubleRhythm]"), NoteTracks_Chart.DoubleRhythm ),
-            new(Encoding.ASCII.GetBytes("Drums]"),        NoteTracks_Chart.Drums ),
-            new(Encoding.ASCII.GetBytes("Keyboard]"),     NoteTracks_Chart.Keys ),
-            new(Encoding.ASCII.GetBytes("GHLGuitar]"),    NoteTracks_Chart.GHLGuitar ),
-            new(Encoding.ASCII.GetBytes("GHLBass]"),      NoteTracks_Chart.GHLBass ),
-            new(Encoding.ASCII.GetBytes("GHLRhythm]"),    NoteTracks_Chart.GHLGuitar ),
-            new(Encoding.ASCII.GetBytes("GHLCoop]"),      NoteTracks_Chart.GHLBass ),
-        };
-
-        private static readonly DotChartEventCombo<byte>[] _EVENTS_SYNC = { _TEMPO, _TIMESIG, _ANCHOR };
-        private static readonly DotChartEventCombo<byte>[] _EVENTS_EVENTS = { _TEXT, };
-        private static readonly DotChartEventCombo<byte>[] _EVENTS_DIFF = { _NOTE, _SPECIAL, _TEXT, };
-
-        public ReadOnlySpan<byte> HEADERTRACK => _HEADERTRACK;
-        public ReadOnlySpan<byte> SYNCTRACK => _SYNCTRACK;
-        public ReadOnlySpan<byte> EVENTTRACK => _EVENTTRACK;
-        public DotChartEventCombo<byte> TEMPO => _TEMPO;
-        public DotChartEventCombo<byte> TIMESIG => _TIMESIG;
-        public DotChartEventCombo<byte> ANCHOR => _ANCHOR;
-        public DotChartEventCombo<byte> TEXT => _TEXT;
-        public DotChartEventCombo<byte> NOTE => _NOTE;
-        public DotChartEventCombo<byte> SPECIAL => _SPECIAL;
-
-        public (byte[], Difficulty)[] DIFFICULTIES => _DIFFICULTIES;
-        public (byte[], NoteTracks_Chart)[] NOTETRACKS => _NOTETRACKS;
-        public DotChartEventCombo<byte>[] EVENTS_SYNC => _EVENTS_SYNC;
-        public DotChartEventCombo<byte>[] EVENTS_EVENTS => _EVENTS_EVENTS;
-        public DotChartEventCombo<byte>[] EVENTS_DIFF => _EVENTS_DIFF;
-    }
-
-    public readonly struct DotChartChar : IDotChartBases<char>
-    {
-        private static readonly string _HEADERTRACK = "[Song]";
-        private static readonly string _SYNCTRACK = "[SyncTrack]";
-        private static readonly string _EVENTTRACK = "[Events]";
-        private static readonly DotChartEventCombo<char> _TEMPO = new("B", ChartEventType.Bpm);
-        private static readonly DotChartEventCombo<char> _TIMESIG = new("TS", ChartEventType.Time_Sig);
-        private static readonly DotChartEventCombo<char> _ANCHOR = new("A", ChartEventType.Anchor);
-        private static readonly DotChartEventCombo<char> _TEXT = new("E", ChartEventType.Text);
-        private static readonly DotChartEventCombo<char> _NOTE = new("N", ChartEventType.Note);
-        private static readonly DotChartEventCombo<char> _SPECIAL = new("S", ChartEventType.Special);
-
-        private static readonly (char[] name, Difficulty difficulty)[] _DIFFICULTIES =
-        {
-            ("[Easy".ToCharArray(),   Difficulty.Easy),
-            ("[Medium".ToCharArray(), Difficulty.Medium),
-            ("[Hard".ToCharArray(),   Difficulty.Hard),
-            ("[Expert".ToCharArray(), Difficulty.Expert),
-        };
-
-        private static readonly (char[], NoteTracks_Chart)[] _NOTETRACKS =
-        {
-            new("Single]".ToCharArray(),       NoteTracks_Chart.Single ),
-            new("DoubleGuitar]".ToCharArray(), NoteTracks_Chart.DoubleGuitar ),
-            new("DoubleBass]".ToCharArray(),   NoteTracks_Chart.DoubleBass ),
-            new("DoubleRhythm]".ToCharArray(), NoteTracks_Chart.DoubleRhythm ),
-            new("Drums]".ToCharArray(),        NoteTracks_Chart.Drums ),
-            new("Keyboard]".ToCharArray(),     NoteTracks_Chart.Keys ),
-            new("GHLGuitar]".ToCharArray(),    NoteTracks_Chart.GHLGuitar ),
-            new("GHLBass]".ToCharArray(),      NoteTracks_Chart.GHLBass ),
-            new("GHLRhythm]".ToCharArray(),    NoteTracks_Chart.GHLGuitar ),
-            new("GHLCoop]".ToCharArray(),      NoteTracks_Chart.GHLBass ),
-        };
-
-        private static readonly DotChartEventCombo<char>[] _EVENTS_SYNC = { _TEMPO, _TIMESIG, _ANCHOR };
-        private static readonly DotChartEventCombo<char>[] _EVENTS_EVENTS = { _TEXT, };
-        private static readonly DotChartEventCombo<char>[] _EVENTS_DIFF = { _NOTE, _SPECIAL, _TEXT, };
-
-        public ReadOnlySpan<char> HEADERTRACK => _HEADERTRACK;
-        public ReadOnlySpan<char> SYNCTRACK => _SYNCTRACK;
-        public ReadOnlySpan<char> EVENTTRACK => _EVENTTRACK;
-        public DotChartEventCombo<char> TEMPO => _TEMPO;
-        public DotChartEventCombo<char> TIMESIG => _TIMESIG;
-        public DotChartEventCombo<char> ANCHOR => _ANCHOR;
-        public DotChartEventCombo<char> TEXT => _TEXT;
-        public DotChartEventCombo<char> NOTE => _NOTE;
-        public DotChartEventCombo<char> SPECIAL => _SPECIAL;
-        public (char[], Difficulty)[] DIFFICULTIES => _DIFFICULTIES;
-        public (char[], NoteTracks_Chart)[] NOTETRACKS => _NOTETRACKS;
-        public DotChartEventCombo<char>[] EVENTS_SYNC => _EVENTS_SYNC;
-        public DotChartEventCombo<char>[] EVENTS_EVENTS => _EVENTS_EVENTS;
-        public DotChartEventCombo<char>[] EVENTS_DIFF => _EVENTS_DIFF;
-    }
-
-    public sealed class YARGChartFileReader<TChar, TDecoder, TBase>
-        where TChar : unmanaged, IEquatable<TChar>, IConvertible
-        where TDecoder : IStringDecoder<TChar>, new()
-        where TBase : unmanaged, IDotChartBases<TChar>
-    {
-        private static readonly TBase CONFIG = default;
-        private readonly YARGTextReader<TChar, TDecoder> reader;
-
-        private DotChartEventCombo<TChar>[] eventSet = Array.Empty<DotChartEventCombo<TChar>>();
-        private NoteTracks_Chart _instrument;
-        private Difficulty _difficulty;
-
-        public NoteTracks_Chart Instrument => _instrument;
-        public Difficulty Difficulty => _difficulty;
-
-        public YARGChartFileReader(YARGTextReader<TChar, TDecoder> reader)
-        {
-            this.reader = reader;
-        }
-
-        public bool IsStartOfTrack()
-        {
-            return !reader.Container.IsEndOfFile() && reader.Container.IsCurrentCharacter('[');
-        }
-
-        public bool ValidateHeaderTrack()
-        {
-            return ValidateTrack(CONFIG.HEADERTRACK);
-        }
-
-        public bool ValidateSyncTrack()
-        {
-            if (!ValidateTrack(CONFIG.SYNCTRACK))
-                return false;
-
-            eventSet = CONFIG.EVENTS_SYNC;
-            return true;
-        }
-
-        public bool ValidateEventsTrack()
-        {
-            if (!ValidateTrack(CONFIG.EVENTTRACK))
-                return false;
-
-            eventSet = CONFIG.EVENTS_EVENTS;
-            return true;
-        }
-
-        public bool ValidateDifficulty()
-        {
-            for (int diff = 3; diff >= 0; --diff)
-            {
-                var (name, difficulty) = CONFIG.DIFFICULTIES[diff];
-                if (DoesStringMatch(name))
+                foreach (var (name, inst) in YARGChartFileReader.NOTETRACKS)
                 {
-                    _difficulty = difficulty;
-                    eventSet = CONFIG.EVENTS_DIFF;
-                    reader.Container.Position += name.Length;
-                    return true;
+                    if (ValidateTrack(ref container, name))
+                    {
+                        instrument = inst;
+                        return true;
+                    }
                 }
             }
+            instrument = default;
             return false;
         }
 
-        public bool ValidateInstrument()
+        private static unsafe bool ValidateDifficulty<TChar>(ref YARGTextContainer<TChar> container, out Difficulty difficulty)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
-            foreach (var track in CONFIG.NOTETRACKS)
+            for (int diffIndex = 3; diffIndex >= 0; --diffIndex)
             {
-                if (ValidateTrack(track.Item1))
+                var (name, diff) = YARGChartFileReader.DIFFICULTIES[diffIndex];
+                if (DoesStringMatch(ref container, name))
                 {
-                    _instrument = track.Item2;
+                    difficulty = diff;
+                    container.Position += name.Length;
                     return true;
                 }
             }
+            difficulty = default;
             return false;
         }
 
-        private bool ValidateTrack(ReadOnlySpan<TChar> track)
-        {
-            if (!DoesStringMatch(track))
-                return false;
-
-            reader.GotoNextLine();
-            return true;
-        }
-
-        private bool DoesStringMatch(ReadOnlySpan<TChar> str)
+        private static unsafe bool DoesStringMatch<TChar>(ref YARGTextContainer<TChar> container, string str)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             int index = 0;
+            var position = container.Position;
             while (index < str.Length
-                && reader.Container.Position + index < reader.Container.Length
-                && reader.Container.Data[reader.Container.Position + index].Equals(str[index]))
+                && position < container.End
+                && position->ToChar(null) == str[index])
             {
                 ++index;
+                ++position;
             }
             return index == str.Length;
         }
 
-        public bool IsStillCurrentTrack()
+        public static bool IsStillCurrentTrack<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
-            if (reader.Container.Position == reader.Container.Length)
-                return false;
-
-            if (reader.Container.IsCurrentCharacter('}'))
+            YARGTextReader.GotoNextLine(ref container);
+            if (container.IsAtEnd())
             {
-                reader.GotoNextLine();
                 return false;
             }
 
+            if (container.IsCurrentCharacter('}'))
+            {
+                YARGTextReader.GotoNextLine(ref container);
+                return false;
+            }
             return true;
         }
 
-        public bool TryParseEvent(ref DotChartEvent ev)
+        public static unsafe bool TryParseEvent<TChar>(ref YARGTextContainer<TChar> container, ref DotChartEvent ev)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
-            if (!IsStillCurrentTrack())
-                return false;
-
-            ev.Position = reader.ExtractInt64();
-
-            var curr = reader.Container.Position;
-            while (curr < reader.Container.Length)
+            if (!IsStillCurrentTrack(ref container))
             {
-                int c = reader.Container.Data[curr].ToChar(null) | CharacterExtensions.ASCII_LOWERCASE_FLAG;
+                return false;
+            }
+
+            if (!container.TryExtractInt64(out long position))
+            {
+                throw new Exception("Could not parse event position");
+            }
+
+            if (position < ev.Position)
+            {
+                throw new Exception($".chart position out of order (previous: {ev.Position})");
+            }
+            ev.Position = position;
+            YARGTextReader.SkipWhitespaceAndEquals(ref container);
+
+            var curr = container.Position;
+            while (curr < container.End)
+            {
+                int c = curr->ToChar(null) | CharacterExtensions.ASCII_LOWERCASE_FLAG;
                 if (c < 'a' || 'z' < c)
                 {
                     break;
@@ -339,63 +191,47 @@ namespace YARG.Core.IO
                 ++curr;
             }
 
-            unsafe
+            var span = new ReadOnlySpan<TChar>(container.Position, (int) (curr - container.Position));
+            container.Position = curr;
+            ev.Type = ChartEventType.Unknown;
+            foreach (var combo in EVENTS)
             {
-                var span = new ReadOnlySpan<TChar>(reader.Container.Data.Ptr + reader.Container.Position, (int)(curr - reader.Container.Position));
-                reader.Container.Position = curr;
-                foreach (var combo in eventSet)
+                if (span.Length != combo.Descriptor.Length)
                 {
-                    if (combo.DoesEventMatch(span))
-                    {
-                        reader.SkipWhitespace();
-                        ev.Type = combo.eventType;
-                        return true;
-                    }
+                    continue;
+                }
+
+                int index = 0;
+                while (index < span.Length && span[index].ToChar(null) == combo.Descriptor[index])
+                {
+                    ++index;
+                }
+
+                if (index == span.Length)
+                {
+                    YARGTextReader.SkipWhitespace(ref container);
+                    ev.Type = combo.Type;
+                    break;
                 }
             }
-
-            ev.Type = ChartEventType.Unknown;
             return true;
         }
 
-        public void SkipEvent()
-        {
-            reader.GotoNextLine();
-        }
-
-        public void NextEvent()
-        {
-            reader.GotoNextLine();
-        }
-
-        public void ExtractLaneAndSustain(ref DotChartNote note)
-        {
-            note.Lane = reader.ExtractInt32();
-            note.Duration = reader.ExtractInt64();
-        }
-
-        public void SkipTrack()
-        {
-            reader.SkipLinesUntil('}');
-            if (!reader.Container.IsEndOfFile())
-                reader.GotoNextLine();
-        }
-
-        public Dictionary<string, List<IniModifier>> ExtractModifiers(Dictionary<string, IniModifierCreator> validNodes)
+        public unsafe static Dictionary<string, List<IniModifier>> ExtractModifiers<TChar>(ref YARGTextContainer<TChar> container, in delegate*<TChar*, long, string> decoder, Dictionary<string, IniModifierCreator> validNodes)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             Dictionary<string, List<IniModifier>> modifiers = new();
-            while (IsStillCurrentTrack())
+            while (IsStillCurrentTrack(ref container))
             {
-                string name = reader.ExtractModifierName();
+                string name = YARGTextReader.ExtractModifierName(ref container, decoder);
                 if (validNodes.TryGetValue(name, out var node))
                 {
-                    var mod = node.CreateModifier(reader);
+                    var mod = node.CreateModifier(ref container, decoder);
                     if (modifiers.TryGetValue(node.outputName, out var list))
                         list.Add(mod);
                     else
                         modifiers.Add(node.outputName, new() { mod });
                 }
-                reader.GotoNextLine();
             }
             return modifiers;
         }

--- a/YARG.Core/IO/YARGDTAReader.cs
+++ b/YARG.Core/IO/YARGDTAReader.cs
@@ -8,58 +8,50 @@ using YARG.Core.Logging;
 
 namespace YARG.Core.IO
 {
-    public sealed class YARGDTAReader
+    public unsafe struct YARGDTAReader
     {
-        public static YARGDTAReader? TryCreate(FixedArray<byte> data)
+        public static bool TryCreate(FixedArray<byte> data, out YARGDTAReader reader)
         {
             if ((data[0] == 0xFF && data[1] == 0xFE) || (data[0] == 0xFE && data[1] == 0xFF))
             {
                 YargLogger.LogError("UTF-16 & UTF-32 are not supported for .dta files");
-                return null;
+                reader = default;
+                return false;
             }
 
-            int position = data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF ? 3 : 0;
-            return new YARGDTAReader(data, position);
+            reader = data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF
+                ? new YARGDTAReader(data, 3, Encoding.UTF8)
+                : new YARGDTAReader(data, 0, YARGTextContainer.Latin1);
+            return true;
         }
 
-        private readonly YARGTextContainer<byte> container;
-        public Encoding encoding;
+        private YARGTextContainer<byte> _container;
+        public Encoding Encoding;
 
-        private YARGDTAReader(FixedArray<byte> data, int position)
+        private YARGDTAReader(FixedArray<byte> data, int position, Encoding encoding)
         {
-            container = new YARGTextContainer<byte>(data, position);
-            encoding = position == 3 ? Encoding.UTF8 : YARGTextContainer.Latin1;
+            _container = new YARGTextContainer<byte>(data, position);
+            Encoding = encoding;
             SkipWhitespace();
-        }
-
-        public YARGDTAReader Clone()
-        {
-            return new YARGDTAReader(this);
-        }
-
-        private YARGDTAReader(YARGDTAReader reader)
-        {
-            container = new(reader.container);
-            encoding = reader.encoding;
         }
 
         public char SkipWhitespace()
         {
-            while (container.Position < container.Length)
+            while (_container.Position < _container.End)
             {
-                char ch = (char) container.Data[container.Position];
+                char ch = (char) *_container.Position;
                 if (ch > 32 && ch != ';')
                 {
                     return ch;
                 }
 
-                ++container.Position;
+                ++_container.Position;
                 if (ch > 32)
                 {
                     // In comment
-                    while (container.Position < container.Length)
+                    while (_container.Position < _container.End)
                     {
-                        if (container.Data[container.Position++] == '\n')
+                        if (*_container.Position++ == '\n')
                         {
                             break;
                         }
@@ -69,9 +61,9 @@ namespace YARG.Core.IO
             return (char) 0;
         }
 
-        public string GetNameOfNode(bool allowNonAlphetical)
+        public unsafe string GetNameOfNode(bool allowNonAlphetical)
         {
-            char ch = (char)container.Data[container.Position];
+            char ch = (char) _container.CurrentValue;
             if (ch == '(')
             {
                 return string.Empty;
@@ -80,16 +72,12 @@ namespace YARG.Core.IO
             bool hasApostrophe = ch == '\'';
             if (hasApostrophe)
             {
-                ++container.Position;
-                if (container.Position >= container.Length)
-                {
-                    throw new EndOfStreamException();
-                }
-                ch = (char) container.Data[container.Position];
+                ++_container.Position;
+                ch = (char) _container.CurrentValue;
             }
 
-            long start = container.Position;
-            long end = container.Position;
+            var start = _container.Position;
+            var end = _container.Position;
             while (true)
             {
                 if (ch == '\'')
@@ -98,7 +86,7 @@ namespace YARG.Core.IO
                     {
                         throw new Exception("Invalid name format");
                     }
-                    container.Position = end + 1;
+                    _container.Position = end + 1;
                     break;
                 }
 
@@ -108,23 +96,27 @@ namespace YARG.Core.IO
                     {
                         throw new Exception("Invalid name format");
                     }
-                    container.Position = end + 1;
+                    _container.Position = end + 1;
                     break;
                 }
 
                 if (!allowNonAlphetical && !ch.IsAsciiLetter() && ch != '_')
                 {
-                    container.Position = end;
+                    _container.Position = end;
                     break;
                 }
-                ch = (char) container.Data[++end];
+                
+                ++end;
+                if (end >= _container.End)
+                {
+                    _container.Position = end;
+                    break;
+                }
+                ch = (char) *end;
             }
 
             SkipWhitespace();
-            unsafe
-            {
-                return Encoding.UTF8.GetString(container.Data.Ptr + start,(int)(end - start));
-            }
+            return Encoding.UTF8.GetString(start, (int) (end - start));
         }
 
         private enum TextScopeState
@@ -135,33 +127,24 @@ namespace YARG.Core.IO
             Apostrophes
         }
 
-        public string ExtractText()
+        public unsafe string ExtractText()
         {
-            if (container.Position >= container.Length)
-            {
-                throw new EndOfStreamException();
-            }
-
-            char ch = (char)container.Data[container.Position];
+            char ch = (char) _container.CurrentValue;
             var state = ch switch
             {
-                '{'  => TextScopeState.Squirlies,
+                '{' => TextScopeState.Squirlies,
                 '\"' => TextScopeState.Quotes,
                 '\'' => TextScopeState.Apostrophes,
-                _    => TextScopeState.None
+                _ => TextScopeState.None
             };
 
             if (state != TextScopeState.None)
             {
-                ++container.Position;
-                if (container.Position >= container.Length)
-                {
-                    throw new EndOfStreamException();
-                }
-                ch = (char) container.Data[container.Position];
+                ++_container.Position;
+                ch = (char) _container.CurrentValue;
             }
 
-            var start = container.Position;
+            var start = _container.Position;
             // Loop til the end of the text is found
             while (true)
             {
@@ -195,32 +178,25 @@ namespace YARG.Core.IO
                     if (state == TextScopeState.Apostrophes)
                         throw new Exception("Text error - no whitespace allowed");
                 }
-                ++container.Position;
-                if (container.Position >= container.Length)
-                {
-                    throw new EndOfStreamException();
-                }
-                ch = (char) container.Data[container.Position];
+                ++_container.Position;
+                ch = (char) _container.CurrentValue;
             }
 
-            unsafe
+            string txt = Encoding.GetString(start, (int) (_container.Position - start)).Replace("\\q", "\"");
+            if (ch != ')')
             {
-                string txt = encoding.GetString(container.Data.Ptr + start, (int)(container.Position - start)).Replace("\\q", "\"");
-                if (ch != ')')
-                {
-                    ++container.Position;
+                ++_container.Position;
 
-                }
-                SkipWhitespace();
-                return txt;
             }
+            SkipWhitespace();
+            return txt;
         }
 
         public int[] ExtractArray_Int()
         {
             bool doEnd = StartNode();
             List<int> values = new();
-            while (container.Data[container.Position] != ')')
+            while (_container.CurrentValue != ')')
             {
                 values.Add(ExtractInt32());
             }
@@ -236,7 +212,7 @@ namespace YARG.Core.IO
         {
             bool doEnd = StartNode();
             List<float> values = new();
-            while (container.Data[container.Position] != ')')
+            while (_container.CurrentValue != ')')
             {
                 values.Add(ExtractFloat());
             }
@@ -252,7 +228,7 @@ namespace YARG.Core.IO
         {
             bool doEnd = StartNode();
             List<string> strings = new();
-            while (container.Data[container.Position] != ')')
+            while (_container.CurrentValue != ')')
             {
                 strings.Add(ExtractText());
             }
@@ -266,12 +242,12 @@ namespace YARG.Core.IO
 
         public bool StartNode()
         {
-            if (container.Position >= container.Length || container.Data[container.Position] != '(')
+            if (_container.Position >= _container.End || !_container.IsCurrentCharacter('('))
             {
                 return false;
             }
 
-            ++container.Position;
+            ++_container.Position;
             SkipWhitespace();
             return true;
         }
@@ -282,10 +258,10 @@ namespace YARG.Core.IO
             bool inApostropes = false;
             bool inQuotes = false;
             bool inComment = false;
-            while (container.Position < container.Length && scopeLevel >= 0)
+            while (_container.Position < _container.End && scopeLevel >= 0)
             {
-                char curr = (char) container.Data[container.Position];
-                ++container.Position;
+                char curr = (char) *_container.Position;
+                ++_container.Position;
                 if (inComment)
                 {
                     if (curr == '\n')
@@ -322,83 +298,158 @@ namespace YARG.Core.IO
             SkipWhitespace();
         }
 
+        /// <summary>
+        /// Extracts a boolean and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The boolean or `false` on failed extraction</returns>
         public bool ExtractBoolean()
         {
-            bool result = container.ExtractBoolean();
+            bool result = _container.ExtractBoolean();
             SkipWhitespace();
             return result;
         }
-
+        
+        /// <summary>
+        /// Extracts a boolean and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The boolean or `true` on failed extraction</returns>
         public bool ExtractBoolean_FlippedDefault()
         {
-            bool result = container.Position >= container.Length || (char)container.Data[container.Position] switch
+            bool result = _container.Position >= _container.End || (char)*_container.Position switch
             {
                 '0' => false,
                 '1' => true,
-                _ => container.Position + 5 > container.Length ||
-                    char.ToLowerInvariant((char)container.Data[container.Position]    ) != 'f' ||
-                    char.ToLowerInvariant((char)container.Data[container.Position + 1]) != 'a' ||
-                    char.ToLowerInvariant((char)container.Data[container.Position + 2]) != 'l' ||
-                    char.ToLowerInvariant((char)container.Data[container.Position + 3]) != 's' ||
-                    char.ToLowerInvariant((char)container.Data[container.Position + 4]) != 'e',
+                _ => _container.Position + 5 > _container.End ||
+                    char.ToLowerInvariant((char)_container.Position[0]) != 'f' ||
+                    char.ToLowerInvariant((char)_container.Position[1]) != 'a' ||
+                    char.ToLowerInvariant((char)_container.Position[2]) != 'l' ||
+                    char.ToLowerInvariant((char)_container.Position[3]) != 's' ||
+                    char.ToLowerInvariant((char)_container.Position[4]) != 'e',
             };
             SkipWhitespace();
             return result;
         }
 
+        /// <summary>
+        /// Extracts a short and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The short</returns>
         public short ExtractInt16()
         {
-            short result = container.ExtractInt16();
+            if (!_container.TryExtractInt16(out short value))
+            {
+                throw new Exception("Data for Int16 not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
 
+        /// <summary>
+        /// Extracts a ushort and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The ushort</returns>
         public ushort ExtractUInt16()
         {
-            ushort result = container.ExtractUInt16();
+            if (!_container.TryExtractUInt16(out ushort value))
+            {
+                throw new Exception("Data for UInt16 not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
 
+        /// <summary>
+        /// Extracts a int and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The int</returns>
         public int ExtractInt32()
         {
-            int result = container.ExtractInt32();
+            if (!_container.TryExtractInt32(out int value))
+            {
+                throw new Exception("Data for Int32 not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
+
+        /// <summary>
+        /// Extracts a uint and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The uint</returns>
         public uint ExtractUInt32()
         {
-            uint result = container.ExtractUInt32();
+            if (!_container.TryExtractUInt32(out uint value))
+            {
+                throw new Exception("Data for UInt32 not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
 
+        /// <summary>
+        /// Extracts a long and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The long</returns>
         public long ExtractInt64()
         {
-            long result = container.ExtractInt64();
+            if (!_container.TryExtractInt64(out long value))
+            {
+                throw new Exception("Data for Int64 not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
 
+        /// <summary>
+        /// Extracts a ulong and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The ulong</returns>
         public ulong ExtractUInt64()
         {
-            ulong result = container.ExtractUInt64();
+            if (!_container.TryExtractUInt64(out ulong value))
+            {
+                throw new Exception("Data for UInt64 not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
 
+        /// <summary>
+        /// Extracts a float and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The float</returns>
         public float ExtractFloat()
         {
-            float result = container.ExtractFloat();
+            if (!_container.TryExtractFloat(out float value))
+            {
+                throw new Exception("Data for float not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
 
+        /// <summary>
+        /// Extracts a double and skips the following whitespace
+        /// </summary>
+        /// <remarks>Throws if no value could be parsed</remarks>
+        /// <returns>The double</returns>
         public double ExtractDouble()
         {
-            double result = container.ExtractDouble();
+            if (!_container.TryExtractDouble(out double value))
+            {
+                throw new Exception("Data for double not present");
+            }
             SkipWhitespace();
-            return result;
+            return value;
         }
     };
 }

--- a/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/ConGroup.cs
@@ -20,7 +20,7 @@ namespace YARG.Core.Song.Cache
             DefaultPlaylist = defaultPlaylist;
         }
 
-        public abstract void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings);
+        public abstract void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings);
         public abstract byte[] SerializeEntries(Dictionary<SongEntry, CategoryCacheWriteNode> nodes);
 
         public void AddEntry(string name, int index, RBCONEntry entry)

--- a/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/PackedCONGroup.cs
@@ -32,7 +32,7 @@ namespace YARG.Core.Song.Cache
             conFile.TryGetListing(SONGSFILEPATH, out SongDTA);
         }
 
-        public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
+        public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
         {
             var song = PackedRBCONEntry.TryLoadFromCache(in ConFile, nodeName, upgrades, reader, strings);
             if (song != null)
@@ -54,43 +54,47 @@ namespace YARG.Core.Song.Cache
 
         public void AddUpgrade(string name, IRBProUpgrade upgrade) { lock (Upgrades) Upgrades[name] = upgrade; }
 
-        public YARGDTAReader? LoadUpgrades()
+        public bool LoadUpgrades(out YARGDTAReader reader)
         {
             if (UpgradeDta == null)
             {
-                return null;
+                reader = default;
+                return false;
             }
 
             try
             {
                 Stream = new FileStream(Info.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
                 _upgradeDTAData = UpgradeDta.LoadAllBytes(Stream);
-                return YARGDTAReader.TryCreate(_upgradeDTAData);
+                return YARGDTAReader.TryCreate(_upgradeDTAData, out reader);
             }
             catch (Exception ex)
             {
                 YargLogger.LogException(ex, $"Error while loading {UpgradeDta.Filename}");
-                return null;
+                reader = default;
+                return false;
             }
         }
 
-        public YARGDTAReader? LoadSongs()
+        public bool LoadSongs(out YARGDTAReader reader)
         {
             if (SongDTA == null)
             {
-                return null;
+                reader = default;
+                return false;
             }
 
             try
             {
                 Stream ??= new FileStream(Info.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
                 _songDTAData = SongDTA.LoadAllBytes(Stream);
-                return YARGDTAReader.TryCreate(_songDTAData);
+                return YARGDTAReader.TryCreate(_songDTAData, out reader);
             }
             catch (Exception ex)
             {
                 YargLogger.LogException(ex, $"Error while loading {SongDTA.Filename}");
-                return null;
+                reader = default;
+                return false;
             }
         }
 

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedCONGroup.cs
@@ -18,21 +18,22 @@ namespace YARG.Core.Song.Cache
             DTA = new AbridgedFileInfo_Length(dta);
         }
 
-        public YARGDTAReader? LoadDTA()
+        public bool LoadDTA(out YARGDTAReader reader)
         {
             try
             {
                 _fileData = MemoryMappedArray.Load(DTA);
-                return YARGDTAReader.TryCreate(_fileData);
+                return YARGDTAReader.TryCreate(_fileData, out reader);
             }
             catch (Exception ex)
             {
                 YargLogger.LogException(ex, $"Error while loading {DTA.FullName}");
-                return null;
+                reader = default;
+                return false;
             }
         }
 
-        public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
+        public override void ReadEntry(string nodeName, int index, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
         {
             var song = UnpackedRBCONEntry.TryLoadFromCache(Location, DTA, nodeName, upgrades, reader, strings);
             if (song != null)

--- a/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UpdateGroup.cs
@@ -54,32 +54,19 @@ namespace YARG.Core.Song.Cache
     public sealed class SongUpdate : IComparable<SongUpdate>
     {
         private readonly DateTime _dtaLastWrite;
-        private readonly YARGDTAReader[] _readers;
 
         public readonly string BaseDirectory;
         public readonly AbridgedFileInfo_Length? Midi;
         public readonly AbridgedFileInfo? Mogg;
         public readonly AbridgedFileInfo_Length? Milo;
         public readonly AbridgedFileInfo_Length? Image;
-
-        public YARGDTAReader[] Readers
-        {
-            get
-            {
-                var readers = new YARGDTAReader[_readers.Length];
-                for (int i = 0; i < readers.Length; i++)
-                {
-                    readers[i] = _readers[i].Clone();
-                }
-                return readers;
-            }
-        }
+        public readonly YARGDTAReader[] Readers;
 
         public SongUpdate(UpdateGroup group, string name, DateTime dtaLastWrite, YARGDTAReader[] readers)
         {
             BaseDirectory = group.Directory.FullName;
+            Readers = readers;
             _dtaLastWrite = dtaLastWrite;
-            _readers = readers;
 
             string subname = name.ToLowerInvariant();
             if (group.SubDirectories.TryGetValue(subname, out var subDirectory))

--- a/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.Serialization.cs
@@ -368,7 +368,7 @@ namespace YARG.Core.Song.Cache
                 string filename = Path.Combine(directory, $"{name}_plus.mid");
 
                 var info = new AbridgedFileInfo_Length(filename, reader);
-                AddUpgrade(name, null, new UnpackedRBProUpgrade(info));
+                AddUpgrade(name, default, new UnpackedRBProUpgrade(info));
             }
         }
 
@@ -392,7 +392,7 @@ namespace YARG.Core.Song.Cache
                 group?.ConFile.TryGetListing($"songs_upgrades/{name}_plus.mid", out listing);
 
                 var upgrade = new PackedRBProUpgrade(listing, lastWrite);
-                AddUpgrade(name, null, upgrade);
+                AddUpgrade(name, default, upgrade);
             }
         }
 

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
@@ -23,7 +23,7 @@ namespace YARG.Core.Song
         public override string Directory { get; } = string.Empty;
         public override EntryType SubType => EntryType.CON;
 
-        public static (ScanResult, PackedRBCONEntry?) ProcessNewEntry(PackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        public static (ScanResult, PackedRBCONEntry?) ProcessNewEntry(PackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades)
         {
             try
             {
@@ -48,7 +48,7 @@ namespace YARG.Core.Song
             }
         }
 
-        public static PackedRBCONEntry? TryLoadFromCache(in CONFile conFile, string nodename, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
+        public static PackedRBCONEntry? TryLoadFromCache(in CONFile conFile, string nodename, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
         {
             var psuedoDirectory = reader.ReadString();
 
@@ -87,7 +87,7 @@ namespace YARG.Core.Song
             return new PackedRBCONEntry(midiListing, lastMidiWrite, moggListing, miloListing, imgListing, psuedoDirectory, updateMidi, upgrade, reader, strings);
         }
 
-        public static PackedRBCONEntry LoadFromCache_Quick(in CONFile conFile, string nodename, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
+        public static PackedRBCONEntry LoadFromCache_Quick(in CONFile conFile, string nodename, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
         {
             var psuedoDirectory = reader.ReadString();
 
@@ -109,7 +109,7 @@ namespace YARG.Core.Song
             return new PackedRBCONEntry(midiListing, lastMidiWrite, moggListing, miloListing, imgListing, psuedoDirectory, updateMidi, upgrade, reader, strings);
         }
 
-        private PackedRBCONEntry(PackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        private PackedRBCONEntry(PackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades)
             : base()
         {
             var results = Init(nodename, reader, updates, upgrades, group.DefaultPlaylist);

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -309,7 +309,7 @@ namespace YARG.Core.Song
             }
         }
 
-        protected DTAResult Init(string nodeName, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, string defaultPlaylist)
+        protected DTAResult Init(string nodeName, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, string defaultPlaylist)
         {
             var dtaResults = ParseDTA(nodeName, reader);
             ApplyRBCONUpdates(ref dtaResults, nodeName, updates);
@@ -485,13 +485,13 @@ namespace YARG.Core.Song
             }
         }
 
-        private void ApplyRBProUpgrade(string nodeName, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        private void ApplyRBProUpgrade(string nodeName, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades)
         {
             if (upgrades.TryGetValue(nodeName, out var upgrade))
             {
                 try
                 {
-                    ParseDTA(nodeName, upgrade.Item1!.Clone());
+                    ParseDTA(nodeName, upgrade.Item1);
                     _upgrade = upgrade.Item2;
                 }
                 catch (Exception ex)
@@ -504,8 +504,9 @@ namespace YARG.Core.Song
         private DTAResult ParseDTA(string nodeName, params YARGDTAReader[] readers)
         {
             DTAResult result = default;
-            foreach (var reader in readers)
+            for (int i = 0; i < readers.Length; ++i)
             {
+                var reader = readers[i];
                 while (reader.StartNode())
                 {
                     string name = reader.GetNameOfNode(false);
@@ -603,14 +604,14 @@ namespace YARG.Core.Song
                                 "latin1" => YARGTextContainer.Latin1,
                                 "utf-8" or
                                 "utf8" => Encoding.UTF8,
-                                _ => reader.encoding
+                                _ => reader.Encoding
                             };
 
-                            if (reader.encoding != encoding)
+                            if (reader.Encoding != encoding)
                             {
                                 string Convert(string str)
                                 {
-                                    byte[] bytes = reader.encoding.GetBytes(str);
+                                    byte[] bytes = reader.Encoding.GetBytes(str);
                                     return encoding.GetString(bytes);
                                 }
 
@@ -634,7 +635,7 @@ namespace YARG.Core.Song
 
                                 if (_metadata.Playlist.Str.Length != 0)
                                     _metadata.Playlist = Convert(_metadata.Playlist);
-                                reader.encoding = encoding;
+                                reader.Encoding = encoding;
                             }
 
                             break;

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
@@ -21,7 +21,7 @@ namespace YARG.Core.Song
         public override string Directory { get; } = string.Empty;
         public override EntryType SubType => EntryType.ExCON;
 
-        public static (ScanResult, UnpackedRBCONEntry?) ProcessNewEntry(UnpackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        public static (ScanResult, UnpackedRBCONEntry?) ProcessNewEntry(UnpackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades)
         {
             try
             {
@@ -45,7 +45,7 @@ namespace YARG.Core.Song
             }
         }
 
-        public static UnpackedRBCONEntry? TryLoadFromCache(string directory, in AbridgedFileInfo_Length dta, string nodename, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
+        public static UnpackedRBCONEntry? TryLoadFromCache(string directory, in AbridgedFileInfo_Length dta, string nodename, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
         {
             string subname = reader.ReadString();
             string songDirectory = Path.Combine(directory, subname);
@@ -71,7 +71,7 @@ namespace YARG.Core.Song
             return new UnpackedRBCONEntry(midiInfo.Value, dta, songDirectory, subname, updateMidi, upgrade, reader, strings);
         }
 
-        public static UnpackedRBCONEntry LoadFromCache_Quick(string directory, in AbridgedFileInfo_Length? dta, string nodename, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
+        public static UnpackedRBCONEntry LoadFromCache_Quick(string directory, in AbridgedFileInfo_Length? dta, string nodename, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades, BinaryReader reader, CategoryCacheStrings strings)
         {
             string subname = reader.ReadString();
             string songDirectory = Path.Combine(directory, subname);
@@ -96,7 +96,7 @@ namespace YARG.Core.Song
             _nodename = nodename;
         }
 
-        private UnpackedRBCONEntry(UnpackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader?, IRBProUpgrade)> upgrades)
+        private UnpackedRBCONEntry(UnpackedCONGroup group, string nodename, YARGDTAReader reader, Dictionary<string, List<SongUpdate>> updates, Dictionary<string, (YARGDTAReader, IRBProUpgrade)> upgrades)
             : base()
         {
             var results = Init(nodename, reader, updates, upgrades, group.DefaultPlaylist);

--- a/YARG.Core/Song/Entries/SongEntry.Scanning.cs
+++ b/YARG.Core/Song/Entries/SongEntry.Scanning.cs
@@ -60,45 +60,6 @@ namespace YARG.Core.Song
             return true;
         }
 
-        protected static void ParseChart<TChar, TDecoder, TBase>(YARGChartFileReader<TChar, TDecoder, TBase> reader, DrumPreparseHandler drums, ref AvailableParts parts)
-            where TChar : unmanaged, IEquatable<TChar>, IConvertible
-            where TDecoder : IStringDecoder<TChar>, new()
-            where TBase : unmanaged, IDotChartBases<TChar>
-        {
-            while (reader.IsStartOfTrack())
-            {
-                if (!reader.ValidateDifficulty() || !reader.ValidateInstrument())
-                    reader.SkipTrack();
-                else if (reader.Instrument != NoteTracks_Chart.Drums)
-                    ParseChartTrack(reader, ref parts);
-                else
-                    drums.ParseChart(reader);
-            }
-        }
-
-        private static void ParseChartTrack<TChar, TDecoder, TBase>(YARGChartFileReader<TChar, TDecoder, TBase> reader, ref AvailableParts parts)
-            where TChar : unmanaged, IEquatable<TChar>, IConvertible
-            where TDecoder : IStringDecoder<TChar>, new()
-            where TBase : unmanaged, IDotChartBases<TChar>
-        {
-            bool skip = reader.Instrument switch
-            {
-                NoteTracks_Chart.Single =>       ChartPreparser.Preparse(reader, ref parts.FiveFretGuitar,     ChartPreparser.ValidateFiveFret),
-                NoteTracks_Chart.DoubleBass =>   ChartPreparser.Preparse(reader, ref parts.FiveFretBass,       ChartPreparser.ValidateFiveFret),
-                NoteTracks_Chart.DoubleRhythm => ChartPreparser.Preparse(reader, ref parts.FiveFretRhythm,     ChartPreparser.ValidateFiveFret),
-                NoteTracks_Chart.DoubleGuitar => ChartPreparser.Preparse(reader, ref parts.FiveFretCoopGuitar, ChartPreparser.ValidateFiveFret),
-                NoteTracks_Chart.GHLGuitar =>    ChartPreparser.Preparse(reader, ref parts.SixFretGuitar,      ChartPreparser.ValidateSixFret),
-                NoteTracks_Chart.GHLBass =>      ChartPreparser.Preparse(reader, ref parts.SixFretBass,        ChartPreparser.ValidateSixFret),
-                NoteTracks_Chart.GHLRhythm =>    ChartPreparser.Preparse(reader, ref parts.SixFretRhythm,      ChartPreparser.ValidateSixFret),
-                NoteTracks_Chart.GHLCoop =>      ChartPreparser.Preparse(reader, ref parts.SixFretCoopGuitar,  ChartPreparser.ValidateSixFret),
-                NoteTracks_Chart.Keys =>         ChartPreparser.Preparse(reader, ref parts.Keys,               ChartPreparser.ValidateFiveFret),
-                _ => true,
-            };
-
-            if (skip)
-                reader.SkipTrack();
-        }
-
         protected static void SetDrums(ref AvailableParts parts, DrumPreparseHandler drumTracker)
         {
             if (drumTracker.Type == DrumsType.FiveLane)

--- a/YARG.Core/Song/Preparsers/Chart/ChartPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Chart/ChartPreparser.cs
@@ -1,36 +1,29 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text.RegularExpressions;
 using YARG.Core.IO;
 
 namespace YARG.Core.Song
 {
     public static class ChartPreparser
     {
-        public static bool Preparse<TChar, TDecoder, TBase>(YARGChartFileReader<TChar, TDecoder, TBase> reader, ref PartValues scan, Func<int, bool> func)
+        public static bool Preparse<TChar>(ref YARGTextContainer<TChar> container, Difficulty difficulty, ref PartValues scan, Func<int, bool> func)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
-            where TDecoder : IStringDecoder<TChar>, new()
-            where TBase : unmanaged, IDotChartBases<TChar>
         {
-            var difficulty = reader.Difficulty;
             if (scan[difficulty])
                 return true;
 
             DotChartEvent ev = default;
-            DotChartNote note = default;
-            while (reader.TryParseEvent(ref ev))
+            while (YARGChartFileReader.TryParseEvent(ref container, ref ev))
             {
                 if (ev.Type == ChartEventType.Note)
                 {
-                    reader.ExtractLaneAndSustain(ref note);
-                    if (func(note.Lane))
+                    int lane = YARGTextReader.ExtractInt32(ref container);
+                    long _ = YARGTextReader.ExtractInt64(ref container);
+                    if (func(lane))
                     {
                         scan.SetDifficulty(difficulty);
                         return true;
                     }
                 }
-                reader.NextEvent();
             }
             return false;
         }


### PR DESCRIPTION
This PR takes the place of the old TxtContainer cleanup PR. Main reasoning still remains. We're trying to lessen the workload hoisted onto GC caused by constantly constructing more and more class objects. The old setup relied too much on objects that contained objects that contained objects. Add on top the lack of lifetime control and you get a recipe for out of wack GC that procs multiple times in a scan.

Additionally, if we're going to rely on cloning functionality, using classes goes in complete counter to that. Having the runtime create a whole new object just to copy an instance of data is wasteful - especially when you can achieve the same result through the in-language functionality of `struct`.

While I get why you might have an issue with the increased usage of static functions that take `ref` params, we're at the stage in the scanning code that there's not much else you can do to gain ground. This *is* the next step for optimization in speed and memory control.