### PR TITLE
Whammy Pitch Modulation

### DIFF
--- a/YARG.Core/Audio/GlobalAudioHandler.cs
+++ b/YARG.Core/Audio/GlobalAudioHandler.cs
@@ -107,6 +107,16 @@ namespace YARG.Core.Audio
             StemSettings[stem].Reverb = reverb;
         }
 
+        public static float GetWhammyPitchSetting(SongStem stem)
+        {
+            return StemSettings[stem].WhammyPitch;
+        }
+
+        public static void SetWhammyPitchSetting(SongStem stem, float percent)
+        {
+            StemSettings[stem].WhammyPitch = percent;
+        }
+
         private static object _instanceLock = new();
         private static AudioManager? _instance;
 

--- a/YARG.Core/Audio/GlobalAudioHandler.cs
+++ b/YARG.Core/Audio/GlobalAudioHandler.cs
@@ -13,7 +13,7 @@ namespace YARG.Core.Audio
 
     public static class GlobalAudioHandler
     {
-        public const int WHAMMY_FFT_DEFAULT = 2048;
+        public const int WHAMMY_FFT_DEFAULT = 512;
         public const int WHAMMY_OVERSAMPLE_DEFAULT = 8;
         public static readonly int MAX_THREADS = Environment.ProcessorCount switch
         {

--- a/YARG.Core/Audio/StemChannel.cs
+++ b/YARG.Core/Audio/StemChannel.cs
@@ -21,6 +21,7 @@ namespace YARG.Core.Audio
             var settings = GlobalAudioHandler.StemSettings[Stem];
             settings.OnVolumeChange += SetVolume;
             settings.OnReverbChange += SetReverb;
+            settings.OnWhammyPitchChange += SetWhammyPitch;
         }
 
         public void SetWhammyPitch(float percent)

--- a/YARG.Core/Audio/StemSettings.cs
+++ b/YARG.Core/Audio/StemSettings.cs
@@ -8,8 +8,10 @@ namespace YARG.Core.Audio
 
         private Action<double>? _onVolumeChange;
         private Action<bool>? _onReverbChange;
+        private Action<float>? _onWhammyPitchChange;
         private double _volume;
         private bool _reverb;
+        private float _whammyPitch;
 
         public StemSettings()
         {
@@ -26,6 +28,12 @@ namespace YARG.Core.Audio
         {
             add { _onReverbChange += value; }
             remove { _onReverbChange -= value; }
+        }
+
+        public event Action<float> OnWhammyPitchChange
+        {
+            add { _onWhammyPitchChange += value; }
+            remove { _onWhammyPitchChange -= value; }
         }
 
         public double VolumeSetting
@@ -49,6 +57,20 @@ namespace YARG.Core.Audio
                 {
                     _reverb = value;
                     _onReverbChange?.Invoke(value);
+                }
+            }
+        }
+
+        public float WhammyPitch
+        {
+            get => _whammyPitch;
+            set
+            {
+                value = Math.Clamp(value, 0, 1);
+                if (value != _whammyPitch)
+                {
+                    _whammyPitch = value;
+                    _onWhammyPitchChange?.Invoke(value);
                 }
             }
         }


### PR DESCRIPTION
Added pitch bending whammy support back in. I will submit another PR for YARG front-end consuming these changes and open a discussion in this feature request:

https://github.com/YARC-Official/YARG/issues/786

Here are the changes I implemented to restore this feature:

1. Added WhammyPitch (float) to StemSettings

2. Added OnWhammyPitchChange to StemSettings

3. In StemChannel subscribed to OnWhammyPitchChange at the same location volume change is called

4. In GlobalAudioHandler added Get/SetWhammyPitchSetting 

5. In StemState added SetWhammyPitch.

6. In SettingsManager.Settings uncommented UseWhammyFx setting and UseWhammyFxChange.

7. In SettingsManager.Settings uncommented WhammyPitchShiftAmount setting and WhammyPitchShiftAmountChange.

8. In GameManager.Audio added ChangeStemWhammyPitch

9. In FiveFretPlayer added SetStemWhammyPitch

10. In FiveFretPlayer called SetStemWhammyPitch in override for OnInputQueued when WhammyFactor is updated.

11. In GlobalAudioHandler changed WHAMMY_FFT_DEFAULT to 512 to try and reduce latency between guitar track and other tracks when pitch change is enabled.








