### PR TITLE
Fixed drum parsing ending too early

### DIFF
--- a/YARG.Core/Song/Preparsers/Midi/MidiUnknownDrumPreparser.cs
+++ b/YARG.Core/Song/Preparsers/Midi/MidiUnknownDrumPreparser.cs
@@ -21,7 +21,7 @@ namespace YARG.Core.Song
             return (preparser.validations, preparser.type);
         }
 
-        protected override bool IsFullyScanned() { return validations == ALL_DIFFICULTIES_PLUS && type != DrumsType.FourLane; }
+        protected override bool IsFullyScanned() { return validations == ALL_DIFFICULTIES_PLUS && (type == DrumsType.FiveLane || type == DrumsType.ProDrums); }
         protected override bool IsNote() { return DEFAULT_MIN <= note.value && note.value <= FIVELANE_MAX; }
 
         protected override bool ParseLaneColor_ON(YARGMidiTrack track)


### PR DESCRIPTION
This should fix issue #734 in the YARG repository. While debugging, I found that YARG will stop parsing the chart when it finds all difficulties and would not continue parsing to check for notes that would make it a 5 lane. For GHWT charts, because expert+ did not exist, it would be able to parse the notes that would make the chart a five-lane.