### PR TITLE
Countdown rework core

### DIFF
--- a/YARG.Core/Chart/Events/WaitCountdown.cs
+++ b/YARG.Core/Chart/Events/WaitCountdown.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 
 namespace YARG.Core.Chart
@@ -7,7 +6,7 @@ namespace YARG.Core.Chart
     {
         public const float MIN_SECONDS = 9;
         public const uint MIN_MEASURES = 4;
-        public const float MIN_UPDATE_SECONDS = 1;
+        public const float MIN_MEASURE_LENGTH = 1;
         public const float FADE_ANIM_LENGTH = 0.45f;
         public const int END_COUNTDOWN_MEASURE = 1;
 

--- a/YARG.Core/Chart/Events/WaitCountdown.cs
+++ b/YARG.Core/Chart/Events/WaitCountdown.cs
@@ -20,13 +20,13 @@ namespace YARG.Core.Chart
         {
             _measureBeatlines = measureBeatlines;
 
-            var firstVisibleCountdownMeasure = measureBeatlines[0];
-            var lastVisibleCountdownMeasure = measureBeatlines[^(END_COUNTDOWN_MEASURE + 1)];
+            var firstCountdownMeasure = measureBeatlines[0];
+            var lastCountdownMeasure = measureBeatlines[^1];
 
-            Time = firstVisibleCountdownMeasure.Time;
-            Tick = firstVisibleCountdownMeasure.Tick;
-            TimeLength = lastVisibleCountdownMeasure.Time - Time;
-            TickLength = lastVisibleCountdownMeasure.Tick - Tick;
+            Time = firstCountdownMeasure.Time;
+            Tick = firstCountdownMeasure.Tick;
+            TimeLength = lastCountdownMeasure.Time - Time;
+            TickLength = lastCountdownMeasure.Tick - Tick;
 
             MeasuresLeft = TotalMeasures;
         }

--- a/YARG.Core/Chart/Events/WaitCountdown.cs
+++ b/YARG.Core/Chart/Events/WaitCountdown.cs
@@ -8,9 +8,14 @@ namespace YARG.Core.Chart
         public const float MIN_SECONDS = 9;
         public const uint MIN_MEASURES = 4;
         public const float MIN_UPDATE_SECONDS = 1;
+        public const float FADE_ANIM_LENGTH = 0.45f;
         public const int END_COUNTDOWN_MEASURE = 1;
 
         public int TotalMeasures => _measureBeatlines.Count;
+
+        //The time where the countdown should start fading out and overstrums will break combo again
+        public double DeactivateTime => _measureBeatlines[^(END_COUNTDOWN_MEASURE + 1)].Time;
+        public bool IsActive => MeasuresLeft > END_COUNTDOWN_MEASURE;
 
         private List<Beatline> _measureBeatlines;
 

--- a/YARG.Core/Chart/Events/WaitCountdown.cs
+++ b/YARG.Core/Chart/Events/WaitCountdown.cs
@@ -8,13 +8,9 @@ namespace YARG.Core.Chart
         public const float MIN_SECONDS = 9;
         public const uint MIN_MEASURES = 4;
         public const float MIN_UPDATE_SECONDS = 1;
-        private const float MIN_GET_READY_SECONDS = 2;
-        public const int GET_READY_MEASURE = 2;
         public const int END_COUNTDOWN_MEASURE = 1;
 
         public int TotalMeasures => _measureBeatlines.Count;
-
-        public readonly double GetReadyTime;
 
         private List<Beatline> _measureBeatlines;
 
@@ -31,10 +27,6 @@ namespace YARG.Core.Chart
             Tick = firstVisibleCountdownMeasure.Tick;
             TimeLength = lastVisibleCountdownMeasure.Time - Time;
             TickLength = lastVisibleCountdownMeasure.Tick - Tick;
-
-            double getReadyTotalSeconds = TimeEnd - measureBeatlines[^(GET_READY_MEASURE + 1)].Time;
-
-            GetReadyTime = TimeEnd - Math.Max(getReadyTotalSeconds, MIN_GET_READY_SECONDS);
 
             MeasuresLeft = TotalMeasures;
         }

--- a/YARG.Core/Chart/Events/WaitCountdown.cs
+++ b/YARG.Core/Chart/Events/WaitCountdown.cs
@@ -51,13 +51,5 @@ namespace YARG.Core.Chart
 
             return newMeasuresLeft;
         }
-
-        public double GetNextUpdateTime()
-        {
-            int nextMeasureIndex = TotalMeasures - MeasuresLeft;
-            double nextUpdateTime = _measureBeatlines[nextMeasureIndex].Time;
-
-            return Math.Min(nextUpdateTime, TimeEnd);
-        }
     }
 }

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -663,7 +663,7 @@ namespace YARG.Core.Engine
                     {
                         // Skip counting on measures that are too close together
                         if (beatlinesThisCountdown.Count == 0 || 
-                            curMeasureline.Time - beatlinesThisCountdown.Last().Time >= WaitCountdown.MIN_UPDATE_SECONDS)
+                            curMeasureline.Time - beatlinesThisCountdown.Last().Time >= WaitCountdown.MIN_MEASURE_LENGTH)
                         {
                             beatlinesThisCountdown.Add(curMeasureline);
                         }

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -33,7 +33,7 @@ namespace YARG.Core.Engine
 
         public delegate void StarPowerPhraseMissEvent(TNoteType note);
 
-        public delegate void CountdownChangeEvent(int measuresLeft, float progress);
+        public delegate void CountdownChangeEvent(int measuresLeft, double countdownLength, double endTime);
 
         public NoteHitEvent?    OnNoteHit;
         public NoteMissedEvent? OnNoteMissed;
@@ -252,8 +252,7 @@ namespace YARG.Core.Engine
                             YargLogger.LogFormatDebug("Countdown {0} deactivated at time {1}. Expected time: {2}", State.CurrentWaitCountdownIndex, time, currentCountdown.DeactivateTime);
                         }
 
-                        float progress = (State.CurrentTick - currentCountdown.Tick) / (float) currentCountdown.TickLength;
-                        UpdateCountdown(newMeasuresLeft, Math.Clamp(progress, 0, 1));
+                        UpdateCountdown(newMeasuresLeft, currentCountdown.TimeLength, currentCountdown.TimeEnd);
                     }
                     else
                     {
@@ -485,9 +484,9 @@ namespace YARG.Core.Engine
             State.CurrentSoloIndex++;
         }
 
-        protected void UpdateCountdown(int measuresLeft, float progress)
+        protected void UpdateCountdown(int measuresLeft, double countdownLength, double endTime)
         {
-            OnCountdownChange?.Invoke(measuresLeft, progress);
+            OnCountdownChange?.Invoke(measuresLeft, countdownLength, endTime);
         }
 
         public sealed override (double FrontEnd, double BackEnd) CalculateHitWindow()

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -189,7 +189,7 @@ namespace YARG.Core.Engine
                     }
                     else
                     {
-                        // A countdown is currently onscreen, but is past its deactivation time
+                        // A countdown is currently onscreen, but is past its deactivation time and is fading out
                         // CurrentWaitCountdownIndex will not be incremented until the progress bar no longer needs updating
                         nextCountdownIndex = State.CurrentWaitCountdownIndex + 1;
                     }

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -235,7 +235,7 @@ namespace YARG.Core.Engine
 
                     UpdateCountdown(newMeasuresLeft, Math.Clamp(progress, 0, 1));
 
-                    if (newMeasuresLeft <= WaitCountdown.END_COUNTDOWN_MEASURE)
+                    if (newMeasuresLeft <= 0)
                     {
                         State.IsWaitCountdownActive = false;
                         YargLogger.LogFormatDebug("Countdown {0} deactivated at time {1}. Expected time: {2}", State.CurrentWaitCountdownIndex, time, activeCountdown.TimeEnd);


### PR DESCRIPTION
Removed "Get Ready!" message and added a progress bar like Clone Hero's implementation. Only start and end times are queued, while mid-countdown updates occur during every frame that `BaseEngineState.IsCountdownActive` is set to true.