### PR TITLE
Check for phrases when preparsing vocals; generate a default vocal range shift anyways when no phrases are parsed in

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -200,9 +200,12 @@ namespace YARG.Core.Chart
         {
             var ranges = new List<VocalsRangeShift>();
 
-            // Do nothing if no phrases were parsed in
             if (parts.All((part) => part.NotePhrases.Count < 1))
+            {
+                // No phrases; add a dummy default range
+                ranges.Add(new(48, 72, 0, 0, 0, 0));
                 return ranges;
+            }
 
             double shiftLength = 0;
             uint shiftStartTick = 0;


### PR DESCRIPTION
PR'ing so the preparsing changes can be reviewed; this area of the code is not well-documented or organized so I wanna make sure I don't break anything lol

I did some minimal testing and it appears to work as intended, charts without any marked vocal phrases are no longer considered as containing vocal charts.