### PR TITLE
Engine support for disabling authored SP phrases

### DIFF
--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -200,6 +200,11 @@ namespace YARG.Core.Chart
             Flags |= noteFlag;
         }
 
+        public void ResetFlags()
+        {
+            Flags = _flags;
+        }
+
         protected abstract void CopyFlags(TNote other);
         protected abstract TNote CloneNote();
 

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -441,11 +441,15 @@ namespace YARG.Core.Engine
             {
                 if (isAllowed)
                 {
-                    note.ResetNoteState();
+                    note.ResetFlags();
                 }
-                else
+                else if (note.IsStarPower)
                 {
-                    StripStarPower(note);
+                    note.Flags &= ~NoteFlags.StarPower;
+                    foreach (var childNote in note.ChildNotes)
+                    {
+                        childNote.Flags &= ~NoteFlags.StarPower;
+                    }
                 }
             }
         }
@@ -465,9 +469,13 @@ namespace YARG.Core.Engine
             {
                 note.ResetNoteState();
 
-                if (!allowStarPower)
+                if (!allowStarPower && note.IsStarPower)
                 {
-                    StripStarPower(note);
+                    note.Flags &= ~NoteFlags.StarPower;
+                    foreach (var childNote in note.ChildNotes)
+                    {
+                        childNote.Flags &= ~NoteFlags.StarPower;
+                    }
                 }
             }
 
@@ -586,10 +594,7 @@ namespace YARG.Core.Engine
                 }
             }
             
-            if (BaseState.AllowStarPower)
-            {
-                OnStarPowerPhraseMissed?.Invoke(note);
-            }
+            OnStarPowerPhraseMissed?.Invoke(note);
         }
 
         protected virtual void RebaseProgressValues(uint baseTick)

--- a/YARG.Core/Engine/BaseEngineState.cs
+++ b/YARG.Core/Engine/BaseEngineState.cs
@@ -24,6 +24,7 @@
 
         public bool IsSoloActive;
 
+        public bool AllowStarPower;
         public bool IsStarPowerInputActive;
         public uint StarPowerBaseTick;
 
@@ -49,7 +50,8 @@
             CurrentStarIndex = 0;
 
             IsSoloActive = false;
-
+            
+            AllowStarPower = true;
             IsStarPowerInputActive = false;
             StarPowerBaseTick = 0;
         }


### PR DESCRIPTION
Necessary to disable SP phrases in Practice mode. This could also be used for a modifier down the line.