### PR TITLE
Bugfix for Starpower in Practice mode

### DIFF
--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -20,6 +20,8 @@ namespace YARG.Core.Engine
         public abstract BaseEngineParameters BaseParameters { get; }
         public abstract BaseStats            BaseStats      { get; }
 
+        protected bool StarPowerIsAllowed = true;
+
         protected bool IsInputUpdate { get; private set; }
         protected bool IsBotUpdate   { get; private set; }
 
@@ -430,12 +432,12 @@ namespace YARG.Core.Engine
 
         public override void AllowStarPower(bool isAllowed)
         {
-            if (isAllowed == State.AllowStarPower)
+            if (isAllowed == StarPowerIsAllowed)
             {
                 return;
             }
 
-            State.AllowStarPower = isAllowed;
+            StarPowerIsAllowed = isAllowed;
 
             foreach (var note in Notes)
             {
@@ -464,12 +466,11 @@ namespace YARG.Core.Engine
 
             EventLogger.Clear();
 
-            bool allowStarPower = State.AllowStarPower;
             foreach (var note in Notes)
             {
                 note.ResetNoteState();
 
-                if (!allowStarPower && note.IsStarPower)
+                if (!StarPowerIsAllowed && note.IsStarPower)
                 {
                     note.Flags &= ~NoteFlags.StarPower;
                     foreach (var childNote in note.ChildNotes)

--- a/YARG.Core/Engine/BaseEngineState.cs
+++ b/YARG.Core/Engine/BaseEngineState.cs
@@ -24,7 +24,6 @@
 
         public bool IsSoloActive;
 
-        public bool AllowStarPower;
         public bool IsStarPowerInputActive;
         public uint StarPowerBaseTick;
 
@@ -51,7 +50,6 @@
 
             IsSoloActive = false;
             
-            AllowStarPower = true;
             IsStarPowerInputActive = false;
             StarPowerBaseTick = 0;
         }


### PR DESCRIPTION
Moved `AllowStarPower` bool from Engine State to the Engine itself. This should have been persistent for the life of the engine and not reset with time-dependent properties.