### PR TITLE
Refactor .chart parsing to use `YARGChartFileReader`

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Lyrics.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Lyrics.cs
@@ -69,7 +69,7 @@ namespace YARG.Core.Chart
         public LyricsTrack LoadLyrics()
         {
             var converter = new LyricConverter(_moonSong);
-            var maxTick = _moonSong.Charts.Max(x => x.events.LastOrDefault()?.tick + (uint)_moonSong.resolution ?? 0);
+            var maxTick = _moonSong.Charts.Max(x => x.events.LastOrDefault()?.tick + _moonSong.resolution ?? 0);
             TextEvents.ConvertToPhrases(_moonSong.events, converter, maxTick);
             return new LyricsTrack(converter.Phrases);
         }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -1,9 +1,10 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using Melanchall.DryWetMidi.Core;
 using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
+using YARG.Core.IO;
 using YARG.Core.Logging;
 
 namespace YARG.Core.Chart
@@ -60,6 +61,13 @@ namespace YARG.Core.Chart
         public static MoonSongLoader LoadDotChart(ParseSettings settings, string chartText)
         {
             var song = ChartReader.ReadFromText(ref settings, chartText);
+            return new(song, settings);
+        }
+
+        public static MoonSongLoader LoadDotChart<TChar>(ParseSettings settings, ref YARGTextContainer<TChar> chartText)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
+        {
+            var song = ChartReader.ReadFromText(ref settings, ref chartText);
             return new(song, settings);
         }
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using Melanchall.DryWetMidi.Core;
@@ -110,9 +110,9 @@ namespace YARG.Core.Chart
             _currentInstrument = instrument;
             _currentDifficulty = difficulty;
 
-            _currentMoonMode = YargGameModeToMoonGameMode(_currentMode);
-            _currentMoonInstrument = YargInstrumentToMoonInstrument(_currentInstrument);
-            _currentMoonDifficulty = YargDifficultyToMoonDifficulty(_currentDifficulty);
+            _currentMoonMode = _currentMode.ToMoonGameMode();
+            _currentMoonInstrument = _currentInstrument.ToMoonInstrument();
+            _currentMoonDifficulty = _currentDifficulty.ToMoonDifficulty();
 
             var moonChart = GetMoonChart(instrument, difficulty);
             var notes = GetNotes(moonChart, difficulty, createNote, processText);
@@ -391,66 +391,9 @@ namespace YARG.Core.Chart
 
         private MoonChart GetMoonChart(Instrument instrument, Difficulty difficulty)
         {
-            var moonInstrument = YargInstrumentToMoonInstrument(instrument);
-            var moonDifficulty = YargDifficultyToMoonDifficulty(difficulty);
+            var moonInstrument = instrument.ToMoonInstrument();
+            var moonDifficulty = difficulty.ToMoonDifficulty();
             return _moonSong.GetChart(moonInstrument, moonDifficulty);
         }
-
-        private static MoonChart.GameMode YargGameModeToMoonGameMode(GameMode mode) => mode switch
-        {
-            GameMode.FiveFretGuitar => MoonChart.GameMode.Guitar,
-            GameMode.SixFretGuitar => MoonChart.GameMode.GHLGuitar,
-
-            GameMode.FourLaneDrums => MoonChart.GameMode.Drums,
-            GameMode.FiveLaneDrums => MoonChart.GameMode.Drums,
-
-            GameMode.ProGuitar => MoonChart.GameMode.ProGuitar,
-            GameMode.ProKeys => MoonChart.GameMode.ProKeys,
-
-            GameMode.Vocals => MoonChart.GameMode.Vocals,
-
-            _ => throw new NotImplementedException($"Unhandled game mode {mode}!")
-        };
-
-        private static MoonSong.MoonInstrument YargInstrumentToMoonInstrument(Instrument instrument) => instrument switch
-        {
-            Instrument.FiveFretGuitar     => MoonSong.MoonInstrument.Guitar,
-            Instrument.FiveFretCoopGuitar => MoonSong.MoonInstrument.GuitarCoop,
-            Instrument.FiveFretBass       => MoonSong.MoonInstrument.Bass,
-            Instrument.FiveFretRhythm     => MoonSong.MoonInstrument.Rhythm,
-            Instrument.Keys               => MoonSong.MoonInstrument.Keys,
-
-            Instrument.SixFretGuitar     => MoonSong.MoonInstrument.GHLiveGuitar,
-            Instrument.SixFretCoopGuitar => MoonSong.MoonInstrument.GHLiveBass,
-            Instrument.SixFretBass       => MoonSong.MoonInstrument.GHLiveRhythm,
-            Instrument.SixFretRhythm     => MoonSong.MoonInstrument.GHLiveCoop,
-
-            Instrument.FourLaneDrums or
-            Instrument.FiveLaneDrums or
-            Instrument.ProDrums => MoonSong.MoonInstrument.Drums,
-
-            Instrument.ProGuitar_17Fret => MoonSong.MoonInstrument.ProGuitar_17Fret,
-            Instrument.ProGuitar_22Fret => MoonSong.MoonInstrument.ProGuitar_22Fret,
-            Instrument.ProBass_17Fret   => MoonSong.MoonInstrument.ProBass_17Fret,
-            Instrument.ProBass_22Fret   => MoonSong.MoonInstrument.ProBass_22Fret,
-
-            Instrument.ProKeys => MoonSong.MoonInstrument.ProKeys,
-
-            // Vocals and harmony need to be handled specially
-            // Instrument.Vocals  => MoonSong.MoonInstrument.Vocals,
-            // Instrument.Harmony => MoonSong.MoonInstrument.Harmony1,
-
-            _ => throw new NotImplementedException($"Unhandled instrument {instrument}!")
-        };
-
-        private static MoonSong.Difficulty YargDifficultyToMoonDifficulty(Difficulty difficulty) => difficulty switch
-        {
-            Difficulty.Easy       => MoonSong.Difficulty.Easy,
-            Difficulty.Medium     => MoonSong.Difficulty.Medium,
-            Difficulty.Hard       => MoonSong.Difficulty.Hard,
-            Difficulty.Expert or
-            Difficulty.ExpertPlus => MoonSong.Difficulty.Expert,
-            _ => throw new InvalidOperationException($"Invalid difficulty {difficulty}!")
-        };
     }
 }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -364,7 +364,7 @@ namespace YARG.Core.Chart
                     if (previousNote is null)
                     {
                         // This is the first note in the chart, check by distance
-                        float tickThreshold = song.resolution / 3; // 1/12th note
+                        float tickThreshold = song.resolution / 3f; // 1/12th note
                         return Math.Abs((int) note.tick - endTick) < tickThreshold;
                     }
                     else if (note.tick >= endTick && previousNote.tick < endTick)

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Melanchall.DryWetMidi.Core;
-using YARG.Core.Logging;
+using YARG.Core.IO;
 using YARG.Core.Parsing;
 
 namespace YARG.Core.Chart
@@ -235,6 +235,13 @@ namespace YARG.Core.Chart
         public static SongChart FromDotChart(in ParseSettings settings, string chartText)
         {
             var loader = MoonSongLoader.LoadDotChart(settings, chartText);
+            return new(loader);
+        }
+
+        public static SongChart FromDotChart<TChar>(in ParseSettings settings, ref YARGTextContainer<TChar> chartText)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
+        {
+            var loader = MoonSongLoader.LoadDotChart(settings, ref chartText);
             return new(loader);
         }
 

--- a/YARG.Core/IO/Ini/IniSection.cs
+++ b/YARG.Core/IO/Ini/IniSection.cs
@@ -48,30 +48,22 @@ namespace YARG.Core.IO.Ini
 #endif
 
         private readonly Dictionary<string, List<IniModifier>> modifiers;
-
-#if DEBUG
         private readonly Dictionary<string, IniModifierCreator> knownModifiers;
-#endif
 
         public int Count => modifiers.Count;
 
 
-        // `knownModifiers` is always provided as an argument so other code doesn't have to do `#if DEBUG` guards
         public IniSection(in Dictionary<string, IniModifierCreator> knownModifiers)
         {
             modifiers = new();
-#if DEBUG
             this.knownModifiers = knownModifiers;
-#endif
         }
 
         public IniSection(in Dictionary<string, List<IniModifier>> modifiers,
             in Dictionary<string, IniModifierCreator> knownModifiers)
         {
             this.modifiers = modifiers;
-#if DEBUG
             this.knownModifiers = knownModifiers;
-#endif
         }
 
         public void Append(in Dictionary<string, List<IniModifier>> modsToAdd)

--- a/YARG.Core/IO/Ini/SongIniHandler.cs
+++ b/YARG.Core/IO/Ini/SongIniHandler.cs
@@ -12,33 +12,13 @@ namespace YARG.Core.IO.Ini
             var modifiers = YARGIniReader.ReadIniFile(iniFile, SONG_INI_DICTIONARY);
             if (!modifiers.TryGetValue("[song]", out var section))
             {
-                section = new IniSection();
+                section = new IniSection(SONG_INI_MODIFIERS);
             }
             return section;
         }
 
         public static readonly Dictionary<string, Dictionary<string, IniModifierCreator>> SONG_INI_DICTIONARY;
         public static readonly Dictionary<string, IniModifierCreator> SONG_INI_MODIFIERS;
-
-#if DEBUG
-        private static readonly Dictionary<string, ModifierType> _validations;
-        public static void ThrowIfNot<T>(string key)
-        {
-            if (!SONG_INI_MODIFIERS.TryGetValue(key, out var mod))
-            {
-                throw new ArgumentException($"Dev: {key} is not a valid modifier!");
-            }
-
-            var typename = typeof(T).Name;
-            var type = _validations[typename];
-            if (type != mod.Type
-            && (type == ModifierType.SortString) != (mod.Type == ModifierType.SortString_Chart)
-            && (type == ModifierType.String) != (mod.Type == ModifierType.String_Chart))
-            {
-                throw new ArgumentException($"Dev: Modifier {key} is not of type {typename}");
-            }
-        }
-#endif
 
         static SongIniHandler()
         {
@@ -179,24 +159,6 @@ namespace YARG.Core.IO.Ini
             {
                 { "[song]", SONG_INI_MODIFIERS }
             };
-
-#if DEBUG
-            _validations = new()
-            {
-                { nameof(SortString), ModifierType.SortString },
-                { typeof(string).Name, ModifierType.String },
-                { typeof(ulong).Name, ModifierType.UInt64 },
-                { typeof(long).Name, ModifierType.Int64 },
-                { typeof(uint).Name, ModifierType.UInt32 },
-                { typeof(int).Name, ModifierType.Int32 },
-                { typeof(ushort).Name, ModifierType.UInt16 },
-                { typeof(short).Name, ModifierType.Int16 },
-                { typeof(bool).Name, ModifierType.Bool },
-                { typeof(float).Name, ModifierType.Float },
-                { typeof(double).Name, ModifierType.Double },
-                { typeof(long[]).Name, ModifierType.Int64Array },
-            };
-#endif
         }
     }
 }

--- a/YARG.Core/IO/Ini/YARGIniReader.cs
+++ b/YARG.Core/IO/Ini/YARGIniReader.cs
@@ -86,7 +86,7 @@ namespace YARG.Core.IO.Ini
                         modifiers.Add(node.OutputName, new() { mod });
                 }
             }
-            return new IniSection(modifiers);
+            return new IniSection(modifiers, validNodes);
         }
 
         private static bool IsStillCurrentSection<TChar>(ref YARGTextContainer<TChar> container)

--- a/YARG.Core/IO/SngHandler/SngFile.cs
+++ b/YARG.Core/IO/SngHandler/SngFile.cs
@@ -144,7 +144,7 @@ namespace YARG.Core.IO
                 }
                 container.Position = next;
             }
-            return new IniSection(modifiers);
+            return new IniSection(modifiers, SongIniHandler.SONG_INI_MODIFIERS);
         }
 
         private static Dictionary<string, SngFileListing> ReadListings(Stream stream)

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -240,10 +240,11 @@ namespace YARG.Core.IO
             return true;
         }
 
-        public static Dictionary<string, List<IniModifier>> ExtractChartModifiers<TChar>(ref YARGTextContainer<TChar> container)
+        public static IniSection ExtractChartModifiers<TChar>(ref YARGTextContainer<TChar> container)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
-            return ExtractModifiers(ref container, METADATA_MODIFIERS);
+            var modifiers = ExtractModifiers(ref container, METADATA_MODIFIERS);
+            return new IniSection(modifiers, METADATA_MODIFIERS);
         }
 
         public static Dictionary<string, List<IniModifier>> ExtractModifiers<TChar>(

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -77,29 +77,6 @@ namespace YARG.Core.IO
             new("S",  ChartEventType.Special),
         };
 
-        public static readonly Dictionary<string, IniModifierCreator> METADATA_MODIFIERS = new()
-        {
-            { "Name",           new("Name", ModifierType.String_Chart) },
-            { "Artist",         new("Artist", ModifierType.String_Chart) },
-            { "Album",          new("Album", ModifierType.String_Chart) },
-            { "Genre",          new("Genre", ModifierType.String_Chart) },
-            { "Year",           new("Year", ModifierType.String_Chart) },
-            { "Charter",        new("Charter", ModifierType.String_Chart) },
-
-            { "Difficulty",     new("Difficulty", ModifierType.Int32) },
-            { "Length",         new("Length", ModifierType.Double) },
-            { "Offset",         new("Offset", ModifierType.Double) },
-            { "PreviewStart",   new("PreviewStart", ModifierType.Double) },
-            { "PreviewEnd",     new("PreviewEnd", ModifierType.Double) },
-
-            { "Resolution",     new("Resolution", ModifierType.UInt32) },
-        };
-
-        public static readonly Dictionary<string, Dictionary<string, IniModifierCreator>> METADATA_DICTIONARY = new()
-        {
-            { "[Song]", METADATA_MODIFIERS },
-        };
-
         public static bool IsStartOfTrack<TChar>(in YARGTextContainer<TChar> container)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -77,6 +77,29 @@ namespace YARG.Core.IO
             new("S",  ChartEventType.Special),
         };
 
+        public static readonly Dictionary<string, IniModifierCreator> METADATA_MODIFIERS = new()
+        {
+            { "Name",           new("Name", ModifierType.String_Chart) },
+            { "Artist",         new("Artist", ModifierType.String_Chart) },
+            { "Album",          new("Album", ModifierType.String_Chart) },
+            { "Genre",          new("Genre", ModifierType.String_Chart) },
+            { "Year",           new("Year", ModifierType.String_Chart) },
+            { "Charter",        new("Charter", ModifierType.String_Chart) },
+
+            { "Difficulty",     new("Difficulty", ModifierType.Int32) },
+            { "Length",         new("Length", ModifierType.Double) },
+            { "Offset",         new("Offset", ModifierType.Double) },
+            { "PreviewStart",   new("PreviewStart", ModifierType.Double) },
+            { "PreviewEnd",     new("PreviewEnd", ModifierType.Double) },
+
+            { "Resolution",     new("Resolution", ModifierType.UInt32) },
+        };
+
+        public static readonly Dictionary<string, Dictionary<string, IniModifierCreator>> METADATA_DICTIONARY = new()
+        {
+            { "[Song]", METADATA_MODIFIERS },
+        };
+
         public static bool IsStartOfTrack<TChar>(in YARGTextContainer<TChar> container)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
@@ -215,6 +238,12 @@ namespace YARG.Core.IO
                 }
             }
             return true;
+        }
+
+        public static Dictionary<string, List<IniModifier>> ExtractChartModifiers<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
+        {
+            return ExtractModifiers(ref container, METADATA_MODIFIERS);
         }
 
         public static Dictionary<string, List<IniModifier>> ExtractModifiers<TChar>(

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -184,6 +184,15 @@ namespace YARG.Core.IO
             return true;
         }
 
+        public static void SkipCurrentTrack<TChar>(ref YARGTextContainer<TChar> container)
+            where TChar : unmanaged, IEquatable<TChar>, IConvertible
+        {
+            if (YARGTextReader.SkipLinesUntil(ref container, TextConstants<TChar>.CLOSE_BRACE))
+            {
+                YARGTextReader.GotoNextLine(ref container);
+            }
+        }
+
         public static unsafe bool TryParseEvent<TChar>(ref YARGTextContainer<TChar> container, ref DotChartEvent ev)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -240,13 +240,6 @@ namespace YARG.Core.IO
             return true;
         }
 
-        public static IniSection ExtractChartModifiers<TChar>(ref YARGTextContainer<TChar> container)
-            where TChar : unmanaged, IEquatable<TChar>, IConvertible
-        {
-            var modifiers = ExtractModifiers(ref container, METADATA_MODIFIERS);
-            return new IniSection(modifiers, METADATA_MODIFIERS);
-        }
-
         public static Dictionary<string, List<IniModifier>> ExtractModifiers<TChar>(
             ref YARGTextContainer<TChar> container, Dictionary<string, IniModifierCreator> knownModifiers)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible

--- a/YARG.Core/IO/YARGChartFileReader.cs
+++ b/YARG.Core/IO/YARGChartFileReader.cs
@@ -217,14 +217,15 @@ namespace YARG.Core.IO
             return true;
         }
 
-        public unsafe static Dictionary<string, List<IniModifier>> ExtractModifiers<TChar>(ref YARGTextContainer<TChar> container)
+        public static Dictionary<string, List<IniModifier>> ExtractModifiers<TChar>(
+            ref YARGTextContainer<TChar> container, Dictionary<string, IniModifierCreator> knownModifiers)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             Dictionary<string, List<IniModifier>> modifiers = new();
             while (IsStillCurrentTrack(ref container))
             {
                 string name = YARGTextReader.ExtractModifierName(ref container);
-                if (SongIniHandler.SONG_INI_MODIFIERS.TryGetValue(name, out var node))
+                if (knownModifiers.TryGetValue(name, out var node))
                 {
                     var mod = node.CreateModifier(ref container);
                     if (modifiers.TryGetValue(node.OutputName, out var list))

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartIOHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartIOHelper.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using YARG.Core.Chart;
+using YARG.Core.IO.Ini;
 
 namespace MoonscraperChartEditor.Song.IO
 {
@@ -24,6 +25,12 @@ namespace MoonscraperChartEditor.Song.IO
         public const int PHRASE_DRUM_FILL = 64;
         public const int PHRASE_TREMOLO_LANE = 65;
         public const int PHRASE_TRILL_LANE = 66;
+
+        // Only metadata relevant to parsing the chart is included here
+        public static readonly Dictionary<string, IniModifierCreator> MetadataModifiers = new()
+        {
+            { "Resolution",     new("Resolution", ModifierType.UInt32) },
+        };
 
         public static readonly Dictionary<int, int> GuitarNoteNumLookup = new()
         {

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -154,7 +154,8 @@ namespace MoonscraperChartEditor.Song.IO
         {
             YargLogger.LogTrace("Loading .chart [Song] section");
 
-            var metadata = YARGChartFileReader.ExtractChartModifiers(ref chartText);
+            var modifiers = YARGChartFileReader.ExtractModifiers(ref chartText, YARGChartFileReader.METADATA_MODIFIERS);
+            var metadata = new IniSection(modifiers, YARGChartFileReader.METADATA_MODIFIERS);
 
             // Resolution = 192
             if (!metadata.TryGet("Resolution", out uint resolution))

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Alexander Ong
+﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
 // Chart file format specifications- https://docs.google.com/document/d/1v2v0U-9HQ5qHeccpExDOLJ5CMPZZ3QytPmAG5WF0Kzs/edit?usp=sharing
@@ -53,33 +53,6 @@ namespace MoonscraperChartEditor.Song.IO
         {
             public uint resolution;
         }
-
-        #region Utility
-
-        // https://cc.davelozinski.com/c-sharp/fastest-way-to-convert-a-string-to-an-int
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static int FastInt32Parse(ReadOnlySpan<char> text)
-        {
-            int value = 0;
-            foreach (char character in text) value = value * 10 + (character - '0');
-
-            return value;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong FastUint64Parse(ReadOnlySpan<char> text)
-        {
-            ulong value = 0;
-            foreach (char character in text) value = value * 10 + (ulong) (character - '0');
-
-            return value;
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ReadOnlySpan<char> GetNextWord(this ReadOnlySpan<char> buffer, out ReadOnlySpan<char> remaining)
-            => buffer.SplitOnceTrimmed(' ', out remaining);
-
-        #endregion
 
         public static MoonSong ReadFromFile(string filepath)
         {

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -154,8 +154,7 @@ namespace MoonscraperChartEditor.Song.IO
         {
             YargLogger.LogTrace("Loading .chart [Song] section");
 
-            var modifiers = YARGChartFileReader.ExtractChartModifiers(ref chartText);
-            var metadata = new IniSection(modifiers);
+            var metadata = YARGChartFileReader.ExtractChartModifiers(ref chartText);
 
             // Resolution = 192
             if (!metadata.TryGet("Resolution", out uint resolution))

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -209,8 +209,6 @@ namespace MoonscraperChartEditor.Song.IO
                             // Denominator is optional, and defaults to 2 (becomes 4)
                             if (!YARGTextReader.TryExtractUInt32(ref chartText, out uint denominator))
                                 denominator = 2;
-                            else
-                                YARGTextReader.SkipWhitespace(ref chartText);
 
                             // Denominator is stored as a power of 2, apply it here
                             denominator = (uint) Math.Pow(2, denominator);

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -143,6 +143,12 @@ namespace MoonscraperChartEditor.Song.IO
                     ReadInstrumentSection(ref chartText, song, ref settings,
                         instrument.ToMoonInstrument(), difficulty.ToMoonDifficulty());
                 }
+                else
+                {
+                    string trackName = YARGTextReader.PeekLine(ref chartText);
+                    YargLogger.LogFormatWarning("Unrecognized .chart section '{0}'!", trackName);
+                    YARGChartFileReader.SkipCurrentTrack(ref chartText);
+                }
             }
 
             return song;

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -185,9 +185,6 @@ namespace MoonscraperChartEditor.Song.IO
         {
             YargLogger.LogTrace("Loading .chart [SyncTrack] section");
 
-            // This is valid since we are guaranteed to have at least one tempo event at all times
-            var tempoTracker = new ChartEventTickTracker<TempoChange>(song.syncTrack.Tempos);
-
             uint prevTick = 0;
             var chartEvent = new DotChartEvent();
             while (YARGChartFileReader.TryParseEvent(ref chartText, ref chartEvent))
@@ -199,14 +196,13 @@ namespace MoonscraperChartEditor.Song.IO
                         throw new Exception("Tick value not in ascending order");
                     prevTick = tick;
 
-                    tempoTracker.Update(tick);
-
                     switch (chartEvent.Type)
                     {
                         case ChartEventType.Bpm:
                         {
                             ulong tempo = YARGTextReader.ExtractUInt64AndWhitespace(ref chartText);
-                            song.Add(new TempoChange(tempo / 1000f, song.TickToTime(tick, tempoTracker.Current!), tick));
+                            song.Add(new TempoChange(tempo / 1000f,
+                                song.TickToTime(tick, song.syncTrack.Tempos[^1]), tick));
                             break;
                         }
 
@@ -224,7 +220,7 @@ namespace MoonscraperChartEditor.Song.IO
                             denominator = (uint) Math.Pow(2, denominator);
 
                             song.Add(new TimeSignatureChange(numerator, denominator,
-                                song.TickToTime(tick, tempoTracker.Current!), tick));
+                                song.TickToTime(tick, song.syncTrack.Tempos[^1]), tick));
                             break;
                         }
 

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -185,16 +185,12 @@ namespace MoonscraperChartEditor.Song.IO
         {
             YargLogger.LogTrace("Loading .chart [SyncTrack] section");
 
-            uint prevTick = 0;
             var chartEvent = new DotChartEvent();
             while (YARGChartFileReader.TryParseEvent(ref chartText, ref chartEvent))
             {
                 try
                 {
                     uint tick = (uint) chartEvent.Position;
-                    if (prevTick > tick)
-                        throw new Exception("Tick value not in ascending order");
-                    prevTick = tick;
 
                     switch (chartEvent.Type)
                     {
@@ -255,16 +251,12 @@ namespace MoonscraperChartEditor.Song.IO
         {
             YargLogger.LogTrace("Loading .chart [Events] section");
 
-            uint prevTick = 0;
             var chartEvent = new DotChartEvent();
             while (YARGChartFileReader.TryParseEvent(ref chartText, ref chartEvent))
             {
                 try
                 {
                     uint tick = (uint) chartEvent.Position;
-                    if (prevTick > tick)
-                        throw new Exception("Tick value not in ascending order");
-                    prevTick = tick;
 
                     // Get event type
                     switch (chartEvent.Type)
@@ -323,16 +315,12 @@ namespace MoonscraperChartEditor.Song.IO
             var noteProcessDict = GetNoteProcessDict(gameMode);
             var specialPhraseProcessDict = GetSpecialPhraseProcessDict(gameMode);
 
-            uint prevTick = 0;
             var chartEvent = new DotChartEvent();
             while (YARGChartFileReader.TryParseEvent(ref chartText, ref chartEvent))
             {
                 try
                 {
                     uint tick = (uint) chartEvent.Position;
-                    if (prevTick > tick)
-                        throw new Exception("Tick value not in ascending order");
-                    prevTick = tick;
 
                     switch (chartEvent.Type)
                     {

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -160,8 +160,8 @@ namespace MoonscraperChartEditor.Song.IO
         {
             YargLogger.LogTrace("Loading .chart [Song] section");
 
-            var modifiers = YARGChartFileReader.ExtractModifiers(ref chartText, YARGChartFileReader.METADATA_MODIFIERS);
-            var metadata = new IniSection(modifiers, YARGChartFileReader.METADATA_MODIFIERS);
+            var modifiers = YARGChartFileReader.ExtractModifiers(ref chartText, ChartIOHelper.MetadataModifiers);
+            var metadata = new IniSection(modifiers, ChartIOHelper.MetadataModifiers);
 
             // Resolution = 192
             if (!metadata.TryGet("Resolution", out uint resolution))

--- a/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Chart/ChartReader.cs
@@ -223,7 +223,7 @@ namespace MoonscraperChartEditor.Song.IO
                             // Denominator is stored as a power of 2, apply it here
                             denominator = (uint) Math.Pow(2, denominator);
 
-                            song.Add(new TimeSignatureChange(numerator, (uint) Math.Pow(2, denominator),
+                            song.Add(new TimeSignatureChange(numerator, denominator,
                                 song.TickToTime(tick, tempoTracker.Current!), tick));
                             break;
                         }

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -105,7 +105,7 @@ namespace MoonscraperChartEditor.Song.IO
             if (midi.TimeDivision is not TicksPerQuarterNoteTimeDivision ticks)
                 throw new InvalidOperationException("MIDI file has no beat resolution set!");
 
-            var song = new MoonSong((uint)ticks.TicksPerQuarterNote);
+            var song = new MoonSong((uint) ticks.TicksPerQuarterNote);
 
             // Apply settings
             ValidateAndApplySettings(song, ref settings);
@@ -204,7 +204,7 @@ namespace MoonscraperChartEditor.Song.IO
             if (settings.SustainCutoffThreshold < 0)
             {
                 // Default to 1/12th step + 1
-                settings.SustainCutoffThreshold = (long) (song.resolution / 3) + 1;
+                settings.SustainCutoffThreshold = (long) (song.resolution / 3f) + 1;
             }
             else
             {

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -231,7 +231,10 @@ namespace MoonscraperChartEditor.Song.IO
                     song.TickToTime(tempoTick, song.syncTrack.Tempos[^1]), tempoTick));
             }
 
+            // Use tempo tracker to avoid repeated binary search lookup
+            // This is valid since we are guaranteed to have at least one tempo event at all times
             var tempoTracker = new ChartEventTickTracker<TempoChange>(song.syncTrack.Tempos);
+
             foreach (var timesig in tempoMap.GetTimeSignatureChanges())
             {
                 uint tsTick = (uint) timesig.Time;

--- a/YARG.Core/MoonscraperChartParser/Metadata.cs
+++ b/YARG.Core/MoonscraperChartParser/Metadata.cs
@@ -47,7 +47,7 @@ namespace MoonscraperChartEditor.Song
         public string year;
 
         public int difficulty;
-        public float previewStart, previewEnd;
+        public double previewStart, previewEnd;
 
         public Metadata()
         {

--- a/YARG.Core/MoonscraperChartParser/MoonExtensions.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonExtensions.cs
@@ -1,0 +1,65 @@
+using System;
+using YARG.Core;
+
+namespace MoonscraperChartEditor.Song
+{
+    internal static class MoonExtensions
+    {
+        public static MoonChart.GameMode ToMoonGameMode(this GameMode mode) => mode switch
+        {
+            GameMode.FiveFretGuitar => MoonChart.GameMode.Guitar,
+            GameMode.SixFretGuitar => MoonChart.GameMode.GHLGuitar,
+
+            GameMode.FourLaneDrums => MoonChart.GameMode.Drums,
+            GameMode.FiveLaneDrums => MoonChart.GameMode.Drums,
+
+            GameMode.ProGuitar => MoonChart.GameMode.ProGuitar,
+            GameMode.ProKeys => MoonChart.GameMode.ProKeys,
+
+            GameMode.Vocals => MoonChart.GameMode.Vocals,
+
+            _ => throw new NotImplementedException($"Unhandled game mode {mode}!")
+        };
+
+        public static MoonSong.MoonInstrument ToMoonInstrument(this Instrument instrument) => instrument switch
+        {
+            Instrument.FiveFretGuitar     => MoonSong.MoonInstrument.Guitar,
+            Instrument.FiveFretCoopGuitar => MoonSong.MoonInstrument.GuitarCoop,
+            Instrument.FiveFretBass       => MoonSong.MoonInstrument.Bass,
+            Instrument.FiveFretRhythm     => MoonSong.MoonInstrument.Rhythm,
+            Instrument.Keys               => MoonSong.MoonInstrument.Keys,
+
+            Instrument.SixFretGuitar     => MoonSong.MoonInstrument.GHLiveGuitar,
+            Instrument.SixFretCoopGuitar => MoonSong.MoonInstrument.GHLiveBass,
+            Instrument.SixFretBass       => MoonSong.MoonInstrument.GHLiveRhythm,
+            Instrument.SixFretRhythm     => MoonSong.MoonInstrument.GHLiveCoop,
+
+            Instrument.FourLaneDrums or
+            Instrument.FiveLaneDrums or
+            Instrument.ProDrums => MoonSong.MoonInstrument.Drums,
+
+            Instrument.ProGuitar_17Fret => MoonSong.MoonInstrument.ProGuitar_17Fret,
+            Instrument.ProGuitar_22Fret => MoonSong.MoonInstrument.ProGuitar_22Fret,
+            Instrument.ProBass_17Fret   => MoonSong.MoonInstrument.ProBass_17Fret,
+            Instrument.ProBass_22Fret   => MoonSong.MoonInstrument.ProBass_22Fret,
+
+            Instrument.ProKeys => MoonSong.MoonInstrument.ProKeys,
+
+            // Vocals and harmony need to be handled specially
+            // Instrument.Vocals  => MoonSong.MoonInstrument.Vocals,
+            // Instrument.Harmony => MoonSong.MoonInstrument.Harmony1,
+
+            _ => throw new NotImplementedException($"Unhandled instrument {instrument}!")
+        };
+
+        public static MoonSong.Difficulty ToMoonDifficulty(this Difficulty difficulty) => difficulty switch
+        {
+            Difficulty.Easy       => MoonSong.Difficulty.Easy,
+            Difficulty.Medium     => MoonSong.Difficulty.Medium,
+            Difficulty.Hard       => MoonSong.Difficulty.Hard,
+            Difficulty.Expert or
+            Difficulty.ExpertPlus => MoonSong.Difficulty.Expert,
+            _ => throw new InvalidOperationException($"Invalid difficulty {difficulty}!")
+        };
+    }
+}

--- a/YARG.Core/MoonscraperChartParser/MoonSong.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonSong.cs
@@ -11,7 +11,7 @@ namespace MoonscraperChartEditor.Song
 {
     internal class MoonSong
     {
-        public float resolution => syncTrack.Resolution;
+        public uint resolution => syncTrack.Resolution;
         public float hopoThreshold;
 
         // Charts
@@ -171,9 +171,9 @@ namespace MoonscraperChartEditor.Song
             return MoonObjectHelper.Remove(venueEvent, venue);
         }
 
-        public float ResolutionScaleRatio(float targetResoltion)
+        public float ResolutionScaleRatio(uint targetResoltion)
         {
-            return targetResoltion / resolution;
+            return (float) targetResoltion / resolution;
         }
 
         public static MoonChart.GameMode InstrumentToChartGameMode(MoonInstrument instrument)

--- a/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
@@ -210,7 +210,7 @@ namespace YARG.Core.Song
         {
             if (YARGChartFileReader.ValidateTrack(ref container, YARGChartFileReader.HEADERTRACK))
             {
-                var chartMods = YARGChartFileReader.ExtractModifiers(ref container);
+                var chartMods = YARGChartFileReader.ExtractModifiers(ref container, SongIniHandler.SONG_INI_MODIFIERS);
                 modifiers.Append(chartMods);
             }
 

--- a/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
@@ -218,10 +218,7 @@ namespace YARG.Core.Song
             {
                 if (!TraverseChartTrack(ref container, drums, ref parts))
                 {
-                    if (YARGTextReader.SkipLinesUntil(ref container, TextConstants<TChar>.CLOSE_BRACE))
-                    {
-                        YARGTextReader.GotoNextLine(ref container);
-                    }
+                    YARGChartFileReader.SkipCurrentTrack(ref container);
                 }
             }
 

--- a/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
@@ -237,7 +237,7 @@ namespace YARG.Core.Song
             }
             else
             {
-                iniModifiers = new();
+                iniModifiers = new(SongIniHandler.SONG_INI_MODIFIERS);
             }
 
             if ((chart.File.Attributes & AbridgedFileInfo.RECALL_ON_DATA_ACCESS) > 0)


### PR DESCRIPTION
This ensures parsing behavior consistency between song scanning and chart loading, and fixes a possible issue where closing braces `}` being present in a text event would trip up the parser and make it fail to load.

To support this, I made some changes to some of the .ini classes to un-hard-code their expectance on being used for song.ini files, due to `YARGChartFileReader` relying on that infrastructure in its implementation and results. `YARGChartFileReader.ExtractModifiers` now takes a lookup of allowed modifiers as a parameter, and `IniSection` now takes a constructor argument for known modifiers to use for debug validation.