### PR TITLE
Fix and refactor chart parsing behavior tests; implement Pro Keys parsing test

### DIFF
--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Chart.cs
@@ -17,13 +17,65 @@ namespace YARG.Core.UnitTests.Parsing
 
     public class ChartParseBehaviorTests
     {
+        private class ChartSection : IDisposable
+        {
+            private StringBuilder _builder;
+            private List<(uint tick, string typeCode, string data)> _events = new();
+
+            public ChartSection(StringBuilder builder, string sectionName)
+            {
+                _builder = builder;
+
+                _builder.Append($"[{sectionName}]{NEWLINE}");
+                _builder.Append($"{{{NEWLINE}");
+            }
+
+            public void AddEvent(uint tick, string typeCode, string data)
+            {
+                _events.Add((tick, typeCode, data));
+            }
+
+            public void AddEvent(uint tick, string typeCode, uint value1)
+            {
+                _events.Add((tick, typeCode, $"{value1}"));
+            }
+
+            public void AddEvent(uint tick, string typeCode, uint value1, uint value2)
+            {
+                _events.Add((tick, typeCode, $"{value1} {value2}"));
+            }
+
+            public void Dispose()
+            {
+                _events.Sort((left, right) =>
+                {
+                    int compare = left.tick.CompareTo(right.tick);
+                    if (compare != 0)
+                        return compare;
+
+                    compare = string.Compare(left.typeCode, right.typeCode, StringComparison.Ordinal);
+                    if (compare != 0)
+                        return compare;
+
+                    return string.Compare(left.data, right.data, StringComparison.Ordinal);
+                });
+
+                foreach (var (tick, typeCode, data) in _events)
+                {
+                    _builder.Append($"  {tick} = {typeCode} {data}{NEWLINE}");
+                }
+
+                _builder.Append($"}}{NEWLINE}");
+            }
+        }
+
         private static readonly Dictionary<MoonInstrument, string> InstrumentToNameLookup =
             InstrumentStrToEnumLookup.ToDictionary((pair) => pair.Value, (pair) => pair.Key);
 
         private static readonly Dictionary<Difficulty, string> DifficultyToNameLookup =
             TrackNameToTrackDifficultyLookup.ToDictionary((pair) => pair.Value, (pair) => pair.Key);
 
-        private static readonly Dictionary<int, int> GuitarNoteLookup = new()
+        private static readonly Dictionary<int, uint> GuitarNoteLookup = new()
         {
             { (int)GuitarFret.Green,  0 },
             { (int)GuitarFret.Red,    1 },
@@ -33,7 +85,7 @@ namespace YARG.Core.UnitTests.Parsing
             { (int)GuitarFret.Open,   7 },
         };
 
-        private static readonly Dictionary<int, int> GhlGuitarNoteLookup = new()
+        private static readonly Dictionary<int, uint> GhlGuitarNoteLookup = new()
         {
             { (int)GHLiveGuitarFret.Black1, 3 },
             { (int)GHLiveGuitarFret.Black2, 4 },
@@ -44,7 +96,7 @@ namespace YARG.Core.UnitTests.Parsing
             { (int)GHLiveGuitarFret.Open,   7 },
         };
 
-        private static readonly Dictionary<int, int> DrumsNoteLookup = new()
+        private static readonly Dictionary<int, uint> DrumsNoteLookup = new()
         {
             { (int)DrumPad.Kick,   0 },
             { (int)DrumPad.Red,    1 },
@@ -54,14 +106,14 @@ namespace YARG.Core.UnitTests.Parsing
             { (int)DrumPad.Green,  5 },
         };
 
-        private static readonly Dictionary<GameMode, Dictionary<int, int>> InstrumentToNoteLookupLookup = new()
+        private static readonly Dictionary<GameMode, Dictionary<int, uint>> InstrumentToNoteLookupLookup = new()
         {
             { GameMode.Guitar,    GuitarNoteLookup },
             { GameMode.Drums,     DrumsNoteLookup },
             { GameMode.GHLGuitar, GhlGuitarNoteLookup },
         };
 
-        private static readonly Dictionary<MoonPhrase.Type, int> SpecialPhraseLookup = new()
+        private static readonly Dictionary<MoonPhrase.Type, uint> SpecialPhraseLookup = new()
         {
             { MoonPhrase.Type.Starpower,           PHRASE_STARPOWER },
             { MoonPhrase.Type.Versus_Player1,      PHRASE_VERSUS_PLAYER_1 },
@@ -78,80 +130,44 @@ namespace YARG.Core.UnitTests.Parsing
             MoonPhrase.Type.ProDrums_Activation,
         };
 
+        // Explicitly use \r\n here to ensure the parser handles all whitespace correctly
         private const string NEWLINE = "\r\n";
 
         private static void GenerateSongSection(MoonSong sourceSong, StringBuilder builder)
         {
-            builder.Append($"[{SECTION_SONG}]{NEWLINE}{{{NEWLINE}");
+            // Used only as a scoped guard here for the start/end of the section
+            using var section = new ChartSection(builder, SECTION_SONG);
+
+            // Write metadata values manually, shoving methods for it into ChartSection isn't really viable
             builder.Append($"  Resolution = {sourceSong.resolution}{NEWLINE}");
-            builder.Append($"}}{NEWLINE}");
         }
 
         private static void GenerateSyncSection(MoonSong sourceSong, StringBuilder builder)
         {
-            builder.Append($"[{SECTION_SYNC_TRACK}]{NEWLINE}{{{NEWLINE}");
+            using var section = new ChartSection(builder, SECTION_SYNC_TRACK);
 
             var syncTrack = sourceSong.syncTrack;
 
-            // Indexing the separate lists is the only way to
-            // 1: Not allocate more space for a combined list, and
-            // 2: Not rely on polymorphic queries
-            int timeSigIndex = 0;
-            int bpmIndex = 0;
-            while (timeSigIndex < syncTrack.TimeSignatures.Count ||
-                   bpmIndex < syncTrack.Tempos.Count)
+            foreach (var bpm in syncTrack.Tempos)
             {
-                // Generate in this order: time sig, bpm
-                while (timeSigIndex < syncTrack.TimeSignatures.Count &&
-                    // Time sig comes before or at the same time as a bpm
-                    (bpmIndex == syncTrack.Tempos.Count || syncTrack.TimeSignatures[timeSigIndex].Tick <= syncTrack.Tempos[bpmIndex].Tick))
-                {
-                    var ts = syncTrack.TimeSignatures[timeSigIndex++];
-                    builder.Append($"  {ts.Tick} = TS {ts.Numerator} {(int) Math.Log2(ts.Denominator)}{NEWLINE}");
-                }
-
-                while (bpmIndex < syncTrack.Tempos.Count &&
-                    // Bpm comes before a time sig (equals does not count)
-                    (timeSigIndex == syncTrack.TimeSignatures.Count || syncTrack.Tempos[bpmIndex].Tick < syncTrack.TimeSignatures[timeSigIndex].Tick))
-                {
-                    var bpm = syncTrack.Tempos[bpmIndex++];
-                    uint writtenBpm = (uint) (bpm.BeatsPerMinute * 1000);
-                    builder.Append($"  {bpm.Tick} = B {writtenBpm}{NEWLINE}");
-                }
+                uint writtenBpm = (uint) (bpm.BeatsPerMinute * 1000);
+                section.AddEvent(bpm.Tick, "B", $"{writtenBpm}");
             }
-            builder.Append($"}}{NEWLINE}");
+
+            foreach (var ts in syncTrack.TimeSignatures)
+            {
+                section.AddEvent(ts.Tick, "TS", ts.Numerator, (uint) Math.Log2(ts.Denominator));
+            }
         }
 
         private static void GenerateEventsSection(MoonSong sourceSong, StringBuilder builder)
         {
-            builder.Append($"[{SECTION_EVENTS}]{NEWLINE}{{{NEWLINE}");
+            using var section = new ChartSection(builder, SECTION_EVENTS);
 
-            // Indexing the separate lists is the only way to
-            // 1: Not allocate more space for a combined list, and
-            // 2: Not rely on polymorphic queries
-            int sectionIndex = 0;
-            int eventIndex = 0;
-            while (sectionIndex < sourceSong.sections.Count ||
-                   eventIndex < sourceSong.events.Count)
+            foreach (var ev in sourceSong.events.Concat(sourceSong.sections))
             {
-                // Generate in this order: sections, events
-                while (sectionIndex < sourceSong.sections.Count &&
-                    // Section comes before or at the same time as an event
-                    (eventIndex == sourceSong.events.Count || sourceSong.sections[sectionIndex].tick <= sourceSong.events[eventIndex].tick))
-                {
-                    var section = sourceSong.sections[sectionIndex++];
-                    builder.Append($"  {section.tick} = E \"{section.text}\"");
-                }
-
-                while (eventIndex < sourceSong.events.Count &&
-                    // Event comes before a section (equals does not count)
-                    (sectionIndex == sourceSong.sections.Count || sourceSong.events[eventIndex].tick < sourceSong.sections[sectionIndex].tick))
-                {
-                    var ev = sourceSong.events[eventIndex++];
-                    builder.Append($"  {ev.tick} = E \"{ev.text}\"");
-                }
+                section.AddEvent(ev.tick, "E", $"\"{ev.text}\"");
             }
-            builder.Append($"}}{NEWLINE}");
         }
 
         private static void GenerateInstrumentSection(MoonSong sourceSong, StringBuilder builder, MoonInstrument instrument, Difficulty difficulty)
@@ -165,47 +181,19 @@ namespace YARG.Core.UnitTests.Parsing
 
             string instrumentName = InstrumentToNameLookup[instrument];
             string difficultyName = DifficultyToNameLookup[difficulty];
-            builder.Append($"[{difficultyName}{instrumentName}]{NEWLINE}{{{NEWLINE}");
 
-            // Combine all of the chart events into a single list and sort them according to insertion order
-            // Not very efficient, but adding a 4th list to the previous handling and
-            // quadratically increasing the number of checks is just not sane lol
-            List<MoonObject> combined = [..chart.notes, ..chart.specialPhrases, ..chart.events];
-            combined.Sort((obj1, obj2) => obj1.InsertionCompareTo(obj2));
+            using var section = new ChartSection(builder, $"{difficultyName}{instrumentName}");
 
-            List<MoonPhrase> phrasesToRemove = new();
-            for (int i = 0; i < combined.Count; i++)
+            foreach (var note in chart.notes)
             {
-                var chartObj = combined[i];
+                AppendNote(section, note, gameMode);
+            }
 
-                switch (chartObj)
-                {
-                    case MoonNote note:
-                        AppendNote(builder, note, gameMode);
-                        break;
-                    case MoonPhrase phrase:
-                        // Drums-only phrases
-                        if (gameMode is not GameMode.Drums && DrumsOnlySpecialPhrases.Contains(phrase.type))
-                        {
-                            phrasesToRemove.Add(phrase);
-                            continue;
-                        }
-
-                        // Solos are written as text events in .chart
-                        if (phrase.type is MoonPhrase.Type.Solo)
-                        {
-                            builder.Append($"  {phrase.tick} = E {SOLO_START}{NEWLINE}");
-                            MoonObjectHelper.Insert(new MoonText(SOLO_END, phrase.tick + phrase.length), combined);
-                            continue;
-                        }
-
-                        int phraseNumber = SpecialPhraseLookup[phrase.type];
-                        builder.Append($"  {phrase.tick} = S {phraseNumber} {phrase.length}{NEWLINE}");
-                        break;
-                    case MoonText text:
-                        builder.Append($"  {text.tick} = E {text.text}{NEWLINE}");
-                        break;
-                }
+            var textPhrases = new List<MoonText>();
+            var phrasesToRemove = new List<MoonPhrase>();
+            foreach (var phrase in chart.specialPhrases)
+            {
+                AppendPhrase(section, phrase, gameMode, phrasesToRemove, textPhrases);
             }
 
             foreach (var phrase in phrasesToRemove)
@@ -213,10 +201,13 @@ namespace YARG.Core.UnitTests.Parsing
                 chart.Remove(phrase);
             }
 
-            builder.Append($"}}{NEWLINE}");
+            foreach (var text in chart.events.Concat(textPhrases))
+            {
+                section.AddEvent(text.tick, "E", text.text);
+            }
         }
 
-        private static void AppendNote(StringBuilder builder, MoonNote note, GameMode gameMode)
+        private static void AppendNote(ChartSection section, MoonNote note, GameMode gameMode)
         {
             uint tick = note.tick;
             var flags = note.flags;
@@ -230,29 +221,53 @@ namespace YARG.Core.UnitTests.Parsing
             var noteLookup = InstrumentToNoteLookupLookup[gameMode];
 
             // Not technically necessary, but might as well lol
-            int rawNote = gameMode switch {
+            int rawNote = gameMode switch
+            {
                 GameMode.Guitar => (int)note.guitarFret,
                 GameMode.GHLGuitar => (int)note.ghliveGuitarFret,
-                GameMode.ProGuitar => throw new NotSupportedException(".chart does not support Pro Guitar!"),
                 GameMode.Drums => (int)note.drumPad,
-                _ => note.rawNote
+
+                _ => throw new NotSupportedException($".chart does not support game mode {gameMode}!")
             };
 
-            int chartNumber = noteLookup[rawNote];
+            uint chartNumber = noteLookup[rawNote];
             if (canDoubleKick && (flags & Flags.DoubleKick) != 0)
                 chartNumber = NOTE_OFFSET_INSTRUMENT_PLUS;
 
-            builder.Append($"  {tick} = N {chartNumber} {note.length}{NEWLINE}");
+            section.AddEvent(tick, "N", chartNumber, note.length);
             if (canForce && (flags & Flags.Forced) != 0)
-                builder.Append($"  {tick} = N 5 0{NEWLINE}");
+                section.AddEvent(tick, "N", 5, 0);
             if (canTap && (flags & Flags.Tap) != 0)
-                builder.Append($"  {tick} = N 6 0{NEWLINE}");
+                section.AddEvent(tick, "N", 6, 0);
             if (canCymbal && (flags & Flags.ProDrums_Cymbal) != 0)
-                builder.Append($"  {tick} = N {NOTE_OFFSET_PRO_DRUMS + chartNumber} 0{NEWLINE}");
+                section.AddEvent(tick, "N", NOTE_OFFSET_PRO_DRUMS + chartNumber, 0);
             if (canDynamics && (flags & Flags.ProDrums_Accent) != 0)
-                builder.Append($"  {tick} = N {NOTE_OFFSET_DRUMS_ACCENT + chartNumber} 0{NEWLINE}");
+                section.AddEvent(tick, "N", NOTE_OFFSET_DRUMS_ACCENT + chartNumber, 0);
             if (canDynamics && (flags & Flags.ProDrums_Ghost) != 0)
-                builder.Append($"  {tick} = N {NOTE_OFFSET_DRUMS_GHOST + chartNumber} 0{NEWLINE}");
+                section.AddEvent(tick, "N", NOTE_OFFSET_DRUMS_GHOST + chartNumber, 0);
+        }
+
+        private static void AppendPhrase(ChartSection section, MoonPhrase phrase, GameMode gameMode,
+            List<MoonPhrase> phrasesToRemove, List<MoonText> textPhrases)
+        {
+            // Drums-only phrases
+            if (gameMode is not GameMode.Drums && DrumsOnlySpecialPhrases.Contains(phrase.type))
+            {
+                phrasesToRemove.Add(phrase);
+                return;
+            }
+
+            // Solos are written as text events in .chart
+            if (phrase.type is MoonPhrase.Type.Solo)
+            {
+                // No need to worry about sorting here, `ChartSection` will already sort its events
+                textPhrases.Add(new MoonText(SOLO_START, phrase.tick));
+                textPhrases.Add(new MoonText(SOLO_END, phrase.tick + phrase.length));
+                return;
+            }
+
+            uint phraseNumber = SpecialPhraseLookup[phrase.type];
+            section.AddEvent(phrase.tick, "S", phraseNumber, phrase.length);
         }
 
         private static string GenerateChartFile(MoonSong sourceSong)

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.Midi.cs
@@ -49,6 +49,8 @@ namespace YARG.Core.UnitTests.Parsing
         };
 
 #pragma warning disable IDE0230 // Use UTF-8 string literal
+
+        #region Guitar
         private static readonly Dictionary<int, int> GuitarNoteOffsetLookup = new()
         {
             { (int)GuitarFret.Open,   -1 },
@@ -74,7 +76,9 @@ namespace YARG.Core.UnitTests.Parsing
             { MoonPhrase.Type.TremoloLane,    new[] { TREMOLO_LANE_NOTE } },
             { MoonPhrase.Type.TrillLane,      new[] { TRILL_LANE_NOTE } },
         };
+        #endregion
 
+        #region GhlGuitar
         private static readonly Dictionary<int, int> GhlGuitarNoteOffsetLookup = new()
         {
             { (int)GHLiveGuitarFret.Open,   0 },
@@ -97,7 +101,9 @@ namespace YARG.Core.UnitTests.Parsing
             { MoonPhrase.Type.Starpower, new[] { STARPOWER_NOTE } },
             { MoonPhrase.Type.Solo,      new[] { SOLO_NOTE } },
         };
+        #endregion
 
+        #region ProGuitar
         private static readonly Dictionary<int, int> ProGuitarNoteOffsetLookup = new()
         {
             { (int)ProGuitarString.Red,    0 },
@@ -123,7 +129,9 @@ namespace YARG.Core.UnitTests.Parsing
             { MoonPhrase.Type.TremoloLane, new[] { TREMOLO_LANE_NOTE } },
             { MoonPhrase.Type.TrillLane,   new[] { TRILL_LANE_NOTE } },
         };
+        #endregion
 
+        #region Drums
         private static readonly Dictionary<int, int> DrumsNoteOffsetLookup = new()
         {
             { (int)DrumPad.Kick,   0 },
@@ -144,7 +152,9 @@ namespace YARG.Core.UnitTests.Parsing
             { MoonPhrase.Type.TrillLane,           new[] { TRILL_LANE_NOTE } },
             { MoonPhrase.Type.ProDrums_Activation, new[] { DRUM_FILL_NOTE_0, DRUM_FILL_NOTE_1, DRUM_FILL_NOTE_2, DRUM_FILL_NOTE_3, DRUM_FILL_NOTE_4 } },
         };
+        #endregion
 
+        #region Vocals
         private static readonly Dictionary<int, int> VocalsNoteOffsetLookup = BuildVocalsNoteLookup();
 
         private static Dictionary<int, int> BuildVocalsNoteLookup()
@@ -176,7 +186,9 @@ namespace YARG.Core.UnitTests.Parsing
             { MoonPhrase.Type.Versus_Player1, new[] { LYRICS_PHRASE_1 } },
             { MoonPhrase.Type.Versus_Player2, new[] { LYRICS_PHRASE_2 } },
         };
+        #endregion
 
+        #region Lookups
         private static readonly Dictionary<GameMode, Dictionary<int, int>> InstrumentNoteOffsetLookup = new()
         {
             { GameMode.Guitar,    GuitarNoteOffsetLookup },
@@ -221,6 +233,8 @@ namespace YARG.Core.UnitTests.Parsing
             { GameMode.ProGuitar, ProGuitarSpecialPhraseLookup },
             { GameMode.Vocals,    VocalsSpecialPhraseLookup },
         };
+        #endregion
+
 #pragma warning restore IDE0230
 
         // Because SevenBitNumber andFourBitNumber have no implicit operators for taking in bytes

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -34,405 +34,333 @@ namespace YARG.Core.UnitTests.Parsing
         private static MoonPhrase NewSpecial(int index, MoonPhrase.Type type, uint length = 0)
             => new((uint)(index * RESOLUTION), length, type);
 
-        public class ParseBehavior
+        public static readonly MoonChart GuitarTrack = new(GameMode.Guitar)
         {
-            public MoonNote[] Notes;
-            public MoonPhrase[] Phrases;
+            NewNote(0, GuitarFret.Green),
+            NewNote(1, GuitarFret.Red),
+            NewNote(2, GuitarFret.Yellow),
+            NewNote(3, GuitarFret.Blue),
+            NewNote(4, GuitarFret.Orange),
+            NewNote(5, GuitarFret.Open),
 
-            public ParseBehavior(MoonNote[] notes, MoonPhrase[] phrases)
-            {
-                Notes = notes;
-                Phrases = phrases;
-            }
-        }
+            NewSpecial(6, MoonPhrase.Type.Versus_Player1, RESOLUTION * 6),
+            NewNote(6, GuitarFret.Green, flags: Flags.Forced),
+            NewNote(7, GuitarFret.Red, flags: Flags.Forced),
+            NewNote(8, GuitarFret.Yellow, flags: Flags.Forced),
+            NewNote(9, GuitarFret.Blue, flags: Flags.Forced),
+            NewNote(10, GuitarFret.Orange, flags: Flags.Forced),
+            NewNote(11, GuitarFret.Open, flags: Flags.Forced),
 
-        public static readonly ParseBehavior GuitarTrack = new(
-            new[]
-            {
-                NewNote(0, GuitarFret.Green),
-                NewNote(1, GuitarFret.Red),
-                NewNote(2, GuitarFret.Yellow),
-                NewNote(3, GuitarFret.Blue),
-                NewNote(4, GuitarFret.Orange),
-                NewNote(5, GuitarFret.Open),
+            NewSpecial(12, MoonPhrase.Type.Versus_Player2, RESOLUTION * 5),
+            NewNote(12, GuitarFret.Green, flags: Flags.Tap),
+            NewNote(13, GuitarFret.Red, flags: Flags.Tap),
+            NewNote(14, GuitarFret.Yellow, flags: Flags.Tap),
+            NewNote(15, GuitarFret.Blue, flags: Flags.Tap),
+            NewNote(16, GuitarFret.Orange, flags: Flags.Tap),
 
-                // Versus_Player1
-                NewNote(6, GuitarFret.Green, flags: Flags.Forced),
-                NewNote(7, GuitarFret.Red, flags: Flags.Forced),
-                NewNote(8, GuitarFret.Yellow, flags: Flags.Forced),
-                NewNote(9, GuitarFret.Blue, flags: Flags.Forced),
-                NewNote(10, GuitarFret.Orange, flags: Flags.Forced),
-                NewNote(11, GuitarFret.Open, flags: Flags.Forced),
+            NewSpecial(17, MoonPhrase.Type.Starpower, RESOLUTION * 6),
+            NewNote(17, GuitarFret.Green),
+            NewNote(18, GuitarFret.Red),
+            NewNote(19, GuitarFret.Yellow),
+            NewNote(20, GuitarFret.Blue),
+            NewNote(21, GuitarFret.Orange),
+            NewNote(22, GuitarFret.Open),
 
-                // Versus_Player2
-                NewNote(12, GuitarFret.Green, flags: Flags.Tap),
-                NewNote(13, GuitarFret.Red, flags: Flags.Tap),
-                NewNote(14, GuitarFret.Yellow, flags: Flags.Tap),
-                NewNote(15, GuitarFret.Blue, flags: Flags.Tap),
-                NewNote(16, GuitarFret.Orange, flags: Flags.Tap),
+            NewSpecial(23, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
+            NewNote(23, GuitarFret.Yellow),
+            NewNote(24, GuitarFret.Yellow),
+            NewNote(25, GuitarFret.Yellow),
+            NewNote(26, GuitarFret.Yellow),
+            NewNote(27, GuitarFret.Yellow),
+            NewNote(28, GuitarFret.Yellow),
 
-                // Starpower
-                NewNote(17, GuitarFret.Green),
-                NewNote(18, GuitarFret.Red),
-                NewNote(19, GuitarFret.Yellow),
-                NewNote(20, GuitarFret.Blue),
-                NewNote(21, GuitarFret.Orange),
-                NewNote(22, GuitarFret.Open),
+            NewSpecial(29, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
+            NewNote(29, GuitarFret.Green),
+            NewNote(30, GuitarFret.Red),
+            NewNote(31, GuitarFret.Green),
+            NewNote(32, GuitarFret.Red),
+            NewNote(33, GuitarFret.Green),
+            NewNote(34, GuitarFret.Red),
 
-                // TremoloLane
-                NewNote(23, GuitarFret.Yellow),
-                NewNote(24, GuitarFret.Yellow),
-                NewNote(25, GuitarFret.Yellow),
-                NewNote(26, GuitarFret.Yellow),
-                NewNote(27, GuitarFret.Yellow),
-                NewNote(28, GuitarFret.Yellow),
+            NewSpecial(35, MoonPhrase.Type.Solo, RESOLUTION * 6),
+            NewNote(35, GuitarFret.Green, flags: Flags.Forced),
+            NewNote(36, GuitarFret.Red, flags: Flags.Forced),
+            NewNote(37, GuitarFret.Yellow, flags: Flags.Forced),
+            NewNote(38, GuitarFret.Blue, flags: Flags.Forced),
+            NewNote(39, GuitarFret.Orange, flags: Flags.Forced),
+            NewNote(40, GuitarFret.Open, flags: Flags.Forced),
+        };
 
-                // TrillLane
-                NewNote(29, GuitarFret.Green),
-                NewNote(30, GuitarFret.Red),
-                NewNote(31, GuitarFret.Green),
-                NewNote(32, GuitarFret.Red),
-                NewNote(33, GuitarFret.Green),
-                NewNote(34, GuitarFret.Red),
+        public static readonly MoonChart GhlGuitarTrack = new(GameMode.GHLGuitar)
+        {
+            NewNote(0, GHLiveGuitarFret.Black1),
+            NewNote(1, GHLiveGuitarFret.Black2),
+            NewNote(2, GHLiveGuitarFret.Black3),
+            NewNote(3, GHLiveGuitarFret.White1),
+            NewNote(4, GHLiveGuitarFret.White2),
+            NewNote(5, GHLiveGuitarFret.White3),
+            NewNote(6, GHLiveGuitarFret.Open),
 
-                // Solo
-                NewNote(35, GuitarFret.Green, flags: Flags.Forced),
-                NewNote(36, GuitarFret.Red, flags: Flags.Forced),
-                NewNote(37, GuitarFret.Yellow, flags: Flags.Forced),
-                NewNote(38, GuitarFret.Blue, flags: Flags.Forced),
-                NewNote(39, GuitarFret.Orange, flags: Flags.Forced),
-                NewNote(40, GuitarFret.Open, flags: Flags.Forced),
-            },
-            new[]
-            {
-                NewSpecial(6, MoonPhrase.Type.Versus_Player1, RESOLUTION * 6),
-                NewSpecial(12, MoonPhrase.Type.Versus_Player2, RESOLUTION * 5),
-                NewSpecial(17, MoonPhrase.Type.Starpower, RESOLUTION * 6),
-                NewSpecial(23, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
-                NewSpecial(29, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
-                NewSpecial(35, MoonPhrase.Type.Solo, RESOLUTION * 6),
-            }
-        );
+            NewNote(7, GHLiveGuitarFret.Black1, flags: Flags.Forced),
+            NewNote(8, GHLiveGuitarFret.Black2, flags: Flags.Forced),
+            NewNote(9, GHLiveGuitarFret.Black3, flags: Flags.Forced),
+            NewNote(10, GHLiveGuitarFret.White1, flags: Flags.Forced),
+            NewNote(11, GHLiveGuitarFret.White2, flags: Flags.Forced),
+            NewNote(12, GHLiveGuitarFret.White3, flags: Flags.Forced),
+            NewNote(13, GHLiveGuitarFret.Open, flags: Flags.Forced),
 
-        public static readonly ParseBehavior GhlGuitarTrack = new(
-            new[]
-            {
-                NewNote(0, GHLiveGuitarFret.Black1),
-                NewNote(1, GHLiveGuitarFret.Black2),
-                NewNote(2, GHLiveGuitarFret.Black3),
-                NewNote(3, GHLiveGuitarFret.White1),
-                NewNote(4, GHLiveGuitarFret.White2),
-                NewNote(5, GHLiveGuitarFret.White3),
-                NewNote(6, GHLiveGuitarFret.Open),
+            NewNote(14, GHLiveGuitarFret.Black1, flags: Flags.Tap),
+            NewNote(15, GHLiveGuitarFret.Black2, flags: Flags.Tap),
+            NewNote(16, GHLiveGuitarFret.Black3, flags: Flags.Tap),
+            NewNote(17, GHLiveGuitarFret.White1, flags: Flags.Tap),
+            NewNote(18, GHLiveGuitarFret.White2, flags: Flags.Tap),
+            NewNote(19, GHLiveGuitarFret.White3, flags: Flags.Tap),
 
-                NewNote(7, GHLiveGuitarFret.Black1, flags: Flags.Forced),
-                NewNote(8, GHLiveGuitarFret.Black2, flags: Flags.Forced),
-                NewNote(9, GHLiveGuitarFret.Black3, flags: Flags.Forced),
-                NewNote(10, GHLiveGuitarFret.White1, flags: Flags.Forced),
-                NewNote(11, GHLiveGuitarFret.White2, flags: Flags.Forced),
-                NewNote(12, GHLiveGuitarFret.White3, flags: Flags.Forced),
-                NewNote(13, GHLiveGuitarFret.Open, flags: Flags.Forced),
+            NewSpecial(20, MoonPhrase.Type.Starpower, RESOLUTION * 7),
+            NewNote(20, GHLiveGuitarFret.Black1),
+            NewNote(21, GHLiveGuitarFret.Black2),
+            NewNote(22, GHLiveGuitarFret.Black3),
+            NewNote(23, GHLiveGuitarFret.White1),
+            NewNote(24, GHLiveGuitarFret.White2),
+            NewNote(25, GHLiveGuitarFret.White3),
+            NewNote(26, GHLiveGuitarFret.Open),
 
-                NewNote(14, GHLiveGuitarFret.Black1, flags: Flags.Tap),
-                NewNote(15, GHLiveGuitarFret.Black2, flags: Flags.Tap),
-                NewNote(16, GHLiveGuitarFret.Black3, flags: Flags.Tap),
-                NewNote(17, GHLiveGuitarFret.White1, flags: Flags.Tap),
-                NewNote(18, GHLiveGuitarFret.White2, flags: Flags.Tap),
-                NewNote(19, GHLiveGuitarFret.White3, flags: Flags.Tap),
+            NewSpecial(27, MoonPhrase.Type.Solo, RESOLUTION * 7),
+            NewNote(27, GHLiveGuitarFret.Black1),
+            NewNote(28, GHLiveGuitarFret.Black2),
+            NewNote(29, GHLiveGuitarFret.Black3),
+            NewNote(30, GHLiveGuitarFret.White1),
+            NewNote(31, GHLiveGuitarFret.White2),
+            NewNote(32, GHLiveGuitarFret.White3),
+            NewNote(33, GHLiveGuitarFret.Open),
+        };
 
-                // Starpower
-                NewNote(20, GHLiveGuitarFret.Black1),
-                NewNote(21, GHLiveGuitarFret.Black2),
-                NewNote(22, GHLiveGuitarFret.Black3),
-                NewNote(23, GHLiveGuitarFret.White1),
-                NewNote(24, GHLiveGuitarFret.White2),
-                NewNote(25, GHLiveGuitarFret.White3),
-                NewNote(26, GHLiveGuitarFret.Open),
+        public static readonly MoonChart ProGuitarTrack = new(GameMode.ProGuitar)
+        {
+            NewNote(0, ProGuitarString.Red, 0),
+            NewNote(1, ProGuitarString.Green, 1),
+            NewNote(2, ProGuitarString.Orange, 2),
+            NewNote(3, ProGuitarString.Blue, 3),
+            NewNote(4, ProGuitarString.Yellow, 4),
+            NewNote(5, ProGuitarString.Purple, 5),
 
-                // Solo
-                NewNote(27, GHLiveGuitarFret.Black1),
-                NewNote(28, GHLiveGuitarFret.Black2),
-                NewNote(29, GHLiveGuitarFret.Black3),
-                NewNote(30, GHLiveGuitarFret.White1),
-                NewNote(31, GHLiveGuitarFret.White2),
-                NewNote(32, GHLiveGuitarFret.White3),
-                NewNote(33, GHLiveGuitarFret.Open),
-            },
-            new[]
-            {
-                NewSpecial(20, MoonPhrase.Type.Starpower, RESOLUTION * 7),
-                NewSpecial(27, MoonPhrase.Type.Solo, RESOLUTION * 7),
-            }
-        );
+            NewNote(6, ProGuitarString.Red, 6, flags: Flags.Forced),
+            NewNote(7, ProGuitarString.Green, 7, flags: Flags.Forced),
+            NewNote(8, ProGuitarString.Orange, 8, flags: Flags.Forced),
+            NewNote(9, ProGuitarString.Blue, 9, flags: Flags.Forced),
+            NewNote(10, ProGuitarString.Yellow, 10, flags: Flags.Forced),
+            NewNote(11, ProGuitarString.Purple, 11, flags: Flags.Forced),
 
-        public static readonly ParseBehavior ProGuitarTrack = new(
-            new[]
-            {
-                NewNote(0, ProGuitarString.Red, 0),
-                NewNote(1, ProGuitarString.Green, 1),
-                NewNote(2, ProGuitarString.Orange, 2),
-                NewNote(3, ProGuitarString.Blue, 3),
-                NewNote(4, ProGuitarString.Yellow, 4),
-                NewNote(5, ProGuitarString.Purple, 5),
+            NewNote(12, ProGuitarString.Red, 12, flags: Flags.ProGuitar_Muted),
+            NewNote(13, ProGuitarString.Green, 13, flags: Flags.ProGuitar_Muted),
+            NewNote(14, ProGuitarString.Orange, 14, flags: Flags.ProGuitar_Muted),
+            NewNote(15, ProGuitarString.Blue, 15, flags: Flags.ProGuitar_Muted),
+            NewNote(16, ProGuitarString.Yellow, 16, flags: Flags.ProGuitar_Muted),
+            NewNote(17, ProGuitarString.Purple, 17, flags: Flags.ProGuitar_Muted),
 
-                NewNote(6, ProGuitarString.Red, 6, flags: Flags.Forced),
-                NewNote(7, ProGuitarString.Green, 7, flags: Flags.Forced),
-                NewNote(8, ProGuitarString.Orange, 8, flags: Flags.Forced),
-                NewNote(9, ProGuitarString.Blue, 9, flags: Flags.Forced),
-                NewNote(10, ProGuitarString.Yellow, 10, flags: Flags.Forced),
-                NewNote(11, ProGuitarString.Purple, 11, flags: Flags.Forced),
+            NewSpecial(18, MoonPhrase.Type.Starpower, RESOLUTION * 6),
+            NewNote(18, ProGuitarString.Red, 0),
+            NewNote(19, ProGuitarString.Green, 1),
+            NewNote(20, ProGuitarString.Orange, 2),
+            NewNote(21, ProGuitarString.Blue, 3),
+            NewNote(22, ProGuitarString.Yellow, 4),
+            NewNote(23, ProGuitarString.Purple, 5),
 
-                NewNote(12, ProGuitarString.Red, 12, flags: Flags.ProGuitar_Muted),
-                NewNote(13, ProGuitarString.Green, 13, flags: Flags.ProGuitar_Muted),
-                NewNote(14, ProGuitarString.Orange, 14, flags: Flags.ProGuitar_Muted),
-                NewNote(15, ProGuitarString.Blue, 15, flags: Flags.ProGuitar_Muted),
-                NewNote(16, ProGuitarString.Yellow, 16, flags: Flags.ProGuitar_Muted),
-                NewNote(17, ProGuitarString.Purple, 17, flags: Flags.ProGuitar_Muted),
+            NewSpecial(24, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
+            NewNote(24, ProGuitarString.Red, 0),
+            NewNote(25, ProGuitarString.Red, 0),
+            NewNote(26, ProGuitarString.Red, 0),
+            NewNote(27, ProGuitarString.Red, 0),
+            NewNote(28, ProGuitarString.Red, 0),
+            NewNote(29, ProGuitarString.Red, 0),
 
-                // Starpower
-                NewNote(18, ProGuitarString.Red, 0),
-                NewNote(19, ProGuitarString.Green, 1),
-                NewNote(20, ProGuitarString.Orange, 2),
-                NewNote(21, ProGuitarString.Blue, 3),
-                NewNote(22, ProGuitarString.Yellow, 4),
-                NewNote(23, ProGuitarString.Purple, 5),
+            NewSpecial(30, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
+            NewNote(30, ProGuitarString.Yellow, 5),
+            NewNote(31, ProGuitarString.Yellow, 6),
+            NewNote(32, ProGuitarString.Yellow, 5),
+            NewNote(33, ProGuitarString.Yellow, 6),
+            NewNote(34, ProGuitarString.Yellow, 5),
+            NewNote(35, ProGuitarString.Yellow, 6),
 
-                // TremoloLane
-                NewNote(24, ProGuitarString.Red, 0),
-                NewNote(25, ProGuitarString.Red, 0),
-                NewNote(26, ProGuitarString.Red, 0),
-                NewNote(27, ProGuitarString.Red, 0),
-                NewNote(28, ProGuitarString.Red, 0),
-                NewNote(29, ProGuitarString.Red, 0),
+            NewSpecial(36, MoonPhrase.Type.Solo, RESOLUTION * 6),
+            NewNote(36, ProGuitarString.Red, 0),
+            NewNote(37, ProGuitarString.Green, 1),
+            NewNote(38, ProGuitarString.Orange, 2),
+            NewNote(39, ProGuitarString.Blue, 3),
+            NewNote(40, ProGuitarString.Yellow, 4),
+            NewNote(41, ProGuitarString.Purple, 5),
+        };
 
-                // TrillLane
-                NewNote(30, ProGuitarString.Yellow, 5),
-                NewNote(31, ProGuitarString.Yellow, 6),
-                NewNote(32, ProGuitarString.Yellow, 5),
-                NewNote(33, ProGuitarString.Yellow, 6),
-                NewNote(34, ProGuitarString.Yellow, 5),
-                NewNote(35, ProGuitarString.Yellow, 6),
+        public static readonly MoonChart DrumsTrack = new(GameMode.Drums)
+        {
+            NewNote(0, DrumPad.Kick),
+            NewNote(1, DrumPad.Kick, flags: Flags.DoubleKick),
 
-                // Solo
-                NewNote(36, ProGuitarString.Red, 0),
-                NewNote(37, ProGuitarString.Green, 1),
-                NewNote(38, ProGuitarString.Orange, 2),
-                NewNote(39, ProGuitarString.Blue, 3),
-                NewNote(40, ProGuitarString.Yellow, 4),
-                NewNote(41, ProGuitarString.Purple, 5),
-            },
-            new[]
-            {
-                NewSpecial(18, MoonPhrase.Type.Starpower, RESOLUTION * 6),
-                NewSpecial(24, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
-                NewSpecial(30, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
-                NewSpecial(36, MoonPhrase.Type.Solo, RESOLUTION * 6),
-            }
-        );
+            NewNote(2, DrumPad.Red, length: 16),
+            NewNote(3, DrumPad.Yellow, length: 16),
+            NewNote(4, DrumPad.Blue, length: 16),
+            NewNote(5, DrumPad.Orange, length: 16),
+            NewNote(6, DrumPad.Green, length: 16),
+            NewNote(7, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(8, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+            NewNote(9, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-        public static readonly ParseBehavior DrumsTrack = new(
-            new[]
-            {
-                NewNote(0, DrumPad.Kick),
-                NewNote(1, DrumPad.Kick, flags: Flags.DoubleKick),
+            NewNote(10, DrumPad.Red, flags: Flags.ProDrums_Accent),
+            NewNote(11, DrumPad.Yellow, flags: Flags.ProDrums_Accent),
+            NewNote(12, DrumPad.Blue, flags: Flags.ProDrums_Accent),
+            NewNote(13, DrumPad.Orange, flags: Flags.ProDrums_Accent),
+            NewNote(14, DrumPad.Green, flags: Flags.ProDrums_Accent),
+            NewNote(15, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+            NewNote(16, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+            NewNote(17, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
 
-                NewNote(2, DrumPad.Red, length: 16),
-                NewNote(3, DrumPad.Yellow, length: 16),
-                NewNote(4, DrumPad.Blue, length: 16),
-                NewNote(5, DrumPad.Orange, length: 16),
-                NewNote(6, DrumPad.Green, length: 16),
-                NewNote(7, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(8, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-                NewNote(9, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewNote(18, DrumPad.Red, flags: Flags.ProDrums_Ghost),
+            NewNote(19, DrumPad.Yellow, flags: Flags.ProDrums_Ghost),
+            NewNote(20, DrumPad.Blue, flags: Flags.ProDrums_Ghost),
+            NewNote(21, DrumPad.Orange, flags: Flags.ProDrums_Ghost),
+            NewNote(22, DrumPad.Green, flags: Flags.ProDrums_Ghost),
+            NewNote(23, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+            NewNote(24, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+            NewNote(25, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
 
-                NewNote(10, DrumPad.Red, flags: Flags.ProDrums_Accent),
-                NewNote(11, DrumPad.Yellow, flags: Flags.ProDrums_Accent),
-                NewNote(12, DrumPad.Blue, flags: Flags.ProDrums_Accent),
-                NewNote(13, DrumPad.Orange, flags: Flags.ProDrums_Accent),
-                NewNote(14, DrumPad.Green, flags: Flags.ProDrums_Accent),
-                NewNote(15, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
-                NewNote(16, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
-                NewNote(17, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Accent),
+            NewSpecial(26, MoonPhrase.Type.Starpower, RESOLUTION * 8),
+            NewNote(26, DrumPad.Red),
+            NewNote(27, DrumPad.Yellow),
+            NewNote(28, DrumPad.Blue),
+            NewNote(29, DrumPad.Orange),
+            NewNote(30, DrumPad.Green),
+            NewNote(31, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(32, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+            NewNote(33, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-                NewNote(18, DrumPad.Red, flags: Flags.ProDrums_Ghost),
-                NewNote(19, DrumPad.Yellow, flags: Flags.ProDrums_Ghost),
-                NewNote(20, DrumPad.Blue, flags: Flags.ProDrums_Ghost),
-                NewNote(21, DrumPad.Orange, flags: Flags.ProDrums_Ghost),
-                NewNote(22, DrumPad.Green, flags: Flags.ProDrums_Ghost),
-                NewNote(23, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
-                NewNote(24, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
-                NewNote(25, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
+            NewSpecial(34, MoonPhrase.Type.ProDrums_Activation, RESOLUTION * 5),
+            NewNote(34, DrumPad.Red),
+            NewNote(35, DrumPad.Yellow),
+            NewNote(36, DrumPad.Blue),
+            NewNote(37, DrumPad.Orange),
+            NewNote(38, DrumPad.Green),
+            NewNote(39, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(40, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+            NewNote(41, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-                // Starpower
-                NewNote(26, DrumPad.Red),
-                NewNote(27, DrumPad.Yellow),
-                NewNote(28, DrumPad.Blue),
-                NewNote(29, DrumPad.Orange),
-                NewNote(30, DrumPad.Green),
-                NewNote(31, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(32, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-                NewNote(33, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewSpecial(42, MoonPhrase.Type.Versus_Player1, RESOLUTION * 8),
+            NewNote(42, DrumPad.Red),
+            NewNote(43, DrumPad.Yellow),
+            NewNote(44, DrumPad.Blue),
+            NewNote(45, DrumPad.Orange),
+            NewNote(46, DrumPad.Green),
+            NewNote(47, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(48, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+            NewNote(49, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-                // ProDrums_Activation
-                NewNote(34, DrumPad.Red),
-                NewNote(35, DrumPad.Yellow),
-                NewNote(36, DrumPad.Blue),
-                NewNote(37, DrumPad.Orange),
-                NewNote(38, DrumPad.Green),
-                NewNote(39, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(40, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-                NewNote(41, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewSpecial(50, MoonPhrase.Type.Versus_Player2, RESOLUTION * 8),
+            NewNote(50, DrumPad.Red),
+            NewNote(51, DrumPad.Yellow),
+            NewNote(52, DrumPad.Blue),
+            NewNote(53, DrumPad.Orange),
+            NewNote(54, DrumPad.Green),
+            NewNote(55, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(56, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+            NewNote(57, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-                // Versus_Player1
-                NewNote(42, DrumPad.Red),
-                NewNote(43, DrumPad.Yellow),
-                NewNote(44, DrumPad.Blue),
-                NewNote(45, DrumPad.Orange),
-                NewNote(46, DrumPad.Green),
-                NewNote(47, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(48, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-                NewNote(49, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewSpecial(58, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
+            NewNote(58, DrumPad.Red),
+            NewNote(59, DrumPad.Red),
+            NewNote(60, DrumPad.Red),
+            NewNote(61, DrumPad.Red),
+            NewNote(62, DrumPad.Red),
+            NewNote(63, DrumPad.Red),
 
-                // Versus_Player2
-                NewNote(50, DrumPad.Red),
-                NewNote(51, DrumPad.Yellow),
-                NewNote(52, DrumPad.Blue),
-                NewNote(53, DrumPad.Orange),
-                NewNote(54, DrumPad.Green),
-                NewNote(55, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(56, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-                NewNote(57, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewSpecial(64, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
+            NewNote(64, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(65, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewNote(66, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(67, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+            NewNote(68, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(69, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-                // TremoloLane
-                NewNote(58, DrumPad.Red),
-                NewNote(59, DrumPad.Red),
-                NewNote(60, DrumPad.Red),
-                NewNote(61, DrumPad.Red),
-                NewNote(62, DrumPad.Red),
-                NewNote(63, DrumPad.Red),
-
-                // TrillLane
-                NewNote(64, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(65, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-                NewNote(66, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(67, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-                NewNote(68, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(69, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-
-                // Solo
-                NewNote(70, DrumPad.Red),
-                NewNote(71, DrumPad.Yellow),
-                NewNote(72, DrumPad.Blue),
-                NewNote(73, DrumPad.Orange),
-                NewNote(74, DrumPad.Green),
-                NewNote(75, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
-                NewNote(76, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
-                NewNote(77, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
-            },
-            new[]
-            {
-                NewSpecial(26, MoonPhrase.Type.Starpower, RESOLUTION * 8),
-                NewSpecial(34, MoonPhrase.Type.ProDrums_Activation, RESOLUTION * 5),
-                NewSpecial(42, MoonPhrase.Type.Versus_Player1, RESOLUTION * 8),
-                NewSpecial(50, MoonPhrase.Type.Versus_Player2, RESOLUTION * 8),
-                NewSpecial(58, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
-                NewSpecial(64, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
-                NewSpecial(70, MoonPhrase.Type.Solo, RESOLUTION * 8),
-            }
-        );
+            NewSpecial(70, MoonPhrase.Type.Solo, RESOLUTION * 8),
+            NewNote(70, DrumPad.Red),
+            NewNote(71, DrumPad.Yellow),
+            NewNote(72, DrumPad.Blue),
+            NewNote(73, DrumPad.Orange),
+            NewNote(74, DrumPad.Green),
+            NewNote(75, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
+            NewNote(76, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
+            NewNote(77, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
+        };
 
         private const byte VOCALS_RANGE_START = MidIOHelper.VOCALS_RANGE_START;
 
-        public static readonly ParseBehavior VocalsNotes = new(
-            new[]
-            {
-                // Versus_Player1
-                // Vocals_LyricPhrase
-                NewNote(0, VOCALS_RANGE_START + 0, length: RESOLUTION / 2),
-                NewNote(1, VOCALS_RANGE_START + 1, length: RESOLUTION / 2),
-                NewNote(2, VOCALS_RANGE_START + 2, length: RESOLUTION / 2),
-                NewNote(3, VOCALS_RANGE_START + 3, length: RESOLUTION / 2),
-                NewNote(4, VOCALS_RANGE_START + 4, length: RESOLUTION / 2),
-                NewNote(5, VOCALS_RANGE_START + 5, length: RESOLUTION / 2),
-                NewNote(6, VOCALS_RANGE_START + 6, length: RESOLUTION / 2),
-                NewNote(7, VOCALS_RANGE_START + 7, length: RESOLUTION / 2),
-                NewNote(8, VOCALS_RANGE_START + 8, length: RESOLUTION / 2),
-                NewNote(9, VOCALS_RANGE_START + 9, length: RESOLUTION / 2),
-                NewNote(10, VOCALS_RANGE_START + 10, length: RESOLUTION / 2),
-                NewNote(11, VOCALS_RANGE_START + 11, length: RESOLUTION / 2),
+        public static readonly MoonChart VocalsNotes = new(GameMode.Vocals)
+        {
+            NewSpecial(0, MoonPhrase.Type.Versus_Player1, RESOLUTION * 12),
+            NewSpecial(0, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+            NewNote(0, VOCALS_RANGE_START + 0, length: RESOLUTION / 2),
+            NewNote(1, VOCALS_RANGE_START + 1, length: RESOLUTION / 2),
+            NewNote(2, VOCALS_RANGE_START + 2, length: RESOLUTION / 2),
+            NewNote(3, VOCALS_RANGE_START + 3, length: RESOLUTION / 2),
+            NewNote(4, VOCALS_RANGE_START + 4, length: RESOLUTION / 2),
+            NewNote(5, VOCALS_RANGE_START + 5, length: RESOLUTION / 2),
+            NewNote(6, VOCALS_RANGE_START + 6, length: RESOLUTION / 2),
+            NewNote(7, VOCALS_RANGE_START + 7, length: RESOLUTION / 2),
+            NewNote(8, VOCALS_RANGE_START + 8, length: RESOLUTION / 2),
+            NewNote(9, VOCALS_RANGE_START + 9, length: RESOLUTION / 2),
+            NewNote(10, VOCALS_RANGE_START + 10, length: RESOLUTION / 2),
+            NewNote(11, VOCALS_RANGE_START + 11, length: RESOLUTION / 2),
 
-                // Versus_Player2
-                // Vocals_LyricPhrase
-                // Starpower
-                NewNote(12, VOCALS_RANGE_START + 12, length: RESOLUTION / 2),
-                NewNote(13, VOCALS_RANGE_START + 13, length: RESOLUTION / 2),
-                NewNote(14, VOCALS_RANGE_START + 14, length: RESOLUTION / 2),
-                NewNote(15, VOCALS_RANGE_START + 15, length: RESOLUTION / 2),
-                NewNote(16, VOCALS_RANGE_START + 16, length: RESOLUTION / 2),
-                NewNote(17, VOCALS_RANGE_START + 17, length: RESOLUTION / 2),
-                NewNote(18, VOCALS_RANGE_START + 18, length: RESOLUTION / 2),
-                NewNote(19, VOCALS_RANGE_START + 19, length: RESOLUTION / 2),
-                NewNote(20, VOCALS_RANGE_START + 20, length: RESOLUTION / 2),
-                NewNote(21, VOCALS_RANGE_START + 21, length: RESOLUTION / 2),
-                NewNote(22, VOCALS_RANGE_START + 22, length: RESOLUTION / 2),
-                NewNote(23, VOCALS_RANGE_START + 23, length: RESOLUTION / 2),
+            NewSpecial(12, MoonPhrase.Type.Versus_Player2, RESOLUTION * 12),
+            NewSpecial(12, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+            NewSpecial(12, MoonPhrase.Type.Starpower, RESOLUTION * 12),
+            NewNote(12, VOCALS_RANGE_START + 12, length: RESOLUTION / 2),
+            NewNote(13, VOCALS_RANGE_START + 13, length: RESOLUTION / 2),
+            NewNote(14, VOCALS_RANGE_START + 14, length: RESOLUTION / 2),
+            NewNote(15, VOCALS_RANGE_START + 15, length: RESOLUTION / 2),
+            NewNote(16, VOCALS_RANGE_START + 16, length: RESOLUTION / 2),
+            NewNote(17, VOCALS_RANGE_START + 17, length: RESOLUTION / 2),
+            NewNote(18, VOCALS_RANGE_START + 18, length: RESOLUTION / 2),
+            NewNote(19, VOCALS_RANGE_START + 19, length: RESOLUTION / 2),
+            NewNote(20, VOCALS_RANGE_START + 20, length: RESOLUTION / 2),
+            NewNote(21, VOCALS_RANGE_START + 21, length: RESOLUTION / 2),
+            NewNote(22, VOCALS_RANGE_START + 22, length: RESOLUTION / 2),
+            NewNote(23, VOCALS_RANGE_START + 23, length: RESOLUTION / 2),
 
-                // Versus_Player1
-                // Vocals_LyricPhrase
-                // Versus_Player2
-                NewNote(24, VOCALS_RANGE_START + 24, length: RESOLUTION / 2),
-                NewNote(25, VOCALS_RANGE_START + 25, length: RESOLUTION / 2),
-                NewNote(26, VOCALS_RANGE_START + 26, length: RESOLUTION / 2),
-                NewNote(27, VOCALS_RANGE_START + 27, length: RESOLUTION / 2),
-                NewNote(28, VOCALS_RANGE_START + 28, length: RESOLUTION / 2),
-                NewNote(29, VOCALS_RANGE_START + 29, length: RESOLUTION / 2),
-                NewNote(30, VOCALS_RANGE_START + 30, length: RESOLUTION / 2),
-                NewNote(31, VOCALS_RANGE_START + 31, length: RESOLUTION / 2),
-                NewNote(32, VOCALS_RANGE_START + 32, length: RESOLUTION / 2),
-                NewNote(33, VOCALS_RANGE_START + 33, length: RESOLUTION / 2),
-                NewNote(34, VOCALS_RANGE_START + 34, length: RESOLUTION / 2),
-                NewNote(35, VOCALS_RANGE_START + 35, length: RESOLUTION / 2),
+            NewSpecial(24, MoonPhrase.Type.Versus_Player1, RESOLUTION * 12),
+            NewSpecial(24, MoonPhrase.Type.Versus_Player2, RESOLUTION * 12),
+            NewSpecial(24, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
+            NewNote(24, VOCALS_RANGE_START + 24, length: RESOLUTION / 2),
+            NewNote(25, VOCALS_RANGE_START + 25, length: RESOLUTION / 2),
+            NewNote(26, VOCALS_RANGE_START + 26, length: RESOLUTION / 2),
+            NewNote(27, VOCALS_RANGE_START + 27, length: RESOLUTION / 2),
+            NewNote(28, VOCALS_RANGE_START + 28, length: RESOLUTION / 2),
+            NewNote(29, VOCALS_RANGE_START + 29, length: RESOLUTION / 2),
+            NewNote(30, VOCALS_RANGE_START + 30, length: RESOLUTION / 2),
+            NewNote(31, VOCALS_RANGE_START + 31, length: RESOLUTION / 2),
+            NewNote(32, VOCALS_RANGE_START + 32, length: RESOLUTION / 2),
+            NewNote(33, VOCALS_RANGE_START + 33, length: RESOLUTION / 2),
+            NewNote(34, VOCALS_RANGE_START + 34, length: RESOLUTION / 2),
+            NewNote(35, VOCALS_RANGE_START + 35, length: RESOLUTION / 2),
 
-                // Versus_Player2
-                // Vocals_LyricPhrase
-                NewNote(36, VOCALS_RANGE_START + 36, length: RESOLUTION / 2),
-                NewNote(37, VOCALS_RANGE_START + 37, length: RESOLUTION / 2),
-                NewNote(38, VOCALS_RANGE_START + 38, length: RESOLUTION / 2),
-                NewNote(39, VOCALS_RANGE_START + 39, length: RESOLUTION / 2),
-                NewNote(40, VOCALS_RANGE_START + 40, length: RESOLUTION / 2),
-                NewNote(41, VOCALS_RANGE_START + 41, length: RESOLUTION / 2),
-                NewNote(42, VOCALS_RANGE_START + 42, length: RESOLUTION / 2),
-                NewNote(43, VOCALS_RANGE_START + 43, length: RESOLUTION / 2),
-                NewNote(44, VOCALS_RANGE_START + 44, length: RESOLUTION / 2),
-                NewNote(45, VOCALS_RANGE_START + 45, length: RESOLUTION / 2),
-                NewNote(46, VOCALS_RANGE_START + 46, length: RESOLUTION / 2),
-                NewNote(47, VOCALS_RANGE_START + 47, length: RESOLUTION / 2),
-                NewNote(48, VOCALS_RANGE_START + 48, length: RESOLUTION / 2),
+            NewSpecial(36, MoonPhrase.Type.Versus_Player2, RESOLUTION * 13),
+            NewSpecial(36, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
+            NewNote(36, VOCALS_RANGE_START + 36, length: RESOLUTION / 2),
+            NewNote(37, VOCALS_RANGE_START + 37, length: RESOLUTION / 2),
+            NewNote(38, VOCALS_RANGE_START + 38, length: RESOLUTION / 2),
+            NewNote(39, VOCALS_RANGE_START + 39, length: RESOLUTION / 2),
+            NewNote(40, VOCALS_RANGE_START + 40, length: RESOLUTION / 2),
+            NewNote(41, VOCALS_RANGE_START + 41, length: RESOLUTION / 2),
+            NewNote(42, VOCALS_RANGE_START + 42, length: RESOLUTION / 2),
+            NewNote(43, VOCALS_RANGE_START + 43, length: RESOLUTION / 2),
+            NewNote(44, VOCALS_RANGE_START + 44, length: RESOLUTION / 2),
+            NewNote(45, VOCALS_RANGE_START + 45, length: RESOLUTION / 2),
+            NewNote(46, VOCALS_RANGE_START + 46, length: RESOLUTION / 2),
+            NewNote(47, VOCALS_RANGE_START + 47, length: RESOLUTION / 2),
+            NewNote(48, VOCALS_RANGE_START + 48, length: RESOLUTION / 2),
 
-                // Versus_Player1
-                // Vocals_LyricPhrase
-                NewNote(49, 0, flags: Flags.Vocals_Percussion),
-            },
-            new[]
-            {
-                NewSpecial(0, MoonPhrase.Type.Versus_Player1, RESOLUTION * 12),
-                NewSpecial(0, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-
-                NewSpecial(12, MoonPhrase.Type.Versus_Player2, RESOLUTION * 12),
-                NewSpecial(12, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-                NewSpecial(12, MoonPhrase.Type.Starpower, RESOLUTION * 12),
-
-                NewSpecial(24, MoonPhrase.Type.Versus_Player1, RESOLUTION * 12),
-                NewSpecial(24, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-                NewSpecial(24, MoonPhrase.Type.Versus_Player2, RESOLUTION * 12),
-
-                NewSpecial(36, MoonPhrase.Type.Versus_Player2, RESOLUTION * 13),
-                NewSpecial(36, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
-
-                NewSpecial(49, MoonPhrase.Type.Versus_Player1, RESOLUTION * 1),
-                NewSpecial(49, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
-            }
-        );
+            NewSpecial(49, MoonPhrase.Type.Versus_Player1, RESOLUTION * 1),
+            NewSpecial(49, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
+            NewNote(49, 0, flags: Flags.Vocals_Percussion),
+        };
 
         public static MoonSong GenerateSong()
         {
@@ -448,7 +376,7 @@ namespace YARG.Core.UnitTests.Parsing
             return song;
         }
 
-        public static ParseBehavior GameModeToChartData(GameMode gameMode)
+        public static MoonChart GameModeToChartData(GameMode gameMode)
         {
             return gameMode switch {
                 GameMode.Guitar => GuitarTrack,
@@ -474,7 +402,7 @@ namespace YARG.Core.UnitTests.Parsing
             }
         }
 
-        public static void PopulateInstrument(MoonSong song, MoonInstrument instrument, ParseBehavior track)
+        public static void PopulateInstrument(MoonSong song, MoonInstrument instrument, MoonChart track)
         {
             foreach (var difficulty in EnumExtensions<Difficulty>.Values)
             {
@@ -482,15 +410,15 @@ namespace YARG.Core.UnitTests.Parsing
             }
         }
 
-        public static void PopulateDifficulty(MoonSong song, MoonInstrument instrument, Difficulty difficulty, ParseBehavior track)
+        public static void PopulateDifficulty(MoonSong song, MoonInstrument instrument, Difficulty difficulty, MoonChart track)
         {
             var chart = song.GetChart(instrument, difficulty);
-            foreach (var note in track.Notes)
+            foreach (var note in track.notes)
             {
                 chart.notes.Add(note.Clone());
             }
 
-            foreach (var phrase in track.Phrases)
+            foreach (var phrase in track.specialPhrases)
             {
                 chart.specialPhrases.Add(phrase.Clone());
             }
@@ -515,7 +443,7 @@ namespace YARG.Core.UnitTests.Parsing
         {
             Assert.Multiple(() =>
             {
-                Assert.That(parsedSong.resolution, Is.EqualTo(sourceSong.resolution), $"Resolution was not parsed correctly!");
+                Assert.That(parsedSong.resolution, Is.EqualTo(sourceSong.resolution), "Resolution was not parsed correctly!");
                 CollectionAssert.AreEqual(parsedSong.events, parsedSong.events, "Global events do not match!");
 
                 CollectionAssert.AreEqual(sourceSong.syncTrack.Tempos, parsedSong.syncTrack.Tempos, "BPMs do not match!");

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -1,4 +1,4 @@
-using MoonscraperChartEditor.Song;
+﻿using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
 using NUnit.Framework;
 using YARG.Core.Chart;
@@ -369,6 +369,72 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(49, 0, flags: Flags.Vocals_Percussion),
         };
 
+        public static readonly MoonChart ProKeysNotes = new(GameMode.ProKeys)
+        {
+            NewSpecial(0, MoonPhrase.Type.ProKeys_RangeShift0),
+            NewNote(0, 0, length: 1),
+            NewNote(1, 1, length: 1),
+            NewNote(2, 2, length: 1),
+            NewNote(3, 3, length: 1),
+
+            NewSpecial(4, MoonPhrase.Type.ProKeys_RangeShift1),
+            NewNote(4, 4, length: 1),
+            NewNote(5, 5, length: 1),
+            NewNote(6, 6, length: 1),
+            NewNote(7, 7, length: 1),
+
+            NewSpecial(8, MoonPhrase.Type.Starpower, length: 8),
+            NewSpecial(8, MoonPhrase.Type.ProKeys_RangeShift2),
+            NewNote(8, 8, length: 1),
+            NewNote(9, 9, length: 1),
+            NewNote(10, 10, length: 1),
+            NewNote(11, 11, length: 1),
+
+            NewSpecial(12, MoonPhrase.Type.ProKeys_RangeShift3),
+            NewNote(12, 12, length: 1),
+            NewNote(13, 13, length: 1),
+            NewNote(14, 14, length: 1),
+            NewNote(15, 15, length: 1),
+
+            NewSpecial(16, MoonPhrase.Type.Solo, length: 9),
+            NewSpecial(16, MoonPhrase.Type.ProKeys_RangeShift4),
+            NewNote(16, 16, length: 1),
+            NewNote(17, 17, length: 1),
+            NewNote(18, 18, length: 1),
+            NewNote(19, 19, length: 1),
+
+            NewSpecial(20, MoonPhrase.Type.ProKeys_RangeShift5),
+            NewNote(20, 20, length: 1),
+            NewNote(21, 21, length: 1),
+            NewNote(22, 22, length: 1),
+            NewNote(23, 23, length: 1),
+            NewNote(24, 24, length: 1),
+
+            NewSpecial(25, MoonPhrase.Type.ProKeys_Glissando, length: 10),
+            NewNote(25, 0),
+            NewNote(26, 1),
+            NewNote(27, 2),
+            NewNote(28, 3),
+            NewNote(29, 4),
+            NewNote(30, 5),
+            NewNote(31, 6),
+            NewNote(32, 7),
+            NewNote(33, 8),
+            NewNote(34, 9),
+
+            NewSpecial(35, MoonPhrase.Type.ProKeys_Glissando, length: 10),
+            NewNote(35, 10),
+            NewNote(36, 11),
+            NewNote(37, 10),
+            NewNote(38, 11),
+            NewNote(39, 10),
+            NewNote(40, 11),
+            NewNote(41, 10),
+            NewNote(42, 11),
+            NewNote(43, 10),
+            NewNote(44, 11),
+        };
+
         public static MoonSong GenerateSong()
         {
             var song = new MoonSong(RESOLUTION);
@@ -391,6 +457,7 @@ namespace YARG.Core.UnitTests.Parsing
                 GameMode.ProGuitar => ProGuitarTrack,
                 GameMode.Drums => DrumsTrack,
                 GameMode.Vocals => VocalsNotes,
+                GameMode.ProKeys => ProKeysNotes,
                 _ => throw new NotImplementedException($"No note data for game mode {gameMode}")
             };
         }

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -89,6 +89,13 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(38, GuitarFret.Blue, flags: Flags.Forced),
             NewNote(39, GuitarFret.Orange, flags: Flags.Forced),
             NewNote(40, GuitarFret.Open, flags: Flags.Forced),
+
+            NewNote(41, GuitarFret.Green, length: 1),
+            NewNote(42, GuitarFret.Red, length: 1),
+            NewNote(43, GuitarFret.Yellow, length: 1),
+            NewNote(44, GuitarFret.Blue, length: 1),
+            NewNote(45, GuitarFret.Orange, length: 1),
+            NewNote(46, GuitarFret.Open, length: 1),
         };
 
         public static readonly MoonChart GhlGuitarTrack = new(GameMode.GHLGuitar)

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -21,18 +21,18 @@ namespace YARG.Core.UnitTests.Parsing
         {
         };
 
-        private static MoonNote NewNote(int index, int rawNote, uint length = 0, Flags flags = Flags.None)
-            => new((uint)(index * RESOLUTION), rawNote, length, flags);
-        private static MoonNote NewNote(int index, GuitarFret fret, uint length = 0, Flags flags = Flags.None)
+        private static MoonNote NewNote(int index, int rawNote, float length = 0, Flags flags = Flags.None)
+            => new((uint)(index * RESOLUTION), rawNote, (uint)(length * RESOLUTION), flags);
+        private static MoonNote NewNote(int index, GuitarFret fret, float length = 0, Flags flags = Flags.None)
             => NewNote(index, (int)fret, length, flags);
-        private static MoonNote NewNote(int index, GHLiveGuitarFret fret, uint length = 0, Flags flags = Flags.None)
+        private static MoonNote NewNote(int index, GHLiveGuitarFret fret, float length = 0, Flags flags = Flags.None)
             => NewNote(index, (int)fret, length, flags);
-        private static MoonNote NewNote(int index, DrumPad pad, uint length = 0, Flags flags = Flags.None)
+        private static MoonNote NewNote(int index, DrumPad pad, float length = 0, Flags flags = Flags.None)
             => NewNote(index, (int)pad, length, flags);
-        private static MoonNote NewNote(int index, ProGuitarString str, int fret, uint length = 0, Flags flags = Flags.None)
+        private static MoonNote NewNote(int index, ProGuitarString str, int fret, float length = 0, Flags flags = Flags.None)
             => NewNote(index, MoonNote.MakeProGuitarRawNote(str, fret), length, flags);
-        private static MoonPhrase NewSpecial(int index, MoonPhrase.Type type, uint length = 0)
-            => new((uint)(index * RESOLUTION), length, type);
+        private static MoonPhrase NewSpecial(int index, MoonPhrase.Type type, float length = 0)
+            => new((uint)(index * RESOLUTION), (uint)(length * RESOLUTION), type);
 
         public static readonly MoonChart GuitarTrack = new(GameMode.Guitar)
         {
@@ -43,7 +43,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(4, GuitarFret.Orange),
             NewNote(5, GuitarFret.Open),
 
-            NewSpecial(6, MoonPhrase.Type.Versus_Player1, RESOLUTION * 6),
+            NewSpecial(6, MoonPhrase.Type.Versus_Player1, length: 6),
             NewNote(6, GuitarFret.Green, flags: Flags.Forced),
             NewNote(7, GuitarFret.Red, flags: Flags.Forced),
             NewNote(8, GuitarFret.Yellow, flags: Flags.Forced),
@@ -51,14 +51,14 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(10, GuitarFret.Orange, flags: Flags.Forced),
             NewNote(11, GuitarFret.Open, flags: Flags.Forced),
 
-            NewSpecial(12, MoonPhrase.Type.Versus_Player2, RESOLUTION * 5),
+            NewSpecial(12, MoonPhrase.Type.Versus_Player2, length: 5),
             NewNote(12, GuitarFret.Green, flags: Flags.Tap),
             NewNote(13, GuitarFret.Red, flags: Flags.Tap),
             NewNote(14, GuitarFret.Yellow, flags: Flags.Tap),
             NewNote(15, GuitarFret.Blue, flags: Flags.Tap),
             NewNote(16, GuitarFret.Orange, flags: Flags.Tap),
 
-            NewSpecial(17, MoonPhrase.Type.Starpower, RESOLUTION * 6),
+            NewSpecial(17, MoonPhrase.Type.Starpower, length: 6),
             NewNote(17, GuitarFret.Green),
             NewNote(18, GuitarFret.Red),
             NewNote(19, GuitarFret.Yellow),
@@ -66,7 +66,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(21, GuitarFret.Orange),
             NewNote(22, GuitarFret.Open),
 
-            NewSpecial(23, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
+            NewSpecial(23, MoonPhrase.Type.TremoloLane, length: 6),
             NewNote(23, GuitarFret.Yellow),
             NewNote(24, GuitarFret.Yellow),
             NewNote(25, GuitarFret.Yellow),
@@ -74,7 +74,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(27, GuitarFret.Yellow),
             NewNote(28, GuitarFret.Yellow),
 
-            NewSpecial(29, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
+            NewSpecial(29, MoonPhrase.Type.TrillLane, length: 6),
             NewNote(29, GuitarFret.Green),
             NewNote(30, GuitarFret.Red),
             NewNote(31, GuitarFret.Green),
@@ -82,7 +82,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(33, GuitarFret.Green),
             NewNote(34, GuitarFret.Red),
 
-            NewSpecial(35, MoonPhrase.Type.Solo, RESOLUTION * 6),
+            NewSpecial(35, MoonPhrase.Type.Solo, length: 6),
             NewNote(35, GuitarFret.Green, flags: Flags.Forced),
             NewNote(36, GuitarFret.Red, flags: Flags.Forced),
             NewNote(37, GuitarFret.Yellow, flags: Flags.Forced),
@@ -116,7 +116,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(18, GHLiveGuitarFret.White2, flags: Flags.Tap),
             NewNote(19, GHLiveGuitarFret.White3, flags: Flags.Tap),
 
-            NewSpecial(20, MoonPhrase.Type.Starpower, RESOLUTION * 7),
+            NewSpecial(20, MoonPhrase.Type.Starpower, length: 7),
             NewNote(20, GHLiveGuitarFret.Black1),
             NewNote(21, GHLiveGuitarFret.Black2),
             NewNote(22, GHLiveGuitarFret.Black3),
@@ -125,7 +125,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(25, GHLiveGuitarFret.White3),
             NewNote(26, GHLiveGuitarFret.Open),
 
-            NewSpecial(27, MoonPhrase.Type.Solo, RESOLUTION * 7),
+            NewSpecial(27, MoonPhrase.Type.Solo, length: 7),
             NewNote(27, GHLiveGuitarFret.Black1),
             NewNote(28, GHLiveGuitarFret.Black2),
             NewNote(29, GHLiveGuitarFret.Black3),
@@ -158,7 +158,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(16, ProGuitarString.Yellow, 16, flags: Flags.ProGuitar_Muted),
             NewNote(17, ProGuitarString.Purple, 17, flags: Flags.ProGuitar_Muted),
 
-            NewSpecial(18, MoonPhrase.Type.Starpower, RESOLUTION * 6),
+            NewSpecial(18, MoonPhrase.Type.Starpower, length: 6),
             NewNote(18, ProGuitarString.Red, 0),
             NewNote(19, ProGuitarString.Green, 1),
             NewNote(20, ProGuitarString.Orange, 2),
@@ -166,7 +166,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(22, ProGuitarString.Yellow, 4),
             NewNote(23, ProGuitarString.Purple, 5),
 
-            NewSpecial(24, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
+            NewSpecial(24, MoonPhrase.Type.TremoloLane, length: 6),
             NewNote(24, ProGuitarString.Red, 0),
             NewNote(25, ProGuitarString.Red, 0),
             NewNote(26, ProGuitarString.Red, 0),
@@ -174,7 +174,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(28, ProGuitarString.Red, 0),
             NewNote(29, ProGuitarString.Red, 0),
 
-            NewSpecial(30, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
+            NewSpecial(30, MoonPhrase.Type.TrillLane, length: 6),
             NewNote(30, ProGuitarString.Yellow, 5),
             NewNote(31, ProGuitarString.Yellow, 6),
             NewNote(32, ProGuitarString.Yellow, 5),
@@ -182,7 +182,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(34, ProGuitarString.Yellow, 5),
             NewNote(35, ProGuitarString.Yellow, 6),
 
-            NewSpecial(36, MoonPhrase.Type.Solo, RESOLUTION * 6),
+            NewSpecial(36, MoonPhrase.Type.Solo, length: 6),
             NewNote(36, ProGuitarString.Red, 0),
             NewNote(37, ProGuitarString.Green, 1),
             NewNote(38, ProGuitarString.Orange, 2),
@@ -196,11 +196,11 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(0, DrumPad.Kick),
             NewNote(1, DrumPad.Kick, flags: Flags.DoubleKick),
 
-            NewNote(2, DrumPad.Red, length: 16),
-            NewNote(3, DrumPad.Yellow, length: 16),
-            NewNote(4, DrumPad.Blue, length: 16),
-            NewNote(5, DrumPad.Orange, length: 16),
-            NewNote(6, DrumPad.Green, length: 16),
+            NewNote(2, DrumPad.Red, length: 1),
+            NewNote(3, DrumPad.Yellow, length: 1),
+            NewNote(4, DrumPad.Blue, length: 1),
+            NewNote(5, DrumPad.Orange, length: 1),
+            NewNote(6, DrumPad.Green, length: 1),
             NewNote(7, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
             NewNote(8, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
             NewNote(9, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
@@ -223,7 +223,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(24, DrumPad.Blue, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
             NewNote(25, DrumPad.Orange, flags: Flags.ProDrums_Cymbal | Flags.ProDrums_Ghost),
 
-            NewSpecial(26, MoonPhrase.Type.Starpower, RESOLUTION * 8),
+            NewSpecial(26, MoonPhrase.Type.Starpower, length: 8),
             NewNote(26, DrumPad.Red),
             NewNote(27, DrumPad.Yellow),
             NewNote(28, DrumPad.Blue),
@@ -233,7 +233,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(32, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
             NewNote(33, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-            NewSpecial(34, MoonPhrase.Type.ProDrums_Activation, RESOLUTION * 5),
+            NewSpecial(34, MoonPhrase.Type.ProDrums_Activation, length: 5),
             NewNote(34, DrumPad.Red),
             NewNote(35, DrumPad.Yellow),
             NewNote(36, DrumPad.Blue),
@@ -243,7 +243,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(40, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
             NewNote(41, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-            NewSpecial(42, MoonPhrase.Type.Versus_Player1, RESOLUTION * 8),
+            NewSpecial(42, MoonPhrase.Type.Versus_Player1, length: 8),
             NewNote(42, DrumPad.Red),
             NewNote(43, DrumPad.Yellow),
             NewNote(44, DrumPad.Blue),
@@ -253,7 +253,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(48, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
             NewNote(49, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-            NewSpecial(50, MoonPhrase.Type.Versus_Player2, RESOLUTION * 8),
+            NewSpecial(50, MoonPhrase.Type.Versus_Player2, length: 8),
             NewNote(50, DrumPad.Red),
             NewNote(51, DrumPad.Yellow),
             NewNote(52, DrumPad.Blue),
@@ -263,7 +263,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(56, DrumPad.Blue, flags: Flags.ProDrums_Cymbal),
             NewNote(57, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-            NewSpecial(58, MoonPhrase.Type.TremoloLane, RESOLUTION * 6),
+            NewSpecial(58, MoonPhrase.Type.TremoloLane, length: 6),
             NewNote(58, DrumPad.Red),
             NewNote(59, DrumPad.Red),
             NewNote(60, DrumPad.Red),
@@ -271,7 +271,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(62, DrumPad.Red),
             NewNote(63, DrumPad.Red),
 
-            NewSpecial(64, MoonPhrase.Type.TrillLane, RESOLUTION * 6),
+            NewSpecial(64, MoonPhrase.Type.TrillLane, length: 6),
             NewNote(64, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
             NewNote(65, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
             NewNote(66, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
@@ -279,7 +279,7 @@ namespace YARG.Core.UnitTests.Parsing
             NewNote(68, DrumPad.Yellow, flags: Flags.ProDrums_Cymbal),
             NewNote(69, DrumPad.Orange, flags: Flags.ProDrums_Cymbal),
 
-            NewSpecial(70, MoonPhrase.Type.Solo, RESOLUTION * 8),
+            NewSpecial(70, MoonPhrase.Type.Solo, length: 8),
             NewNote(70, DrumPad.Red),
             NewNote(71, DrumPad.Yellow),
             NewNote(72, DrumPad.Blue),
@@ -294,71 +294,71 @@ namespace YARG.Core.UnitTests.Parsing
 
         public static readonly MoonChart VocalsNotes = new(GameMode.Vocals)
         {
-            NewSpecial(0, MoonPhrase.Type.Versus_Player1, RESOLUTION * 12),
-            NewSpecial(0, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-            NewNote(0, VOCALS_RANGE_START + 0, length: RESOLUTION / 2),
-            NewNote(1, VOCALS_RANGE_START + 1, length: RESOLUTION / 2),
-            NewNote(2, VOCALS_RANGE_START + 2, length: RESOLUTION / 2),
-            NewNote(3, VOCALS_RANGE_START + 3, length: RESOLUTION / 2),
-            NewNote(4, VOCALS_RANGE_START + 4, length: RESOLUTION / 2),
-            NewNote(5, VOCALS_RANGE_START + 5, length: RESOLUTION / 2),
-            NewNote(6, VOCALS_RANGE_START + 6, length: RESOLUTION / 2),
-            NewNote(7, VOCALS_RANGE_START + 7, length: RESOLUTION / 2),
-            NewNote(8, VOCALS_RANGE_START + 8, length: RESOLUTION / 2),
-            NewNote(9, VOCALS_RANGE_START + 9, length: RESOLUTION / 2),
-            NewNote(10, VOCALS_RANGE_START + 10, length: RESOLUTION / 2),
-            NewNote(11, VOCALS_RANGE_START + 11, length: RESOLUTION / 2),
+            NewSpecial(0, MoonPhrase.Type.Versus_Player1, length: 12),
+            NewSpecial(0, MoonPhrase.Type.Vocals_LyricPhrase, length: 12),
+            NewNote(0, VOCALS_RANGE_START + 0, length: 0.5f),
+            NewNote(1, VOCALS_RANGE_START + 1, length: 0.5f),
+            NewNote(2, VOCALS_RANGE_START + 2, length: 0.5f),
+            NewNote(3, VOCALS_RANGE_START + 3, length: 0.5f),
+            NewNote(4, VOCALS_RANGE_START + 4, length: 0.5f),
+            NewNote(5, VOCALS_RANGE_START + 5, length: 0.5f),
+            NewNote(6, VOCALS_RANGE_START + 6, length: 0.5f),
+            NewNote(7, VOCALS_RANGE_START + 7, length: 0.5f),
+            NewNote(8, VOCALS_RANGE_START + 8, length: 0.5f),
+            NewNote(9, VOCALS_RANGE_START + 9, length: 0.5f),
+            NewNote(10, VOCALS_RANGE_START + 10, length: 0.5f),
+            NewNote(11, VOCALS_RANGE_START + 11, length: 0.5f),
 
-            NewSpecial(12, MoonPhrase.Type.Versus_Player2, RESOLUTION * 12),
-            NewSpecial(12, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-            NewSpecial(12, MoonPhrase.Type.Starpower, RESOLUTION * 12),
-            NewNote(12, VOCALS_RANGE_START + 12, length: RESOLUTION / 2),
-            NewNote(13, VOCALS_RANGE_START + 13, length: RESOLUTION / 2),
-            NewNote(14, VOCALS_RANGE_START + 14, length: RESOLUTION / 2),
-            NewNote(15, VOCALS_RANGE_START + 15, length: RESOLUTION / 2),
-            NewNote(16, VOCALS_RANGE_START + 16, length: RESOLUTION / 2),
-            NewNote(17, VOCALS_RANGE_START + 17, length: RESOLUTION / 2),
-            NewNote(18, VOCALS_RANGE_START + 18, length: RESOLUTION / 2),
-            NewNote(19, VOCALS_RANGE_START + 19, length: RESOLUTION / 2),
-            NewNote(20, VOCALS_RANGE_START + 20, length: RESOLUTION / 2),
-            NewNote(21, VOCALS_RANGE_START + 21, length: RESOLUTION / 2),
-            NewNote(22, VOCALS_RANGE_START + 22, length: RESOLUTION / 2),
-            NewNote(23, VOCALS_RANGE_START + 23, length: RESOLUTION / 2),
+            NewSpecial(12, MoonPhrase.Type.Versus_Player2, length: 12),
+            NewSpecial(12, MoonPhrase.Type.Vocals_LyricPhrase, length: 12),
+            NewSpecial(12, MoonPhrase.Type.Starpower, length: 12),
+            NewNote(12, VOCALS_RANGE_START + 12, length: 0.5f),
+            NewNote(13, VOCALS_RANGE_START + 13, length: 0.5f),
+            NewNote(14, VOCALS_RANGE_START + 14, length: 0.5f),
+            NewNote(15, VOCALS_RANGE_START + 15, length: 0.5f),
+            NewNote(16, VOCALS_RANGE_START + 16, length: 0.5f),
+            NewNote(17, VOCALS_RANGE_START + 17, length: 0.5f),
+            NewNote(18, VOCALS_RANGE_START + 18, length: 0.5f),
+            NewNote(19, VOCALS_RANGE_START + 19, length: 0.5f),
+            NewNote(20, VOCALS_RANGE_START + 20, length: 0.5f),
+            NewNote(21, VOCALS_RANGE_START + 21, length: 0.5f),
+            NewNote(22, VOCALS_RANGE_START + 22, length: 0.5f),
+            NewNote(23, VOCALS_RANGE_START + 23, length: 0.5f),
 
-            NewSpecial(24, MoonPhrase.Type.Versus_Player1, RESOLUTION * 12),
-            NewSpecial(24, MoonPhrase.Type.Versus_Player2, RESOLUTION * 12),
-            NewSpecial(24, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 12),
-            NewNote(24, VOCALS_RANGE_START + 24, length: RESOLUTION / 2),
-            NewNote(25, VOCALS_RANGE_START + 25, length: RESOLUTION / 2),
-            NewNote(26, VOCALS_RANGE_START + 26, length: RESOLUTION / 2),
-            NewNote(27, VOCALS_RANGE_START + 27, length: RESOLUTION / 2),
-            NewNote(28, VOCALS_RANGE_START + 28, length: RESOLUTION / 2),
-            NewNote(29, VOCALS_RANGE_START + 29, length: RESOLUTION / 2),
-            NewNote(30, VOCALS_RANGE_START + 30, length: RESOLUTION / 2),
-            NewNote(31, VOCALS_RANGE_START + 31, length: RESOLUTION / 2),
-            NewNote(32, VOCALS_RANGE_START + 32, length: RESOLUTION / 2),
-            NewNote(33, VOCALS_RANGE_START + 33, length: RESOLUTION / 2),
-            NewNote(34, VOCALS_RANGE_START + 34, length: RESOLUTION / 2),
-            NewNote(35, VOCALS_RANGE_START + 35, length: RESOLUTION / 2),
+            NewSpecial(24, MoonPhrase.Type.Versus_Player1, length: 12),
+            NewSpecial(24, MoonPhrase.Type.Versus_Player2, length: 12),
+            NewSpecial(24, MoonPhrase.Type.Vocals_LyricPhrase, length: 12),
+            NewNote(24, VOCALS_RANGE_START + 24, length: 0.5f),
+            NewNote(25, VOCALS_RANGE_START + 25, length: 0.5f),
+            NewNote(26, VOCALS_RANGE_START + 26, length: 0.5f),
+            NewNote(27, VOCALS_RANGE_START + 27, length: 0.5f),
+            NewNote(28, VOCALS_RANGE_START + 28, length: 0.5f),
+            NewNote(29, VOCALS_RANGE_START + 29, length: 0.5f),
+            NewNote(30, VOCALS_RANGE_START + 30, length: 0.5f),
+            NewNote(31, VOCALS_RANGE_START + 31, length: 0.5f),
+            NewNote(32, VOCALS_RANGE_START + 32, length: 0.5f),
+            NewNote(33, VOCALS_RANGE_START + 33, length: 0.5f),
+            NewNote(34, VOCALS_RANGE_START + 34, length: 0.5f),
+            NewNote(35, VOCALS_RANGE_START + 35, length: 0.5f),
 
-            NewSpecial(36, MoonPhrase.Type.Versus_Player2, RESOLUTION * 13),
-            NewSpecial(36, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 13),
-            NewNote(36, VOCALS_RANGE_START + 36, length: RESOLUTION / 2),
-            NewNote(37, VOCALS_RANGE_START + 37, length: RESOLUTION / 2),
-            NewNote(38, VOCALS_RANGE_START + 38, length: RESOLUTION / 2),
-            NewNote(39, VOCALS_RANGE_START + 39, length: RESOLUTION / 2),
-            NewNote(40, VOCALS_RANGE_START + 40, length: RESOLUTION / 2),
-            NewNote(41, VOCALS_RANGE_START + 41, length: RESOLUTION / 2),
-            NewNote(42, VOCALS_RANGE_START + 42, length: RESOLUTION / 2),
-            NewNote(43, VOCALS_RANGE_START + 43, length: RESOLUTION / 2),
-            NewNote(44, VOCALS_RANGE_START + 44, length: RESOLUTION / 2),
-            NewNote(45, VOCALS_RANGE_START + 45, length: RESOLUTION / 2),
-            NewNote(46, VOCALS_RANGE_START + 46, length: RESOLUTION / 2),
-            NewNote(47, VOCALS_RANGE_START + 47, length: RESOLUTION / 2),
-            NewNote(48, VOCALS_RANGE_START + 48, length: RESOLUTION / 2),
+            NewSpecial(36, MoonPhrase.Type.Versus_Player2, length: 13),
+            NewSpecial(36, MoonPhrase.Type.Vocals_LyricPhrase, length: 13),
+            NewNote(36, VOCALS_RANGE_START + 36, length: 0.5f),
+            NewNote(37, VOCALS_RANGE_START + 37, length: 0.5f),
+            NewNote(38, VOCALS_RANGE_START + 38, length: 0.5f),
+            NewNote(39, VOCALS_RANGE_START + 39, length: 0.5f),
+            NewNote(40, VOCALS_RANGE_START + 40, length: 0.5f),
+            NewNote(41, VOCALS_RANGE_START + 41, length: 0.5f),
+            NewNote(42, VOCALS_RANGE_START + 42, length: 0.5f),
+            NewNote(43, VOCALS_RANGE_START + 43, length: 0.5f),
+            NewNote(44, VOCALS_RANGE_START + 44, length: 0.5f),
+            NewNote(45, VOCALS_RANGE_START + 45, length: 0.5f),
+            NewNote(46, VOCALS_RANGE_START + 46, length: 0.5f),
+            NewNote(47, VOCALS_RANGE_START + 47, length: 0.5f),
+            NewNote(48, VOCALS_RANGE_START + 48, length: 0.5f),
 
-            NewSpecial(49, MoonPhrase.Type.Versus_Player1, RESOLUTION * 1),
-            NewSpecial(49, MoonPhrase.Type.Vocals_LyricPhrase, RESOLUTION * 1),
+            NewSpecial(49, MoonPhrase.Type.Versus_Player1, length: 1),
+            NewSpecial(49, MoonPhrase.Type.Vocals_LyricPhrase, length: 1),
             NewNote(49, 0, flags: Flags.Vocals_Percussion),
         };
 

--- a/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
+++ b/YARG.Core.UnitTests/Parsing/ParseBehaviorTests.cs
@@ -398,7 +398,7 @@ namespace YARG.Core.UnitTests.Parsing
         {
             foreach (var text in events)
             {
-                song.events.Add(text.Clone());
+                song.Add(text.Clone());
             }
         }
 
@@ -415,17 +415,20 @@ namespace YARG.Core.UnitTests.Parsing
             var chart = song.GetChart(instrument, difficulty);
             foreach (var note in track.notes)
             {
-                chart.notes.Add(note.Clone());
+                chart.Add(note.Clone());
             }
 
             foreach (var phrase in track.specialPhrases)
             {
-                chart.specialPhrases.Add(phrase.Clone());
+                chart.Add(phrase.Clone());
             }
         }
 
         public static void VerifySong(MoonSong sourceSong, MoonSong parsedSong, IEnumerable<GameMode> supportedModes)
         {
+            sourceSong.Sort();
+            parsedSong.Sort();
+
             VerifyGlobal(sourceSong, parsedSong);
 
             foreach (var instrument in EnumExtensions<MoonInstrument>.Values)

--- a/YARG.Core/MoonscraperChartParser/MoonChart.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonChart.cs
@@ -78,6 +78,13 @@ namespace MoonscraperChartEditor.Song
             return MoonObjectHelper.Remove(ev, events);
         }
 
+        public void Sort()
+        {
+            notes.Sort((left, right) => left.InsertionCompareTo(right));
+            specialPhrases.Sort((left, right) => left.InsertionCompareTo(right));
+            events.Sort((left, right) => left.InsertionCompareTo(right));
+        }
+
         // Only implemented to allow collection initializer support
         IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
 

--- a/YARG.Core/MoonscraperChartParser/MoonChart.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonChart.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) 2016-2020 Alexander Ong
 // See LICENSE in project root for license information.
 
+using System.Collections;
 using System.Collections.Generic;
 
 namespace MoonscraperChartEditor.Song
 {
-    internal class MoonChart
+    internal class MoonChart : IEnumerable
     {
-        /// <summary>
-        /// The song this chart is connected to.
-        /// </summary>
-        public MoonSong song { get; private set; }
         /// <summary>
         /// The game mode the chart is designed for
         /// </summary>
@@ -34,15 +31,13 @@ namespace MoonscraperChartEditor.Song
         /// <summary>
         /// Creates a new chart object.
         /// </summary>
-        /// <param name="_song">The song to associate this chart with.</param>
-        public MoonChart(MoonSong _song, GameMode _gameMode)
+        public MoonChart(GameMode _gameMode)
         {
-            song = _song;
             gameMode = _gameMode;
         }
 
-        public MoonChart(MoonSong song, MoonSong.MoonInstrument Instrument)
-            : this(song, MoonSong.InstrumentToChartGameMode(Instrument))
+        public MoonChart(MoonSong.MoonInstrument Instrument)
+            : this(MoonSong.InstrumentToChartGameMode(Instrument))
         {
         }
 
@@ -82,6 +77,9 @@ namespace MoonscraperChartEditor.Song
         {
             return MoonObjectHelper.Remove(ev, events);
         }
+
+        // Only implemented to allow collection initializer support
+        IEnumerator IEnumerable.GetEnumerator() => throw new System.NotImplementedException();
 
         public enum GameMode
         {

--- a/YARG.Core/MoonscraperChartParser/MoonSong.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonSong.cs
@@ -171,6 +171,18 @@ namespace MoonscraperChartEditor.Song
             return MoonObjectHelper.Remove(venueEvent, venue);
         }
 
+        public void Sort()
+        {
+            events.Sort((left, right) => left.InsertionCompareTo(right));
+            sections.Sort((left, right) => left.InsertionCompareTo(right));
+            venue.Sort((left, right) => left.InsertionCompareTo(right));
+
+            foreach (var chart in charts)
+            {
+                chart.Sort();
+            }
+        }
+
         public float ResolutionScaleRatio(float targetResoltion)
         {
             return targetResoltion / resolution;

--- a/YARG.Core/MoonscraperChartParser/MoonSong.cs
+++ b/YARG.Core/MoonscraperChartParser/MoonSong.cs
@@ -48,7 +48,7 @@ namespace MoonscraperChartEditor.Song
             for (int i = 0; i < charts.Length; ++i)
             {
                 var instrument = (MoonInstrument)(i / EnumExtensions<Difficulty>.Count);
-                charts[i] = new MoonChart(this, instrument);
+                charts[i] = new MoonChart(instrument);
             }
         }
 


### PR DESCRIPTION
Main goal here was to improve maintainability; all of the manual sorted indexing into the various lists is difficult to reason about, very fragile, and scales quadratically in code complexity. Now, each type of event is added to a combined unsorted list, and then sorted afterwards, with no additional type queries being performed.

Sorting was already done for .mid by necessity, but it was not being taken advantage of to simplify things. Sorting was *not* done for .chart previously however, so that has been implemented to achieve the same maintenance simplicity.

Additionally, the amount of manual formatting done for writing out .chart files has been significantly reduced. The same code which handles the sorting also now does the writing, and outside code simply passes values to it.

Lastly, event ordering between the source/parsed charts are now ensured to be the same by sorting their contents before verifying them. This means notes/phrases on the same tick being in a different order will no longer result in a test failure. This sorting is only applied by the test by calling a new `Sort` function, so it will not affect the actual parsing time in-game.