### PR TITLE
Decouple image loading from stb_image; tidy up YARGImage and FixedArray + its derivatives

### DIFF
--- a/YARG.Core/IO/Disposables/AllocatedArray.cs
+++ b/YARG.Core/IO/Disposables/AllocatedArray.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -44,10 +44,9 @@ namespace YARG.Core.IO.Disposables
             return new Span<T>(Ptr + offset, (int) count);
         }
 
-        public override void Dispose()
+        protected override void DisposeUnmanaged()
         {
             Marshal.FreeHGlobal(IntPtr);
-            GC.SuppressFinalize(this);
         }
 
         ~AllocatedArray()

--- a/YARG.Core/IO/Disposables/AllocatedArray.cs
+++ b/YARG.Core/IO/Disposables/AllocatedArray.cs
@@ -1,18 +1,34 @@
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Text;
-using YARG.Core.Logging;
 
 namespace YARG.Core.IO.Disposables
 {
     public sealed unsafe class AllocatedArray<T> : FixedArray<T>
         where T : unmanaged
     {
+        public Span<T> Span => new(Ptr, (int) Length);
+
+        private AllocatedArray(T* ptr, long length)
+            : base(ptr, length) { }
+
+        protected override void DisposeUnmanaged()
+        {
+            Marshal.FreeHGlobal(IntPtr);
+        }
+
+        public Span<T> Slice(long offset, long count)
+        {
+            if (offset < 0 || Length < offset + count)
+            {
+                throw new IndexOutOfRangeException();
+            }
+            return new Span<T>(Ptr + offset, (int) count);
+        }
+
         public static AllocatedArray<T> Alloc(long length)
         {
-            var ptr = (T*)Marshal.AllocHGlobal((int)(length * sizeof(T)));
+            var ptr = (T*) Marshal.AllocHGlobal((int) (length * sizeof(T)));
             return new AllocatedArray<T>(ptr, length);
         }
 
@@ -26,32 +42,8 @@ namespace YARG.Core.IO.Disposables
         public static AllocatedArray<T> Read(Stream stream, long length)
         {
             var buffer = Alloc(length);
-            stream.Read(new Span<byte>(buffer.Ptr, (int)(length * sizeof(T))));
+            stream.Read(new Span<byte>(buffer.Ptr, (int) (length * sizeof(T))));
             return buffer;
-        }
-
-        private AllocatedArray(T* ptr, long length)
-            : base(ptr, length) { }
-
-        public Span<T> Span => new(Ptr, (int)Length);
-
-        public Span<T> Slice(long offset, long count)
-        {
-            if (offset < 0 || Length < offset + count)
-            {
-                throw new IndexOutOfRangeException();
-            }
-            return new Span<T>(Ptr + offset, (int) count);
-        }
-
-        protected override void DisposeUnmanaged()
-        {
-            Marshal.FreeHGlobal(IntPtr);
-        }
-
-        ~AllocatedArray()
-        {
-            YargLogger.LogWarning("Dev warning: only use AllocatedArray IF YOU MANUALLY DISPOSE! Not doing so defeats the purpose!");
         }
     }
 }

--- a/YARG.Core/IO/Disposables/FixedArray.cs
+++ b/YARG.Core/IO/Disposables/FixedArray.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -83,8 +83,19 @@ namespace YARG.Core.IO.Disposables
 
         ~FixedArray()
         {
-            Dispose();
+            YargLogger.LogWarning($"{GetType()} was not disposed correctly!");
+            Dispose(false);
         }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+                DisposeManaged();
+            DisposeUnmanaged();
+        }
+
+        protected virtual void DisposeManaged() { }
+        protected virtual void DisposeUnmanaged() { }
 
         private sealed class FixedArrayDebugView
         {

--- a/YARG.Core/IO/Disposables/MemoryMappedArray.cs
+++ b/YARG.Core/IO/Disposables/MemoryMappedArray.cs
@@ -1,14 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+﻿using System.IO;
 using System.IO.MemoryMappedFiles;
-using System.Text;
-using YARG.Core.Logging;
 
 namespace YARG.Core.IO.Disposables
 {
     public sealed unsafe class MemoryMappedArray : FixedArray<byte>
     {
+        private readonly MemoryMappedFile _file;
+        private readonly MemoryMappedViewAccessor _accessor;
+
+        private MemoryMappedArray(MemoryMappedFile file, MemoryMappedViewAccessor accessor, byte* ptr, long length)
+            : base(ptr, length)
+        {
+            _file = file;
+            _accessor = accessor;
+        }
+
+        // Note: not DisposeUnmanaged, as object references are not guaranteed to be valid during finalization
+        protected override void DisposeManaged()
+        {
+            _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
+            _accessor.Dispose();
+            _file.Dispose();
+        }
+
         public static MemoryMappedArray Load(FileInfo info)
         {
             return Load(info.FullName, info.Length);
@@ -26,29 +40,6 @@ namespace YARG.Core.IO.Disposables
             byte* ptr = null;
             accessor.SafeMemoryMappedViewHandle.AcquirePointer(ref ptr);
             return new MemoryMappedArray(file, accessor, ptr, length);
-        }
-
-        private readonly MemoryMappedFile _file;
-        private readonly MemoryMappedViewAccessor _accessor;
-
-        private MemoryMappedArray(MemoryMappedFile file, MemoryMappedViewAccessor accessor, byte* ptr, long length)
-            : base(ptr, length)
-        {
-            _file = file;
-            _accessor = accessor;
-        }
-
-        // Note: not DisposeUnmanaged, as object references are invalidated during finalization
-        protected override void DisposeManaged()
-        {
-            _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
-            _accessor.Dispose();
-            _file.Dispose();
-        }
-
-        ~MemoryMappedArray()
-        {
-            YargLogger.LogWarning("Dev warning: only use MemoryMappedArray IF YOU MANUALLY DISPOSE! Not doing so defeats the purpose!");
         }
     }
 }

--- a/YARG.Core/IO/Disposables/MemoryMappedArray.cs
+++ b/YARG.Core/IO/Disposables/MemoryMappedArray.cs
@@ -38,12 +38,12 @@ namespace YARG.Core.IO.Disposables
             _accessor = accessor;
         }
 
-        public override void Dispose()
+        // Note: not DisposeUnmanaged, as object references are invalidated during finalization
+        protected override void DisposeManaged()
         {
             _accessor.SafeMemoryMappedViewHandle.ReleasePointer();
             _accessor.Dispose();
             _file.Dispose();
-            GC.SuppressFinalize(this);
         }
 
         ~MemoryMappedArray()

--- a/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
@@ -92,7 +92,7 @@ namespace YARG.Core.Song
 
             if (!string.IsNullOrEmpty(_cover) && sngFile.TryGetValue(_video, out var cover))
             {
-                var image = YARGImage.Load(in cover, sngFile);
+                var image = YARGImage.LoadFile(in cover, sngFile);
                 if (image != null)
                 {
                     return image;
@@ -104,7 +104,7 @@ namespace YARG.Core.Song
             {
                 if (sngFile.TryGetValue(albumFile, out var listing))
                 {
-                    var image = YARGImage.Load(in listing, sngFile);
+                    var image = YARGImage.LoadFile(in listing, sngFile);
                     if (image != null)
                     {
                         return image;
@@ -176,7 +176,7 @@ namespace YARG.Core.Song
                 if ((!string.IsNullOrEmpty(_background) && sngFile.TryGetValue(_background, out var listing))
                 || TryGetRandomBackgroundImage(sngFile, out listing))
                 {
-                    var image = YARGImage.Load(in listing, sngFile);
+                    var image = YARGImage.LoadFile(in listing, sngFile);
                     if (image != null)
                     {
                         return new BackgroundResult(image);
@@ -189,7 +189,7 @@ namespace YARG.Core.Song
                     var file = new FileInfo(Path.ChangeExtension(_sngInfo.FullName, format));
                     if (file.Exists)
                     {
-                        var image = YARGImage.Load(file);
+                        var image = YARGImage.LoadFile(file);
                         if (image != null)
                         {
                             return new BackgroundResult(image);

--- a/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
@@ -101,7 +101,7 @@ namespace YARG.Core.Song
             var subFiles = GetSubFiles();
             if (!string.IsNullOrEmpty(_cover) && subFiles.TryGetValue(_cover, out var cover))
             {
-                var image = YARGImage.Load(cover);
+                var image = YARGImage.LoadFile(cover);
                 if (image != null)
                 {
                     return image;
@@ -113,7 +113,7 @@ namespace YARG.Core.Song
             {
                 if (subFiles.TryGetValue(albumFile, out var info))
                 {
-                    var image = YARGImage.Load(info);
+                    var image = YARGImage.LoadFile(info);
                     if (image != null)
                     {
                         return image;
@@ -162,7 +162,7 @@ namespace YARG.Core.Song
                 if ((!string.IsNullOrEmpty(_background) && subFiles.TryGetValue(_background, out var file))
                 || TryGetRandomBackgroundImage(subFiles, out file))
                 {
-                    var image = YARGImage.Load(file);
+                    var image = YARGImage.LoadFile(file);
                     if (image != null)
                     {
                         return new BackgroundResult(image);

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
@@ -223,7 +223,7 @@ namespace YARG.Core.Song
                         var file = new FileInfo(fileBase + ext);
                         if (file.Exists)
                         {
-                            var image = YARGImage.Load(file);
+                            var image = YARGImage.LoadFile(file);
                             if (image != null)
                             {
                                 return new BackgroundResult(image);

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -213,7 +213,7 @@ namespace YARG.Core.Song
             {
                 return null;
             }
-            return new YARGImage(bytes);
+            return YARGImage.LoadDXT(bytes);
         }
 
         public override FixedArray<byte>? LoadMiloData()

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
@@ -167,7 +167,7 @@ namespace YARG.Core.Song
                         var file = new FileInfo(fileBase + ext);
                         if (file.Exists)
                         {
-                            var image = YARGImage.Load(file);
+                            var image = YARGImage.LoadFile(file);
                             if (image != null)
                             {
                                 return new BackgroundResult(image);


### PR DESCRIPTION
This ensures YARG.Core has no direct dependencies on any native libraries. Currently, if the JIT generates `YARGImage.Load(FixedArray<byte>)` in any of the auxiliary projects for YARG.Core, it will throw an exception due to `STB2CSharp` binaries not being included in the YARG.Core repo; only main YARG includes it at the current time.

While this issue will pretty much never be reached in practice, the potential plans for adding a YARG.Core.Native project become significantly more complicated when attempting to migrate `stb_image` to there, due to conflicting needs between different projects and the technical difficulties in trying to account for those differences:

- The auxiliary projects would need only the native binary for the current platform in order to load correctly. Having all platforms' binaries in the same place would probably confuse the runtime on which to pick, and putting each in a folder would likely make it not be able to be found.
- Main YARG needs binaries for all platforms so they can each function correctly.

This is nigh-impossible to provide proper build automation for with the hybrid CMake + .NET SDK build chain I was trying out, as MSBuild has no way of defining arbitrary properties outside of the command-line. It's much easier to keep YARG.Core functionally separate from YARG.Core.Native, so that they can be built and handled separately.