### PR TITLE
Add HasValidInstrument property to YargProfile

### DIFF
--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -4,6 +4,7 @@ using Newtonsoft.Json;
 using YARG.Core.Chart;
 using YARG.Core.Utility;
 using YARG.Core.Extensions;
+using System.Linq;
 
 namespace YARG.Core.Game
 {
@@ -31,6 +32,8 @@ namespace YARG.Core.Game
             get => InputCalibrationMilliseconds / 1000.0;
             set => InputCalibrationMilliseconds = (long) (value * 1000);
         }
+
+        public bool HasValidInstrument => GameMode.PossibleInstruments().Contains(CurrentInstrument);
 
         public Guid EnginePreset;
 

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -178,6 +178,15 @@ namespace YARG.Core.Game
             }
         }
 
+        public void EnsureValidInstrument()
+        {
+
+            if (!HasValidInstrument)
+            {
+                CurrentInstrument = GameMode.PossibleInstruments()[0];
+            }
+        }
+
         // For replay serialization
         public void Serialize(BinaryWriter writer)
         {


### PR DESCRIPTION
This adds a HasValidInstrument property to YargProfile. Profiles can end up with invalid current instruments when their GameMode is changed.

This is needed for the Active Players List (PR to be submitted in future).