### PR TITLE
Added NoCue to LightingType

### DIFF
--- a/YARG.Core/Chart/Venue/LightingEvent.cs
+++ b/YARG.Core/Chart/Venue/LightingEvent.cs
@@ -70,5 +70,6 @@ namespace YARG.Core.Chart
         //YARG internal
         Menu,
         Score,
+        NoCue,
     }
 }


### PR DESCRIPTION
"Default" is actually a defined light pattern and isn't "off". YARG will send LightingEvents out on its UDP stream so I need to send an "off" as a LightingEvent as well, this adds that.