### PR TITLE
Added metadata entries for song credits

### DIFF
--- a/YARG.Core/IO/Ini/SongIniHandler.cs
+++ b/YARG.Core/IO/Ini/SongIniHandler.cs
@@ -115,6 +115,12 @@ namespace YARG.Core.IO.Ini
                 { "loading_phrase",                       new("loading_phrase", ModifierType.String) },
                 { "lyrics",                               new("lyrics", ModifierType.Bool) },
 
+                { "credit_written_by",                    new("credit_written_by", ModifierType.String) },
+                { "credit_performed_by",                  new("credit_performed_by", ModifierType.String) },
+                { "credit_courtesy_of",                   new("credit_courtesy_of", ModifierType.String) },
+                { "credit_album_cover",                   new("credit_album_cover", ModifierType.String) },
+                { "credit_license",                       new("credit_license", ModifierType.String) },
+
                 { "modchart",                             new("modchart", ModifierType.Bool) },
                 { "multiplier_note",                      new("multiplier_note", ModifierType.Int32) },
 

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -34,7 +34,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        public const int CACHE_VERSION = 24_09_21_01;
+        public const int CACHE_VERSION = 24_09_24_01;
 
         public static ScanProgressTracker Progress => _progress;
         private static ScanProgressTracker _progress;

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -134,6 +134,12 @@ namespace YARG.Core.Song
 
         public string LoadingPhrase => _metadata.LoadingPhrase;
 
+        public string CreditWrittenBy => _metadata.CreditWrittenBy;
+        public string CreditPerformedBy => _metadata.CreditPerformedBy;
+        public string CreditCourtesyOf => _metadata.CreditCourtesyOf;
+        public string CreditAlbumCover => _metadata.CreditAlbumCover;
+        public string CreditLicense => _metadata.CreditLicense;
+
         public ulong SongLengthMilliseconds
         {
             get => _metadata.SongLength;
@@ -369,6 +375,12 @@ namespace YARG.Core.Song
 
             modifiers.TryGet("loading_phrase", out _metadata.LoadingPhrase);
 
+            modifiers.TryGet("credit_written_by", out _metadata.CreditWrittenBy);
+            modifiers.TryGet("credit_performed_by", out _metadata.CreditPerformedBy);
+            modifiers.TryGet("credit_courtesy_of", out _metadata.CreditCourtesyOf);
+            modifiers.TryGet("credit_album_cover", out _metadata.CreditAlbumCover);
+            modifiers.TryGet("credit_license", out _metadata.CreditLicense);
+
             if (!modifiers.TryGet("playlist_track", out _metadata.PlaylistTrack))
             {
                 _metadata.PlaylistTrack = -1;
@@ -493,6 +505,12 @@ namespace YARG.Core.Song
 
             _metadata.LoadingPhrase = stream.ReadString();
 
+            _metadata.CreditWrittenBy = stream.ReadString();
+            _metadata.CreditPerformedBy = stream.ReadString();
+            _metadata.CreditCourtesyOf = stream.ReadString();
+            _metadata.CreditAlbumCover = stream.ReadString();
+            _metadata.CreditLicense = stream.ReadString();
+
             _parseSettings.HopoThreshold = stream.Read<long>(Endianness.Little);
             _parseSettings.HopoFreq_FoF = stream.Read<int>(Endianness.Little);
             _parseSettings.EighthNoteHopo = stream.ReadBoolean();
@@ -542,6 +560,12 @@ namespace YARG.Core.Song
             writer.Write(_metadata.VideoEndTime);
 
             writer.Write(_metadata.LoadingPhrase);
+
+            writer.Write(_metadata.CreditWrittenBy);
+            writer.Write(_metadata.CreditPerformedBy);
+            writer.Write(_metadata.CreditCourtesyOf);
+            writer.Write(_metadata.CreditAlbumCover);
+            writer.Write(_metadata.CreditLicense);
 
             writer.Write(_parseSettings.HopoThreshold);
             writer.Write(_parseSettings.HopoFreq_FoF);

--- a/YARG.Core/Song/Entries/Types/SongMetadata.cs
+++ b/YARG.Core/Song/Entries/Types/SongMetadata.cs
@@ -1,11 +1,4 @@
-﻿using System.IO;
-using System.Text.RegularExpressions;
-using YARG.Core.Chart;
-using YARG.Core.IO;
-using YARG.Core.IO.Ini;
-using YARG.Core.Song.Cache;
-
-namespace YARG.Core.Song
+﻿namespace YARG.Core.Song
 {
     public struct SongMetadata
     {
@@ -30,6 +23,11 @@ namespace YARG.Core.Song
             AlbumTrack = 0,
             PlaylistTrack = 0,
             LoadingPhrase = string.Empty,
+            CreditWrittenBy = string.Empty,
+            CreditPerformedBy = string.Empty,
+            CreditCourtesyOf = string.Empty,
+            CreditAlbumCover = string.Empty,
+            CreditLicense = string.Empty,
             Year = DEFAULT_YEAR,
             SongLength = 0,
             SongOffset = 0,
@@ -65,5 +63,11 @@ namespace YARG.Core.Song
         public int PlaylistTrack;
 
         public string LoadingPhrase;
+
+        public string CreditWrittenBy;
+        public string CreditPerformedBy;
+        public string CreditCourtesyOf;
+        public string CreditAlbumCover;
+        public string CreditLicense;
     }
 }


### PR DESCRIPTION
Adds the following `song.ini` keys (all strings):
* `credit_written_by`
* `credit_performed_by`
* `credit_courtesy_of`
* `credit_album_cover`
* `credit_license`

These will be used in the credits screen to display information about each song (if any).