### PR TITLE
Fix alpha value not being deserialized correctly from JSON 50% of the time

### DIFF
--- a/YARG.Core/Utility/JsonColorConverter.cs
+++ b/YARG.Core/Utility/JsonColorConverter.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Drawing;
 using System.Globalization;
 using Newtonsoft.Json;
@@ -46,6 +46,8 @@ namespace YARG.Core.Utility
 
                 // Convert from RGBA to ARGB
                 rgba >>= 8;
+                // If rgba is negative, the above bit shift will result in the first byte being FF, so we need to clear it.
+                rgba &= 0x00FFFFFF;
                 rgba |= a << 24;
 
                 return Color.FromArgb(rgba);


### PR DESCRIPTION
This fixes an issue in the JSON color serializer that causes alpha values to be deserialized incorrectly when converting from RGBA to ARGB. Depending on the color string provided, this may cause the alpha value to be discarded and replaced with "FF". Fixes issues when loading Highway Presets, and possibly Color Profiles as well.