### PR TITLE
Clamp measure index at 0 to avoid exception when no events at time 0

### DIFF
--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -948,6 +948,12 @@ namespace YARG.Core.Engine
                     // Temporary fix by adding a check for the last measure
                     // Affects 1/1 time signatures
                     int curMeasureIndex = allMeasureBeatLines.GetIndexOfPrevious(noteOneTickEnd);
+                    if (curMeasureIndex == -1)
+                    {
+                        // In songs with no events at time 0, it's possible to have no previous note.
+                        // In that case, just use 0.
+                        curMeasureIndex = 0;
+                    }
                     if (allMeasureBeatLines[curMeasureIndex].Tick < noteOneTickEnd
                         && curMeasureIndex + 1 < allMeasureBeatLines.Count)
                     {


### PR DESCRIPTION
If the first event on the BEAT track does not occur at time 0, a failure to load would occur with a System.ArgumentOutOfRangeException, because the -1 returned by GetIndexOfPrevious would then be used as an array index.  Clamp the value at 0 to use the time of the first event instead.

Fixes the issue detailed in Discord bug-reports: https://discord.com/channels/1086048856678084609/1324542191556759662
