### PR TITLE
Handle unison phrases

### DIFF
--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -29,11 +29,13 @@ namespace YARG.Core.Engine
         public delegate void ComboResetEvent();
         public delegate void ComboIncrementEvent(int amount);
 
+        public delegate void UnisonBonusAwardedEvent();
         public StarPowerStatusEvent? OnStarPowerStatus;
         public SoloStartEvent?       OnSoloStart;
         public SoloEndEvent?         OnSoloEnd;
         public ComboResetEvent?      OnComboReset;
         public ComboIncrementEvent?  OnComboIncrement;
+        public UnisonBonusAwardedEvent? OnUnisonBonusAwarded;
 
         public bool IsInputQueued => InputQueue.Count > 0;
 
@@ -766,6 +768,12 @@ namespace YARG.Core.Engine
         {
             BaseStats.Combo = 0;
             OnComboReset?.Invoke();
+        }
+
+        public void AwardUnisonBonus()
+        {
+            GainStarPower(TicksPerQuarterSpBar);
+            OnUnisonBonusAwarded?.Invoke();
         }
     }
 }

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -1,0 +1,387 @@
+﻿using System;
+using System.Collections.Generic;
+using YARG.Core.Chart;
+using YARG.Core.Input;
+using YARG.Core.Logging;
+
+namespace YARG.Core.Engine
+{
+    public partial class EngineManager
+    {
+        // TODO: There is some cruft around _reportedEngines that should be removed
+        //  now that this is happening in the engine manager, which should already know
+        //  about all engines
+        public class UnisonEvent : IEquatable<UnisonEvent>
+        {
+            public double Time { get; }
+            public double TimeEnd { get; }
+            public int PartCount { get; private set; }
+            public int SuccessCount { get; private set; }
+            public bool Awarded { get; set; }
+            public List<int> ParticipantIds { get; private set; }
+
+            public bool Equals(UnisonEvent other) => Time.Equals(other.Time) && TimeEnd.Equals(other.TimeEnd);
+
+            // public bool Equals(double startTime, double endTime) => Time.Equals(startTime) && TimeEnd.Equals(endTime);
+            // public override bool Equals(object obj) => Equals(obj as UnisonEvent);
+            public override int GetHashCode() => HashCode.Combine(Time, TimeEnd);
+
+            public UnisonEvent(double time, double timeEnd)
+            {
+                Time = time;
+                TimeEnd = timeEnd;
+                PartCount = 0;
+                SuccessCount = 0;
+                Awarded = false;
+                ParticipantIds = new List<int>();
+            }
+
+            public void AddPlayer(EngineContainer engineContainer)
+            {
+                if (ParticipantIds.Contains(engineContainer.EngineId))
+                {
+                    return;
+                }
+
+                ParticipantIds.Add(engineContainer.EngineId);
+                PartCount++;
+            }
+
+            // Returns true if all players succesfully completed the unison
+            public bool Success(EngineContainer engineContainer)
+            {
+                if (ParticipantIds.Contains(engineContainer.EngineId))
+                {
+                    SuccessCount++;
+                }
+
+                if (SuccessCount == ParticipantIds.Count)
+                {
+                    YargLogger.LogDebug("Unison phrase successfully completed");
+                    return true;
+                }
+
+                // If SuccessCount is ever greater than the number of players, something has gone seriously wrong
+                YargLogger.Assert(SuccessCount <= ParticipantIds.Count);
+                return false;
+            }
+        }
+
+        private List<UnisonEvent> _unisonEvents = new();
+
+        public struct StarPowerSection : IEquatable<StarPowerSection>
+        {
+            public double Time;
+            public double TimeEnd;
+            public Phrase PhraseRef;
+
+            public StarPowerSection(double time, double timeEnd, Phrase phrase)
+            {
+                Time = time;
+                TimeEnd = timeEnd;
+                PhraseRef = phrase;
+            }
+
+            public bool Equals(StarPowerSection other) => Time.Equals(other.Time) && TimeEnd.Equals(other.TimeEnd);
+
+            public override bool Equals(object obj) => obj is StarPowerSection other && Equals(other);
+
+            public override int GetHashCode() => HashCode.Combine(Time, TimeEnd);
+        }
+
+        public delegate void UnisonPhrasesReadyEvent(List<UnisonEvent> unisonEvents);
+
+        public delegate void UnisonPhraseSuccessEvent();
+
+        public  UnisonPhraseSuccessEvent?                       OnUnisonPhraseSuccess;
+        private bool                                            _unisonsReady      = false;
+        private int                                             _playerCount  = 0;
+
+        private void AddPlayerToUnisons(EngineContainer engineContainer)
+        {
+            foreach (var phrase in engineContainer.UnisonPhrases)
+            {
+                var unisonEvent = new UnisonEvent(phrase.Time, phrase.TimeEnd);
+                if (!_unisonEvents.Contains(unisonEvent))
+                {
+                    _unisonEvents.Add(unisonEvent);
+                    unisonEvent.AddPlayer(engineContainer);
+                }
+                else
+                {
+                    var idx = _unisonEvents.IndexOf(unisonEvent);
+                    if (idx != -1)
+                    {
+                        _unisonEvents[idx].AddPlayer(engineContainer);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Builds unison phrases for a combination of instrument and chart
+        /// </summary>
+        /// <param name="instrument">YARG.Core.Instrument</param>
+        /// <param name="chart">YARG.Core.Chart.SongChart</param>
+        /// <returns>List of Phrase objects with Type == PhraseType.StarPower
+        /// <br />These Phrases have corresponding StarPower Phrases in other tracks,
+        /// <br />which is what makes them unison phrases.
+        /// </returns>
+        public static List<Phrase> GetUnisonPhrases(Instrument instrument, SongChart chart)
+        {
+            var phrases = new List<Phrase>();
+            // the list we will compare against to find unisons
+            var sourceSpSections = new List<StarPowerSection>();
+            var othersSpSections = new List<StarPowerSection>();
+            var outSpSections = new List<StarPowerSection>();
+            // This list should have the instruments with duplicate SP phrases removed
+            var acceptedSpSections = new List<List<StarPowerSection>>();
+
+            var foundSelf = false;
+
+            if(TryFindTrackForInstrument(instrument, chart.FiveFretTracks, out var fiveFretTrack))
+            {
+                var selfInstrumentDifficulty = GetAnyInstrumentDifficulty(fiveFretTrack);
+                sourceSpSections = GetSpSectionsFromDifficulty(selfInstrumentDifficulty);
+                foundSelf = true;
+            }
+
+            if (!foundSelf && TryFindTrackForInstrument(instrument, chart.DrumsTracks, out var drumsTrack))
+            {
+                var selfInstrumentDifficulty = GetAnyInstrumentDifficulty(drumsTrack);
+                sourceSpSections = GetSpSectionsFromDifficulty(selfInstrumentDifficulty);
+                foundSelf = true;
+            }
+
+            if (!foundSelf && TryFindTrackForInstrument(instrument, chart.SixFretTracks, out var sixFretTrack))
+            {
+                var selfInstrumentDifficulty = GetAnyInstrumentDifficulty(sixFretTrack);
+                sourceSpSections = GetSpSectionsFromDifficulty(selfInstrumentDifficulty);
+                foundSelf = true;
+            }
+
+            if (!foundSelf && TryFindTrackForInstrument(instrument, chart.ProGuitarTracks, out var proGuitarTrack))
+            {
+                var selfInstrumentDifficulty = GetAnyInstrumentDifficulty(proGuitarTrack);
+                sourceSpSections = GetSpSectionsFromDifficulty(selfInstrumentDifficulty);
+                foundSelf = true;
+            }
+
+            if (!foundSelf && chart.ProKeys.Instrument == instrument)
+            {
+                var selfInstrumentDifficulty = GetAnyInstrumentDifficulty(chart.ProKeys);
+                sourceSpSections = GetSpSectionsFromDifficulty(selfInstrumentDifficulty);
+                foundSelf = true;
+            }
+
+            if (!foundSelf)
+            {
+                YargLogger.LogFormatError("Could not find any instrument difficulty for {0}", instrument);
+                return phrases;
+            }
+
+            // Add ourselves to the beginning of the accepted list so any dupes with us will be filtered
+            acceptedSpSections.Add(sourceSpSections);
+
+            GetSpSectionsFromCharts(chart.FiveFretTracks, ref acceptedSpSections, instrument);
+            GetSpSectionsFromCharts(chart.SixFretTracks, ref acceptedSpSections, instrument);
+            GetSpSectionsFromCharts(chart.DrumsTracks, ref acceptedSpSections, instrument);
+            GetSpSectionsFromCharts(chart.ProGuitarTracks, ref acceptedSpSections, instrument);
+
+            if (chart.ProKeys.Instrument != instrument)
+            {
+                var proKeysDifficulty = GetAnyInstrumentDifficulty(chart.ProKeys);
+                var candidateSpSections = GetSpSectionsFromDifficulty(proKeysDifficulty);
+                if (!SpListIsDuplicate(candidateSpSections, acceptedSpSections))
+                {
+                    acceptedSpSections.Add(candidateSpSections);
+                }
+            }
+
+            // Now we delete self from the accepted list to ensure we don't match against self
+            acceptedSpSections.Remove(sourceSpSections);
+
+            // Unpack all the accepted sp sections into othersSpSections
+            foreach (var section in acceptedSpSections)
+            {
+                othersSpSections.AddRange(section);
+            }
+
+            // Now that we have all the SP sections, compare them
+            foreach (var section in othersSpSections)
+            {
+                if (sourceSpSections.Contains(section) && !outSpSections.Contains(section))
+                {
+                    outSpSections.Add(section);
+                }
+            }
+
+            // Build the phrase list we actually want to return
+            foreach (var section in outSpSections)
+            {
+                phrases.Add(section.PhraseRef);
+            }
+
+            return phrases;
+
+            // Thus begins a parade of helper functions
+
+            static bool TryFindTrackForInstrument<TNote>(Instrument instrument,
+                IEnumerable<InstrumentTrack<TNote>> trackEnumerable, out InstrumentTrack<TNote> instrumentTrack) where TNote : Note<TNote>
+            {
+                foreach (var track in trackEnumerable)
+                {
+                    if (track.Instrument == instrument)
+                    {
+                        instrumentTrack = track;
+                        return true;
+                    }
+                }
+
+                instrumentTrack = null;
+                return false;
+            }
+
+            // Gets the StarPower sections from a list of charts, excluding a specific instrument
+            static void GetSpSectionsFromCharts<TNote>(IEnumerable<InstrumentTrack<TNote>> tracks,
+                ref List<List<StarPowerSection>> acceptedSpSections,
+                Instrument instrument) where TNote : Note<TNote>
+            {
+                foreach (var track in tracks)
+                {
+                    if (track.Instrument == instrument)
+                    {
+                        continue;
+                    }
+                    var instrumentDifficulty = GetAnyInstrumentDifficulty(track);
+                    var candidateSpSections = GetSpSectionsFromDifficulty(instrumentDifficulty);
+                    if (!SpListIsDuplicate(candidateSpSections, acceptedSpSections))
+                    {
+                        acceptedSpSections.Add(candidateSpSections);
+                    }
+                }
+            }
+
+            static List<StarPowerSection> GetSpSectionsFromDifficulty<TNote>(InstrumentDifficulty<TNote> difficulty) where TNote : Note<TNote>
+            {
+                var spSections = new List<StarPowerSection>();
+                foreach (var phrase in difficulty.Phrases)
+                {
+                    if (phrase.Type == PhraseType.StarPower)
+                    {
+                        spSections.Add(new StarPowerSection(phrase.Time, phrase.TimeEnd, phrase));
+                    }
+                }
+                return spSections;
+            }
+
+            static bool SpListIsDuplicate(List<StarPowerSection> proposed, List<List<StarPowerSection>> accepted)
+            {
+                foreach (var sections in accepted)
+                {
+                    if (proposed.Count != sections.Count)
+                    {
+                        continue;
+                    }
+
+                    // Count is the same, so it could be a dupe
+                    var dupeCount = 0;
+                    for (var i = 0; i < sections.Count; i++)
+                    {
+                        if (!proposed[i].Equals(sections[i]))
+                        {
+                            break;
+                        }
+                        dupeCount++;
+                    }
+
+                    if (dupeCount == sections.Count)
+                    {
+                        YargLogger.LogDebug("Found duplicate star power list");
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            static InstrumentDifficulty<TNote> GetAnyInstrumentDifficulty<TNote>(InstrumentTrack<TNote> instrumentTrack) where TNote : Note<TNote>
+            {
+                // We don't care what difficulty, so we return the first one we find
+                foreach (var difficulty in Enum.GetValues(typeof(Difficulty)))
+                {
+                    if (instrumentTrack.TryGetDifficulty((Difficulty) difficulty, out var instrumentDifficulty))
+                    {
+                        return instrumentDifficulty;
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        public void StarPowerPhraseHit(BaseEngine engine, double time)
+        {
+            var container = GetEngineContainer(engine);
+            // Find the relevant unison and increment its SuccessCount
+            foreach (var unison in _unisonEvents)
+            {
+                // The engine's conception of SP phrases for each instrument end at different times,
+                // so an exact match is impossible even though the phrases have identical times
+                if (unison.Time < time && time < unison.TimeEnd)
+                {
+                    if (unison.Success(container))
+                    {
+                        // Success returned true, so all the other players
+                        // were also successful
+                        YargLogger.LogDebug("EngineManager bonus SP award triggered");
+                        AwardStarPowerBonus(unison);
+                    }
+                }
+            }
+        }
+
+        // TODO: Figure out how to actually award the bonus SP
+        private void AwardStarPowerBonus(UnisonEvent unison)
+        {
+            if (unison.Awarded)
+            {
+                YargLogger.LogDebug("Attempted to award bonus SP, but it was already awarded");
+                return;
+            }
+            foreach (var id in unison.ParticipantIds)
+            {
+                YargLogger.LogFormatDebug("EngineManager (would be) awarding bonus SP to participant ID {0}", id);
+                var engine = _allEnginesById[id].Engine;
+                // engine.GainStarPower(engine.TicksPerQuarterSpBar);
+                OnUnisonPhraseSuccess?.Invoke();
+            }
+            unison.Awarded = true;
+        }
+
+        private void IncreaseBandMultiplier()
+        {
+            foreach (var container in _allEngines)
+            {
+                // var input = new GameInput(container.Engine.CurrentTime, (int) BandAction.StepMultiplier, true);
+            }
+        }
+
+        private void DecreaseBandMultiplier()
+        {
+            foreach (var container in _allEngines)
+            {
+                // var input = new GameInput(container.Engine.CurrentTime, (int) BandAction.StepMultiplier, false);
+            }
+        }
+
+        public List<UnisonEvent>? GetUnisonEvents()
+        {
+            if (_unisonsReady)
+            {
+                return _unisonEvents;
+            }
+
+            return null;
+        }
+    }
+}

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -18,7 +18,7 @@ namespace YARG.Core.Engine
             public int       PartCount      { get; private set; }
             public int       SuccessCount   { get; private set; }
             public bool      Awarded        { get; set; }
-            public List<int> ParticipantIds { get; private set; }
+            public List<int> ParticipantIds { get; }
 
             public bool Equals(UnisonEvent other) => Time.Equals(other.Time) && TimeEnd.Equals(other.TimeEnd);
 
@@ -175,42 +175,58 @@ namespace YARG.Core.Engine
             var foundSelf = false;
 
             // Find a track that corresponds to the player's instrument
-            if(TryFindTrackForInstrument(instrument, chart.FiveFretTracks, out var fiveFretTrack))
+            if (TryFindTrackForInstrument(instrument, chart.FiveFretTracks, out var fiveFretTrack))
             {
-                // var selfInstrumentDifficulty = GetAnyInstrumentDifficulty(fiveFretTrack);
-                // sourceSpSections = GetSpSectionsFromDifficulty(selfInstrumentDifficulty);
-                sourceSpSections = fiveFretTrack.FirstDifficulty().GetStarpowerSections();
-                foundSelf = true;
+                if (fiveFretTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
+                {
+                    sourceSpSections = difficulty.GetStarpowerSections();
+                    foundSelf = true;
+                }
             }
 
             if (!foundSelf && TryFindTrackForInstrument(instrument, chart.DrumsTracks, out var drumsTrack))
             {
-                sourceSpSections = drumsTrack.FirstDifficulty().GetStarpowerSections();
-                foundSelf = true;
+                if (drumsTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
+                {
+                    sourceSpSections = difficulty.GetStarpowerSections();
+                    foundSelf = true;
+                }
             }
 
             if (!foundSelf && TryFindTrackForInstrument(instrument, chart.SixFretTracks, out var sixFretTrack))
             {
-                sourceSpSections = sixFretTrack.FirstDifficulty().GetStarpowerSections();
-                foundSelf = true;
+                if (sixFretTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
+                {
+                    sourceSpSections = difficulty.GetStarpowerSections();
+                    foundSelf = true;
+                }
             }
 
             if (!foundSelf && TryFindTrackForInstrument(instrument, chart.ProGuitarTracks, out var proGuitarTrack))
             {
-                sourceSpSections = proGuitarTrack.FirstDifficulty().GetStarpowerSections();
-                foundSelf = true;
+                if (proGuitarTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
+                {
+                    sourceSpSections = difficulty.GetStarpowerSections();
+                    foundSelf = true;
+                }
             }
 
             if (!foundSelf && chart.ProKeys.Instrument == instrument)
             {
-                sourceSpSections = chart.ProKeys.FirstDifficulty().GetStarpowerSections();
-                foundSelf = true;
+                if (chart.ProKeys.TryGetAnyInstrumentDifficulty(out var difficulty))
+                {
+                    sourceSpSections = difficulty.GetStarpowerSections();
+                    foundSelf = true;
+                }
             }
 
             if (!foundSelf && chart.Keys.Instrument == instrument)
             {
-                sourceSpSections = chart.Keys.FirstDifficulty().GetStarpowerSections();
-                foundSelf = true;
+                if (chart.Keys.TryGetAnyInstrumentDifficulty(out var difficulty))
+                {
+                    sourceSpSections = difficulty.GetStarpowerSections();
+                    foundSelf = true;
+                }
             }
 
             if (!foundSelf)
@@ -312,7 +328,7 @@ namespace YARG.Core.Engine
         {
             foreach (var container in _allEngines)
             {
-                // var input = new GameInput(container.Engine.CurrentTime, (int) BandAction.StepMultiplier, true);
+
             }
         }
 
@@ -320,18 +336,8 @@ namespace YARG.Core.Engine
         {
             foreach (var container in _allEngines)
             {
-                // var input = new GameInput(container.Engine.CurrentTime, (int) BandAction.StepMultiplier, false);
-            }
-        }
 
-        public List<UnisonEvent>? GetUnisonEvents()
-        {
-            if (_unisonsReady)
-            {
-                return _unisonEvents;
             }
-
-            return null;
         }
     }
 }

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -76,6 +76,11 @@ namespace YARG.Core.Engine
                 // TODO: Make sure it doesn't matter whether this is note.Time or Engine.CurrentTime
                 _engineManager.OnStarPowerPhraseHit(this, Engine.CurrentTime);
             }
+
+            public void UpdateEngine(double time)
+            {
+                Engine.Update(time);
+            }
         }
 
         public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, SongChart chart)
@@ -99,6 +104,14 @@ namespace YARG.Core.Engine
                 }
             }
             throw new ArgumentException("Target engine not found");
+        }
+
+        public void UpdateEngines(double time)
+        {
+            foreach (var engine in _allEngines)
+            {
+                engine.UpdateEngine(time);
+            }
         }
     }
 }

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -73,8 +73,7 @@ namespace YARG.Core.Engine
 
             public void OnStarPowerPhraseHit<TNote>(TNote note) where TNote : Note<TNote>
             {
-                // TODO: Make sure it doesn't matter whether this is note.Time or Engine.CurrentTime
-                _engineManager.OnStarPowerPhraseHit(this, Engine.CurrentTime);
+                _engineManager.OnStarPowerPhraseHit(this, note.Time);
             }
 
             public void UpdateEngine(double time)

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using YARG.Core.Chart;
+using YARG.Core.Logging;
+
+namespace YARG.Core.Engine
+{
+    // Tracks and instantiates engines, handles IPC between engines, and events that affect multiple engines
+    public partial class EngineManager
+    {
+        private int _nextEngineIndex;
+        List <EngineContainer> _allEngines = new();
+        Dictionary<int, EngineContainer> _allEnginesById = new();
+
+        public class Band
+        {
+            public List<EngineContainer> Engines { get; private set; }
+            public int Score { get; private set; }
+
+            private Band()
+            {
+                Engines = new List<EngineContainer>();
+                Score = 0;
+            }
+        }
+
+        public class EngineContainer
+        {
+            public  int          EngineId      { get; }
+            public  BaseEngine   Engine        { get; }
+            private Instrument   Instrument    { get; }
+            private SongChart    SongChart     { get; }
+            public  List<Phrase> UnisonPhrases { get; }
+
+            public EngineContainer(BaseEngine engine, Instrument instrument, SongChart songChart, int engineId)
+            {
+                EngineId = engineId;
+                Engine = engine;
+                Instrument = instrument;
+                SongChart = songChart;
+                UnisonPhrases = GetUnisonPhrases(Instrument, SongChart);
+            }
+        }
+
+        public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, SongChart chart)
+            where TEngineType : BaseEngine
+        {
+            var engineContainer = new EngineContainer(engine, instrument, chart, _nextEngineIndex++);
+
+            _allEngines.Add(engineContainer);
+            _allEnginesById.Add(engineContainer.EngineId, engineContainer);
+            AddPlayerToUnisons(engineContainer);
+
+            return engineContainer;
+        }
+        private EngineContainer GetEngineContainer(BaseEngine target)
+        {
+            foreach (var engine in _allEngines)
+            {
+                if (engine.Engine == target)
+                {
+                    return engine;
+                }
+            }
+            throw new ArgumentException("Target engine not found");
+        }
+    }
+}

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using YARG.Core.Chart;
-using YARG.Core.Logging;
 
 namespace YARG.Core.Engine
 {
@@ -93,6 +92,7 @@ namespace YARG.Core.Engine
 
             return engineContainer;
         }
+
         private EngineContainer GetEngineContainer(BaseEngine target)
         {
             foreach (var engine in _allEngines)

--- a/YARG.Core/Extensions/ChartExtensions.cs
+++ b/YARG.Core/Extensions/ChartExtensions.cs
@@ -28,7 +28,13 @@ namespace YARG.Core.Extensions
                 {
                     continue;
                 }
-                var instrumentDifficulty = GetAnyInstrumentDifficulty(track);
+
+
+                if (!TryGetAnyInstrumentDifficulty(track, out var instrumentDifficulty))
+                {
+                    continue;
+                }
+
                 var candidateSpSections = GetStarpowerSections(instrumentDifficulty);
                 if (!SpListIsDuplicate(candidateSpSections, acceptedSpSections))
                 {
@@ -56,7 +62,12 @@ namespace YARG.Core.Extensions
             {
                 return;
             }
-            var instrumentDifficulty = GetAnyInstrumentDifficulty(track);
+
+            if (!TryGetAnyInstrumentDifficulty(track, out var instrumentDifficulty))
+            {
+                return;
+            }
+
             var candidateSpSections = GetStarpowerSections(instrumentDifficulty);
             if (!SpListIsDuplicate(candidateSpSections, acceptedSpSections))
             {
@@ -108,18 +119,21 @@ namespace YARG.Core.Extensions
             return false;
         }
 
-        private static InstrumentDifficulty<TNote> GetAnyInstrumentDifficulty<TNote>(this InstrumentTrack<TNote> instrumentTrack) where TNote : Note<TNote>
+        public static bool TryGetAnyInstrumentDifficulty<TNote>(
+            this InstrumentTrack<TNote> instrumentTrack, out InstrumentDifficulty<TNote>? ret) where TNote : Note<TNote>
         {
             // We don't care what difficulty, so we return the first one we find
             foreach (var difficulty in Enum.GetValues(typeof(Difficulty)))
             {
                 if (instrumentTrack.TryGetDifficulty((Difficulty) difficulty, out var instrumentDifficulty))
                 {
-                    return instrumentDifficulty;
+                    ret = instrumentDifficulty;
+                    return true;
                 }
             }
 
-            return null;
+            ret = null;
+            return false;
         }
     }
 }

--- a/YARG.Core/Extensions/ChartExtensions.cs
+++ b/YARG.Core/Extensions/ChartExtensions.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+
+namespace YARG.Core.Extensions
+{
+    public static class ChartExtensions
+    {
+
+        // Gets the StarPower sections from a list of instrument tracks, excluding a specific instrument and anything in its group
+        public static void GetStarpowerSections<TNote>(this IEnumerable<InstrumentTrack<TNote>> tracks,
+            ref List<List<EngineManager.StarPowerSection>> acceptedSpSections,
+            Instrument instrument) where TNote : Note<TNote>
+        {
+            var instrumentGroup = new List<Instrument>();
+            foreach (var group in EngineManager.InstrumentGroups)
+            {
+                if (group.Contains(instrument))
+                {
+                    instrumentGroup = group;
+                    break;
+                }
+            }
+            foreach (var track in tracks)
+            {
+                if (instrumentGroup.Contains(track.Instrument))
+                {
+                    continue;
+                }
+                var instrumentDifficulty = GetAnyInstrumentDifficulty(track);
+                var candidateSpSections = GetStarpowerSections(instrumentDifficulty);
+                if (!SpListIsDuplicate(candidateSpSections, acceptedSpSections))
+                {
+                    acceptedSpSections.Add(candidateSpSections);
+                }
+            }
+        }
+
+        // Gets the starpower sections from a single InstrumentTrack, excluding the given instrument
+        public static void GetStarpowerSections<TNote>(this InstrumentTrack<TNote> track,
+            ref List<List<EngineManager.StarPowerSection>> acceptedSpSections,
+            Instrument instrument) where TNote : Note<TNote>
+        {
+            var instrumentGroup = new List<Instrument>();
+            foreach (var group in EngineManager.InstrumentGroups)
+            {
+                if (group.Contains(instrument))
+                {
+                    instrumentGroup = group;
+                    break;
+                }
+            }
+
+            if (instrumentGroup.Contains(track.Instrument))
+            {
+                return;
+            }
+            var instrumentDifficulty = GetAnyInstrumentDifficulty(track);
+            var candidateSpSections = GetStarpowerSections(instrumentDifficulty);
+            if (!SpListIsDuplicate(candidateSpSections, acceptedSpSections))
+            {
+                acceptedSpSections.Add(candidateSpSections);
+            }
+        }
+
+        // Gets the starpower sections from an InstrumentDifficulty
+        public static List<EngineManager.StarPowerSection> GetStarpowerSections<TNote>(
+            this InstrumentDifficulty<TNote> difficulty) where TNote : Note<TNote>
+        {
+            var spSections = new List<EngineManager.StarPowerSection>();
+            foreach (var phrase in difficulty.Phrases)
+            {
+                if (phrase.Type == PhraseType.StarPower)
+                {
+                    spSections.Add(new EngineManager.StarPowerSection(phrase.Time, phrase.TimeEnd, phrase));
+                }
+            }
+            return spSections;
+        }
+
+        private static bool SpListIsDuplicate(List<EngineManager.StarPowerSection> proposed,
+            List<List<EngineManager.StarPowerSection>> accepted)
+        {
+            foreach (var sections in accepted)
+            {
+                if (proposed.Count != sections.Count)
+                {
+                    continue;
+                }
+
+                // Count is the same, so it could be a dupe
+                var dupeCount = 0;
+                for (var i = 0; i < sections.Count; i++)
+                {
+                    if (!proposed[i].Equals(sections[i]))
+                    {
+                        break;
+                    }
+                    dupeCount++;
+                }
+
+                if (dupeCount == sections.Count)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static InstrumentDifficulty<TNote> GetAnyInstrumentDifficulty<TNote>(this InstrumentTrack<TNote> instrumentTrack) where TNote : Note<TNote>
+        {
+            // We don't care what difficulty, so we return the first one we find
+            foreach (var difficulty in Enum.GetValues(typeof(Difficulty)))
+            {
+                if (instrumentTrack.TryGetDifficulty((Difficulty) difficulty, out var instrumentDifficulty))
+                {
+                    return instrumentDifficulty;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
+++ b/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
@@ -145,7 +145,6 @@ namespace YARG.Core.Replays.Analyzer
         {
             var engines = new List<BaseEngine>();
             var manager = new EngineManager();
-            // I don't think the engines will break if their update time goes beyond their last input
             double maxTime = 0;
             var results = new List<AnalysisResult>();
             foreach (var frame in frames)
@@ -168,9 +167,6 @@ namespace YARG.Core.Replays.Analyzer
                 maxTime += 2;
             }
 
-            // TODO: Figure out why we're failing the participant count assertion in UnisonEvent
-            //  when bonus SP is being awarded. (Validation succeeds, though, so it's not awarding extra SP in the replay)
-
             // Seems like a sensible default?
             _fps = _fps > 0 ? _fps : 60;
             int currentInput = 0;
@@ -184,15 +180,12 @@ namespace YARG.Core.Replays.Analyzer
                         {
                             break;
                         }
-
+                        // TODO: Consider running this through EngineManager as well
                         engines[i].QueueInput(ref input);
                     }
                 }
 
-                foreach (var engine in engines)
-                {
-                    engine.Update(time);
-                }
+                manager.UpdateEngines(time);
             }
 
             for (var i = 0; i < frames.Count; i++)


### PR DESCRIPTION
This adds an EngineManager class that will eventually award unison star power bonuses, track band multipliers, and whatever else can't be done within a single engine.

Remaining tasks:

- [x] Actually award bonus star power on successful unison completion.
~~- [ ] Track band score separately from individual scores~~
~~- [ ] Track band multipliers and award extra band score~~
- [x] Rework replay code as necessary to accommodate star power bonuses

Since this doesn't involve changes to the engines themselves, I don't believe this needs to be based on engine-fixes.