### PR TITLE
Move practice section parsing to YARG

### DIFF
--- a/YARG.Core/Parsing/TextEvents.cs
+++ b/YARG.Core/Parsing/TextEvents.cs
@@ -89,7 +89,6 @@ namespace YARG.Core.Parsing
         /// <returns>
         /// True if the event was parsed successfully, false otherwise.
         /// </returns>
-        // Equivalent to reading the capture of this regex: (?:section|prc)[ _](.*)
         public static bool TryParseSectionEvent(ReadOnlySpan<char> text, out ReadOnlySpan<char> name)
         {
             name = ReadOnlySpan<char>.Empty;
@@ -97,17 +96,14 @@ namespace YARG.Core.Parsing
             const string SECTION_PREFIX = "section";
             const string PRC_PREFIX = "prc";
 
-            // Remove event prefix
-            if (text.StartsWith(SECTION_PREFIX))
-                text = text[SECTION_PREFIX.Length..];
-            else if (text.StartsWith(PRC_PREFIX))
-                text = text[PRC_PREFIX.Length..];
+            // Check event prefix
+            if (text.StartsWith(SECTION_PREFIX) || text.StartsWith(PRC_PREFIX))
+            {
+                name = text;
+                return true;
+            }
             else
                 return false;
-
-            // Isolate section name
-            name = text.TrimStart('_').Trim();
-            return !name.IsEmpty;
         }
 
         /// <summary>


### PR DESCRIPTION
**Requires YARG PR 950**

Removes transformation logic from practice section parsing. My other PR moves that logic to YARG, where it can take advantage of localization. YARG.Core now simply checks whether the event begins with `prc` or `section` and, if so, passes it unedited to YARG.