### PR TITLE
Allow Bots to use Star Power (Bodge)

### DIFF
--- a/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
@@ -353,7 +353,7 @@ namespace YARG.Core.Engine.ProKeys.Engines
                 // Activate Star Power if it's available
                 if (EngineStats.CanStarPowerActivate)
                 {
-                    MutateStateWithInput(new GameInput(time, ProKeysAction.StarPower, true));
+                    MutateStateWithInput(new GameInput(note.Time, ProKeysAction.StarPower, true));
                     ActivateStarPower();
                 }
             }

--- a/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
@@ -332,25 +332,19 @@ namespace YARG.Core.Engine.ProKeys.Engines
                 return;
             }
 
-            // Disables keys that are not in the current note
-            int key = 0;
-            for (var mask = KeyMask; mask > 0; mask >>= 1)
-            {
-                if ((mask & 1) == 1)
-                {
-                    MutateStateWithInput(new GameInput(note.Time, key, false));
-                }
-
-                key++;
-            }
-
-
             // Press keys for current note
             foreach (var chordNote in note.AllNotes)
             {
                 MutateStateWithInput(new GameInput(note.Time, chordNote.Key, true));
                 CheckForNoteHit();
+                // Activate Star Power if it's available
+                if (EngineStats.CanStarPowerActivate)
+                {
+                    MutateStateWithInput(new GameInput(time, ProKeysAction.StarPower, true));
+                    ActivateStarPower();
+                }
             }
         }
+
     }
 }

--- a/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
@@ -332,6 +332,19 @@ namespace YARG.Core.Engine.ProKeys.Engines
                 return;
             }
 
+            // Disables keys that are not in the current note
+            int key = 0;
+            for (var mask = KeyMask; mask > 0; mask >>= 1)
+            {
+                if ((mask & 1) == 1)
+                {
+                    MutateStateWithInput(new GameInput(note.Time, key, false));
+                }
+
+                key++;
+            }
+
+
             // Press keys for current note
             foreach (var chordNote in note.AllNotes)
             {
@@ -345,6 +358,5 @@ namespace YARG.Core.Engine.ProKeys.Engines
                 }
             }
         }
-
     }
 }


### PR DESCRIPTION
This PR is a first attempt at allowing bots to use Star Power. While it might not be the cleanest solution, it serves as a proof of concept to (hopefully) allow others to contribute.

What this PR Contains:

- A (hopefully functional) fix for bots to use Star Power, via copy-pasting the functions necessary into the bot function with minimal if-statements. This does not have "smart" usage, just usage.

Steps taken to check compatibility:

- No direct testing yet (I don't know how to build from source yet).
- However, at worst, this should only crash the game, rather than cause a build failure.

Why did I make this PR:

- Multiple people have requested bots be able to use Star-Power
- I thought of this surface-level solution, and wanted to at least PR _something_.

If this works, great. If it doesn’t, well, at least it’s a starting point for someone more competent to come in and clean it up.
