### PR TITLE
Active Profile reordering

### DIFF
--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -24,7 +24,6 @@ namespace YARG.Core.Game
 
         public bool LeftyFlip;
 
-        public bool AutoConnect;
         public int? AutoConnectOrder;
 
         public long InputCalibrationMilliseconds;
@@ -83,7 +82,6 @@ namespace YARG.Core.Game
             NoteSpeed = 6;
             HighwayLength = 1;
             LeftyFlip = false;
-            AutoConnect = false;
 
             // Set preset IDs to default
             ColorProfile = Game.ColorProfile.Default.Id;

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -25,6 +25,7 @@ namespace YARG.Core.Game
         public bool LeftyFlip;
 
         public bool AutoConnect;
+        public int? AutoConnectOrder;
 
         public long InputCalibrationMilliseconds;
         public double InputCalibrationSeconds


### PR DESCRIPTION
This PR replaces one property in YargProfile: AutoConnect -> AutoConnectOrder. This is used to keep track of the order of active profiles so that they can be reconnected in the proper order when the game is closed and restarted.