### PR TITLE
Improve Pro Keys bot

### DIFF
--- a/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
@@ -327,16 +327,20 @@ namespace YARG.Core.Engine.ProKeys.Engines
 
             var note = Notes[NoteIndex];
 
-            if (time < note.Time)
-            {
-                return;
-            }
-
-            // Disables keys that are not in the current note
+            // Release keys that are not associated with an active sustain
             int key = 0;
             for (var mask = KeyMask; mask > 0; mask >>= 1)
             {
-                if ((mask & 1) == 1)
+                bool keySustained = false;
+                for (var i = 0; i < ActiveSustains.Count; i++)
+                {
+                    if (ActiveSustains[i].Note.Key == key)
+                    {
+                        keySustained = true;
+                        break;
+                    }
+                }
+                if ((mask & 1) == 1 && !keySustained)
                 {
                     MutateStateWithInput(new GameInput(note.Time, key, false));
                 }
@@ -344,6 +348,12 @@ namespace YARG.Core.Engine.ProKeys.Engines
                 key++;
             }
 
+            // TODO: Verify the above doesn't break when the gap between a sustain and the next note gets too small
+
+            if (time < note.Time)
+            {
+                return;
+            }
 
             // Press keys for current note
             foreach (var chordNote in note.AllNotes)

--- a/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
@@ -332,7 +332,7 @@ namespace YARG.Core.Engine.ProKeys.Engines
         {
             float        botNoteHoldTime = 0.166f;
             ProKeysNote? note = null;
-            bool[]       keysInSustain = new bool[(int) ProKeysAction.Key25 + 1];
+            int          keysInSustain = 0;
 
             if (!IsBot)
             {
@@ -347,7 +347,7 @@ namespace YARG.Core.Engine.ProKeys.Engines
             // Find the active sustains
             foreach (var sustain in ActiveSustains)
             {
-                keysInSustain[sustain.Note.Key] = true;
+                keysInSustain |= 1 << sustain.Note.Key;
             }
 
             // Release no longer needed keys
@@ -374,7 +374,7 @@ namespace YARG.Core.Engine.ProKeys.Engines
 
                 if (!currentKey)
                 {
-                    if (keysInSustain[key])
+                    if ((keysInSustain & 1 << key) != 0)
                     {
                         keyProtected = true;
                     }
@@ -399,7 +399,7 @@ namespace YARG.Core.Engine.ProKeys.Engines
                     }
 
                     // if the key isn't protected due to a sustain and another note is being played, release the key
-                    if (note is not null && !keysInSustain[key] && time >= note.Time)
+                    if (note is not null && (keysInSustain & 1 << key) == 0 && time >= note.Time)
                     {
                         keyProtected = false;
                     }
@@ -412,7 +412,7 @@ namespace YARG.Core.Engine.ProKeys.Engines
                     // We loop to ensure that all notes in a chord are released at the same time
                     foreach (var chordNote in pressedNote.AllNotes)
                     {
-                        if (!keysInSustain[chordNote.Key])
+                        if ((keysInSustain & 1 << chordNote.Key) == 0)
                         {
                             MutateStateWithInput(new GameInput(time, chordNote.Key, false));
                         }

--- a/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
@@ -331,7 +331,13 @@ namespace YARG.Core.Engine.ProKeys.Engines
             int key = 0;
             for (var mask = KeyMask; mask > 0; mask >>= 1)
             {
+                // If it is a sustain, we do not drop
                 bool keySustained = false;
+                // Don't drop keys if the last note was within 166ms
+                bool keyTooRecent = false;
+                // We do drop the key if the note we're processing is on this key
+                bool currentKey = false;
+
                 for (var i = 0; i < ActiveSustains.Count; i++)
                 {
                     if (ActiveSustains[i].Note.Key == key)
@@ -340,7 +346,14 @@ namespace YARG.Core.Engine.ProKeys.Engines
                         break;
                     }
                 }
-                if ((mask & 1) == 1 && !keySustained)
+
+                // C# does shortcut, right?
+                keyTooRecent = NoteIndex > 0 && Notes[NoteIndex - 1].Time > CurrentTime - 0.166f;
+
+                // TODO: Do child notes need to be checked here?
+                currentKey = time >= note.Time && note.Key == key;
+
+                if ((mask & 1) == 1 && ((!keySustained && !keyTooRecent) || currentKey))
                 {
                     MutateStateWithInput(new GameInput(note.Time, key, false));
                 }


### PR DESCRIPTION
This PR modifies the pro keys bot in two ways.

Firstly, a bug that causes extended sustains to be dropped is fixed.

Secondly, the bot to is changed to release pressed keys 166ms after being pressed unless certain conditions are met.

The conditions that modify the key hold time are:
- Sustains are held for as long as they continue
- If the key is being played again it is released at half the time between the last press and next note
- ~~When the last note(s) have been played, any pressed keys are held for 1.6 seconds.~~

Note that a new field called _keyPressTimes is added to YargProKeysEngine. This may seem duplicative of the existing KeyPressTimes on ProKeysEngine, but that one is unsuitable for this purpose because it is updated on both press and release and is sometimes modified by hit logic.

As for the why, the reason for the first change is obvious. The second is because it makes me happy to have a bot that looks somewhat more natural to play with. Also, it will make future setlist wave preview videos look nicer.