### PR TITLE
Add NoPercussion vocal modifier

### DIFF
--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
@@ -41,5 +41,41 @@
                 vocalsTrack.NotePhrases[i] = newPhrase;
             }
         }
+
+        public static void RemoveAllPercussion(this VocalsPart vocalsTrack)
+        {
+            for (int i = 0; i < vocalsTrack.NotePhrases.Count; i++)
+            {
+                var phrase = vocalsTrack.NotePhrases[i];
+                var phraseParent = phrase.PhraseParentNote;
+
+                // Create a new phrase based off of the original one
+                var newPhraseParent = new VocalNote(phraseParent.Flags, phraseParent.Time,
+                    phraseParent.TimeLength, phraseParent.Tick, phraseParent.TickLength);
+
+                foreach (var note in phraseParent.ChildNotes)
+                {
+                    if (note.Type == VocalNoteType.Percussion)
+                    {
+                        continue;
+                    }
+
+                    newPhraseParent.AddChildNote(note);
+                }
+
+                // Replace the next and previous note values
+                if (i - 1 >= 0)
+                {
+                    var lastPhrase = vocalsTrack.NotePhrases[i - 1];
+                    newPhraseParent.PreviousNote = lastPhrase.PhraseParentNote;
+                    lastPhrase.PhraseParentNote.NextNote = newPhraseParent;
+                }
+
+                // Replace the phrase
+                var newPhrase = new VocalsPhrase(phrase.Time, phrase.TimeLength, phrase.Tick, phrase.TickLength,
+                    newPhraseParent, phrase.Lyrics);
+                vocalsTrack.NotePhrases[i] = newPhrase;
+            }
+        }
     }
 }

--- a/YARG.Core/Game/Modifier.cs
+++ b/YARG.Core/Game/Modifier.cs
@@ -16,6 +16,7 @@ namespace YARG.Core.Game
         NoKicks       = 1 << 6,
         UnpitchedOnly = 1 << 7,
         NoDynamics    = 1 << 8,
+        NoPercussion  = 1 << 9,
     }
 
     public static class ModifierConflicts
@@ -51,7 +52,8 @@ namespace YARG.Core.Game
                     Modifier.NoDynamics,
 
                 GameMode.Vocals =>
-                    Modifier.UnpitchedOnly,
+                    Modifier.UnpitchedOnly |
+                    Modifier.NoPercussion,
 
                 GameMode.SixFretGuitar or
             //  GameMode.EliteDrums    or

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -211,6 +211,10 @@ namespace YARG.Core.Game
             {
                 vocalsPart.ConvertAllToUnpitched();
             }
+            if (IsModifierActive(Modifier.NoPercussion))
+            {
+                vocalsPart.RemoveAllPercussion();
+            }
         }
 
         public void EnsureValidInstrument()


### PR DESCRIPTION
Adds a modifier for vocals to remove percussion notes. Works similar to the "Unpitched Only" modifier, but keeps the notes pitch in-tact.

Issue: https://github.com/YARC-Official/YARG/issues/969