### PR TITLE
Add support for Ultrastar songs

### DIFF
--- a/TestConsole/CacheLoader.cs
+++ b/TestConsole/CacheLoader.cs
@@ -111,5 +111,20 @@ namespace YARG.TestConsole
 
             throw new Exception($"Cannot find song {songId}");
         }
+
+        public static SongEntry LoadUltrastar(SongCache cache, string directory)
+        {
+            Console.WriteLine($"Loading ultrastar song {directory}");
+            foreach (var node in cache.Entries.Values)
+            {
+                foreach (var entry in node)
+                {
+                    if (entry.SubType == EntryType.Ultrastar && entry.SortBasedLocation == directory)
+                        return entry;
+                }
+            }
+
+            throw new Exception($"Cannot find song {directory}");
+        }
     }
 }

--- a/TestConsole/Program.cs
+++ b/TestConsole/Program.cs
@@ -33,3 +33,9 @@ static SongChart LoadCONChart(string songId)
     return CacheLoader.LoadCON(CacheLoader.LoadCache(), songId)
         .LoadChart() ?? throw new Exception("Could not load chart!");
 }
+
+static SongChart LoadUltrastarChart(string directory)
+{
+    return CacheLoader.LoadUltrastar(CacheLoader.LoadCache(), directory)
+        .LoadChart() ?? throw new Exception("Could not load chart!");
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -5,6 +5,7 @@ using Melanchall.DryWetMidi.Core;
 using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
 using YARG.Core.Logging;
+using YARG.Core.MoonscraperChartParser.IO.Ultrastar;
 
 namespace YARG.Core.Chart
 {
@@ -42,6 +43,7 @@ namespace YARG.Core.Chart
             {
                 ".mid" => MidReader.ReadMidi(ref settings, filePath),
                 ".chart" => ChartReader.ReadFromFile(ref settings, filePath),
+                ".txt" => UltrastarReader.ReadFromFile(ref settings, filePath),
                 _ => throw new ArgumentException($"Unrecognized file extension for chart path '{filePath}'!", nameof(filePath))
             };
 
@@ -57,6 +59,12 @@ namespace YARG.Core.Chart
         public static MoonSongLoader LoadDotChart(ParseSettings settings, ReadOnlySpan<char> chartText)
         {
             var song = ChartReader.ReadFromText(ref settings, chartText);
+            return new(song, settings);
+        }
+
+        public static MoonSongLoader LoadUltrastar(ParseSettings settings, ReadOnlySpan<char> chartText)
+        {
+            var song = UltrastarReader.ReadFromText(ref settings, chartText);
             return new(song, settings);
         }
 

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -238,6 +238,12 @@ namespace YARG.Core.Chart
             return new(loader);
         }
 
+        public static SongChart FromUltrastar(in ParseSettings settings, ReadOnlySpan<char> chartText)
+        {
+            var loader = MoonSongLoader.LoadUltrastar(settings, chartText);
+            return new(loader);
+        }
+
         public InstrumentTrack<GuitarNote> GetFiveFretTrack(Instrument instrument)
         {
             return instrument switch

--- a/YARG.Core/IO/Ultrastar/SongUltrastarHandler.cs
+++ b/YARG.Core/IO/Ultrastar/SongUltrastarHandler.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace YARG.Core.IO.Ultrastar
+{
+    public enum UltrastarVersion
+    {
+        Unknown,
+        V1_0_0,
+        V1_1_0,
+        V1_2_0,
+        V2_0_0,
+    };
+
+    public static class SongUltrastarHandler
+    {
+        public static UltrastarModifierCollection ReadSongUltrastarFile(string ultrastarPath)
+        {
+            return YARGUltrastarReader.ReadUltrastarFile(ultrastarPath, SONG_ULTRASTAR_OUTLINES, SONG_ULTRASTAR_DEPRECATION_REPLACEMENTS);
+        }
+
+        public static UltrastarVersion ConvertVersionToEnum(string versionNumber)
+        {
+            string enumString = versionNumber.Replace(".", "_");
+
+            if (Enum.TryParse(enumString, out UltrastarVersion version))
+            {
+                return version;
+            }
+            else
+            {
+                return UltrastarVersion.Unknown;
+            }
+        }
+
+        public static string ConvertEnumToVersion(UltrastarVersion version)
+        {
+            return version.ToString().Replace("_", ".");
+        }
+
+        public static readonly Dictionary<string, UltrastarModifierOutline> SONG_ULTRASTAR_OUTLINES;
+        public static readonly Dictionary<string, string> SONG_ULTRASTAR_DEPRECATION_REPLACEMENTS;
+
+        static SongUltrastarHandler()
+        {
+            SONG_ULTRASTAR_OUTLINES = new()
+            {
+                {"#artist", new("artist", ModifierType.String) },
+                {"#audio", new("audio", ModifierType.String) },
+                {"#audiourl", new("audiourl", ModifierType.String) },
+                {"#background", new("background", ModifierType.String) },
+                {"#backgroundurl", new("backgroundurl", ModifierType.String) },
+                {"#bpm", new("bpm", ModifierType.Double) },
+                {"#cover", new("cover", ModifierType.String) },
+                {"#coverurl", new("coverurl", ModifierType.String) },
+                {"#creator", new("creator", ModifierType.String) },
+                {"#edition", new("edition", ModifierType.String) },
+                {"#end", new("end", ModifierType.Double) },
+                {"#gap", new("gap", ModifierType.Double) },
+                {"#genre", new("genre", ModifierType.String) },
+                {"#instrumental", new("instrumental", ModifierType.String) },
+                {"#language", new("language", ModifierType.String) },
+                {"#medleyend", new("medleyend", ModifierType.Double) },
+                {"#medleyendbeat", new("medleyendbeat", ModifierType.Double) },
+                {"#medleystart", new("medleystart", ModifierType.Double) },
+                {"#medleystartbeat", new("medleystartbeat", ModifierType.Double) },
+                {"#previewend", new("previewend", ModifierType.Double) },
+                {"#previewstart", new("previewstart", ModifierType.Double) },
+                {"#start", new("start", ModifierType.Double) },
+                {"#tags", new("tags", ModifierType.String) },
+                {"#title", new("title", ModifierType.String) },
+                {"#version", new("version", ModifierType.String) },
+                {"#video", new("video", ModifierType.String) },
+                {"#videourl", new("videourl", ModifierType.String) },
+                {"#videogap", new("artist", ModifierType.Double) },
+                {"#vocals", new("vocals", ModifierType.String) },
+                {"#year", new("year", ModifierType.String) },
+
+                // Deprecated tags
+                {"#mp3", new("audio", ModifierType.String) }, // Replaced by #audio
+                {"#website", new("audiourl", ModifierType.String) }, // Replaced by #audiourl
+                {"#instrumentalaudio", new("instrumental", ModifierType.String) }, // Replaced by #instrumental
+                {"#vocalsaudio", new("vocals", ModifierType.String) }, // Replaced by #vocals
+                {"#audiogap", new("gap", ModifierType.Double) }, // Replaced by #gap
+                {"#duetsingerp1", new("p1", ModifierType.String) }, // Replaced by #p1
+                {"#duetsingerp2", new("p2", ModifierType.String) }, // Replaced by #p2
+            };
+
+            SONG_ULTRASTAR_DEPRECATION_REPLACEMENTS = new()
+            {
+                {"#mp3", "#audio"},
+                {"#website", "#audiourl"},
+                {"#instrumentalaudio", "#instrumental"},
+                {"#vocalsaudio", "#vocals"},
+                {"#audiogap", "#gap"},
+                {"#duetsingerp1", "#p1"},
+                {"#duetsingerp2", "#duetsingerp2"},
+            };
+        }
+    }
+}

--- a/YARG.Core/IO/Ultrastar/UltrastarModifierCollection.cs
+++ b/YARG.Core/IO/Ultrastar/UltrastarModifierCollection.cs
@@ -1,0 +1,184 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace YARG.Core.IO.Ultrastar
+{
+    public enum ModifierType
+    {
+        None,
+        String,
+        UInt64,
+        Bool,
+        Double,
+    };
+
+    public readonly struct UltrastarModifierOutline
+    {
+        public readonly string Output;
+        public readonly ModifierType Type;
+
+        public UltrastarModifierOutline(string output, ModifierType type)
+        {
+            Output = output;
+            Type = type;
+        }
+    };
+
+    public class UltrastarModifierCollection
+    {
+        private Dictionary<string, string>? _strings;
+        private Dictionary<string, ulong>? _uint64s;
+        private Dictionary<string, bool>? _booleans;
+        private Dictionary<string, double>? _doubles;
+
+        public bool Contains(string key)
+        {
+            static bool DictContains<T>(Dictionary<string, T>? dict, string key)
+            {
+                return dict != null && dict.ContainsKey(key);
+            }
+
+            return DictContains(_strings, key)
+                || DictContains(_uint64s, key)
+                || DictContains(_booleans, key)
+                || DictContains(_doubles, key);
+        }
+
+        public void Add<TChar>(ref YARGTextContainer<TChar> container, in UltrastarModifierOutline outline, bool isChartFile)
+            where TChar : unmanaged, IConvertible
+        {
+            switch (outline.Type)
+            {
+                case ModifierType.String:
+                    _strings ??= new Dictionary<string, string>();
+                    _strings[outline.Output] = YARGTextReader.ExtractText(ref container, isChartFile);
+                    break;
+                case ModifierType.UInt64:
+                {
+                    if (!YARGTextReader.TryExtract(ref container, out ulong value))
+                    {
+                        value = 0;
+                    }
+                    _uint64s ??= new Dictionary<string, ulong>();
+                    _uint64s[outline.Output] = value;
+                    break;
+                }
+                case ModifierType.Bool:
+                    _booleans ??= new Dictionary<string, bool>();
+                    _booleans[outline.Output] = YARGTextReader.ExtractBoolean(in container, "yes");
+                    break;
+                case ModifierType.Double:
+                {
+                    if (!YARGTextReader.TryExtract(ref container, out double value))
+                    {
+                        value = 0;
+                    }
+                    _doubles ??= new Dictionary<string, double>();
+                    _doubles[outline.Output] = value;
+                    break;
+                }
+            }
+        }
+
+        public void Union(UltrastarModifierCollection source)
+        {
+            if (source._strings != null)
+            {
+                _strings ??= new Dictionary<string, string>();
+                foreach (var node in source._strings)
+                {
+                    if (!_strings.TryGetValue(node.Key, out string str) || string.IsNullOrEmpty(str))
+                    {
+                        _strings[node.Key] = node.Value;
+                    }
+                }
+            }
+
+            Union(ref _uint64s, source._uint64s);
+            Union(ref _booleans, source._booleans);
+            Union(ref _doubles, source._doubles);
+        }
+
+        public bool IsEmpty()
+        {
+            static bool DictEmpty<T>(Dictionary<string, T>? dict)
+            {
+                return dict == null || dict.Count == 0;
+            }
+
+            return DictEmpty(_strings)
+                && DictEmpty(_uint64s)
+                && DictEmpty(_booleans)
+                && DictEmpty(_doubles);
+        }
+
+        public bool Extract(string key, out string value)
+        {
+#if DEBUG
+            ThrowIfMismatch(key, ModifierType.String, "Mismatched modifier types - String requested");
+#endif
+            value = default!;
+            return _strings != null && _strings.Remove(key, out value);
+        }
+
+        public bool Extract(string key, out ulong value)
+        {
+#if DEBUG
+            ThrowIfMismatch(key, ModifierType.UInt64, "Mismatched modifier types - UInt64 requested");
+#endif
+            value = default!;
+            return _uint64s != null && _uint64s.Remove(key, out value);
+        }
+
+
+        public bool Extract(string key, out bool value)
+        {
+#if DEBUG
+            ThrowIfMismatch(key, ModifierType.Bool, "Mismatched modifier types - Boolean requested");
+#endif
+            value = default!;
+            return _booleans != null && _booleans.Remove(key, out value);
+        }
+
+        public bool Extract(string key, out double value)
+        {
+#if DEBUG
+            ThrowIfMismatch(key, ModifierType.Double, "Mismatched modifier types - Double requested");
+#endif
+            value = default!;
+            return _doubles != null && _doubles.Remove(key, out value);
+        }
+
+
+        private static void Union<TValue>(ref Dictionary<string, TValue>? dest, Dictionary<string, TValue>? source)
+            where TValue : unmanaged, IEquatable<TValue>
+        {
+            if (source != null)
+            {
+                dest ??= new Dictionary<string, TValue>();
+                foreach (var node in source)
+                {
+                    if (!dest.TryGetValue(node.Key, out var value) || value.Equals(default))
+                    {
+                        dest[node.Key] = node.Value;
+                    }
+                }
+            }
+        }
+
+#if DEBUG
+        private static Dictionary<string, ModifierType> _debugValidation = new();
+        private static void ThrowIfMismatch(string key, ModifierType type, string error)
+        {
+            lock (_debugValidation)
+            {
+                if (_debugValidation.TryGetValue(key, out var value) && value != type)
+                {
+                    throw new InvalidOperationException(error);
+                }
+                _debugValidation[key] = type;
+            }
+        }
+#endif
+    }
+}

--- a/YARG.Core/IO/Ultrastar/YargUltrastarReader.cs
+++ b/YARG.Core/IO/Ultrastar/YargUltrastarReader.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using YARG.Core.Logging;
+
+namespace YARG.Core.IO.Ultrastar
+{
+    public static class YARGUltrastarReader
+    {
+        public static UltrastarModifierCollection ReadUltrastarFile(string ultrastarPath, Dictionary<string, UltrastarModifierOutline> outlines, Dictionary<string, string> deprecations)
+        {
+            try
+            {
+                using var bytes = FixedArray.LoadFile(ultrastarPath);
+                if (YARGTextReader.TryUTF8(in bytes, out var byteContainer))
+                {
+                    return ProcessUltrastar(ref byteContainer, outlines, deprecations);
+                }
+
+                using var chars = YARGTextReader.TryUTF16Cast(in bytes);
+                if (chars.IsAllocated)
+                {
+                    var charContainer = YARGTextReader.CreateUTF16Container(in chars);
+                    return ProcessUltrastar(ref charContainer, outlines, deprecations);
+                }
+
+                using var ints = YARGTextReader.CastUTF32(in bytes);
+                var intContainer = YARGTextReader.CreateUTF32Container(in ints);
+                return ProcessUltrastar(ref intContainer, outlines, deprecations);
+
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogException(ex, ex.Message);
+                return new();
+            }
+        }
+
+        private static UltrastarModifierCollection ProcessUltrastar<TChar>(ref YARGTextContainer<TChar> container, Dictionary<string, UltrastarModifierOutline> outlines, Dictionary<string, string> deprecations)
+            where TChar : unmanaged, IConvertible, IEquatable<TChar>
+        {
+
+            UltrastarModifierCollection collection = new();
+
+            string line = string.Empty;
+
+            while ((line = YARGTextReader.PeekLine(ref container)).Length > 0)
+            {
+                if (line[0] != '#')
+                {
+                    YARGTextReader.SkipLinesUntil(ref container, TextConstants<TChar>.POUND_SIGN);
+                    continue;
+                }
+
+                string name = YARGTextReader.ExtractModifierName(ref container, splitChar: ':').ToLower();
+
+                // Override deprecated name with new name
+                if (deprecations.TryGetValue(name, out string newName))
+                {
+                    name = newName;
+                }
+
+                if (outlines.TryGetValue(name, out var outline))
+                {
+                    container.Position++; // Account for splitChar
+                    collection.Add(ref container, outline, false);
+                }
+
+                YARGTextReader.GotoNextLine(ref container);
+            }
+
+            return collection;
+        }
+    }
+}

--- a/YARG.Core/MoonscraperChartParser/IO/Ultrastar/UltrastarReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Ultrastar/UltrastarReader.cs
@@ -1,0 +1,299 @@
+﻿using MoonscraperChartEditor.Song;
+using MoonscraperChartEditor.Song.IO;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using YARG.Core.Chart;
+using YARG.Core.Extensions;
+using YARG.Core.Logging;
+using YARG.Core.Parsing;
+using YARG.Core.Utility;
+
+namespace YARG.Core.MoonscraperChartParser.IO.Ultrastar
+{
+    internal static partial class UltrastarReader
+    {
+        private const int MIDI_OFFSET_C4 = 60;
+
+        /// <summary>
+        /// BPM in Ultrastar file is 1/4th of the original, so multiplying to get correct bpm.
+        /// </summary>
+        private const float BPM_MULTIPLIER = 4f;
+
+        private const char SLIDE_CHAR = '~';
+
+        private enum NoteType
+        {
+            Normal,
+            Freestyle,
+            Rap
+        }
+
+        private struct ChartSettings
+        {
+            public ChartSettings(uint _gap, uint _player, float _bpm, bool _relativeOffsets, bool _reachedEnd)
+            {
+                gapInMilliseconds = _gap;
+                currentPlayer = _player;
+                bpm = _bpm;
+                relativeNoteOffsets = _relativeOffsets;
+                reachedEnd = _reachedEnd;
+            }
+
+            public uint gapInMilliseconds;
+            public uint currentPlayer;
+            public float bpm;
+            public bool relativeNoteOffsets;
+            public bool reachedEnd;
+        }
+
+        private const uint DEFAULT_RESOLUTION = 480;
+
+        public static MoonSong ReadFromFile(string filepath)
+        {
+            var settings = ParseSettings.Default_Chart;
+            return ReadFromFile(ref settings, filepath);
+        }
+
+        public static MoonSong ReadFromText(ReadOnlySpan<char> chartText)
+        {
+            var settings = ParseSettings.Default_Chart;
+            return ReadFromText(ref settings, chartText);
+        }
+
+        public static MoonSong ReadFromFile(ref ParseSettings settings, string filepath)
+        {
+            try
+            {
+                if (!File.Exists(filepath)) throw new Exception("File does not exist");
+
+                string extension = Path.GetExtension(filepath);
+
+                if (extension != ".txt") throw new Exception("Bad file type");
+
+                string text = File.ReadAllText(filepath);
+                return ReadFromText(ref settings, text);
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Could not open file!", e);
+            }
+        }
+
+        public static MoonSong ReadFromText(ref ParseSettings settings, ReadOnlySpan<char> chartText)
+        {
+            int textIndex = 0;
+
+            ChartSettings chartSettings = new ChartSettings(0, 0, 120f, false, false);
+            var song = new MoonSong(DEFAULT_RESOLUTION);
+            var chart = song.GetChart(MoonSong.MoonInstrument.Vocals, MoonSong.Difficulty.Expert);
+
+            ReadOnlySpan<char> line;
+            chart.specialPhrases.Add(new MoonPhrase(0, 0, MoonPhrase.Type.Vocals_LyricPhrase));
+
+            while ((line = GetNextLine(chartText, ref textIndex)).Length > 0 && !chartSettings.reachedEnd)
+            {
+                ParseLine(line, ref song, ref chartSettings);
+
+                textIndex += 1;
+            }
+
+            // Fix last special phrase end time
+            {
+                uint endOfLastNote = chart.notes.Last().tick + chart.notes.Last().length;
+                chart.specialPhrases.Last().length = endOfLastNote - chart.specialPhrases.Last().tick;
+            }
+
+            return song;
+        }
+
+        private static void ParseLine(ReadOnlySpan<char> lineText, ref MoonSong song, ref ChartSettings chartSettings)
+        {
+            if (lineText.Length < 1)
+            {
+                return;
+            }
+
+            switch (lineText[0])
+            {
+                case '#':
+                    ParseMetadataLine(lineText, ref chartSettings, ref song);
+                    break;
+                case 'P':
+                    ParsePlayerLine(lineText, ref chartSettings);
+                    break;
+                case ':':
+                case '*':
+                case 'F':
+                case 'R':
+                case 'G':
+                    ParseNoteLine(lineText, chartSettings, ref song);
+                    break;
+                case '-':
+                    ParsePhraseEndLine(lineText, chartSettings, ref song);
+                    break;
+                case 'E':
+                    chartSettings.reachedEnd = true;
+                    break;
+            }
+        }
+
+        private static void ParseMetadataLine(ReadOnlySpan<char> lineText, ref ChartSettings chartSettings, ref MoonSong song)
+        {
+            var splits = lineText.Split(':');
+            splits.MoveNext();
+
+            if (splits.Current.StartsWith("#BPM"))
+            {
+                if (splits.MoveNext())
+                {
+                    if (float.TryParse(splits.Current, out float bpm))
+                    {
+                        song.syncTrack.Tempos.Clear();
+                        var tempoChange = new TempoChange(bpm * BPM_MULTIPLIER, 0, 0);
+                        song.syncTrack.Tempos.Add(tempoChange);
+                        chartSettings.bpm = bpm * BPM_MULTIPLIER;
+                    }
+                }
+            }
+
+            if (splits.Current.StartsWith("#GAP") || splits.Current.StartsWith("#AUDIOGAP"))
+            {
+                if (splits.MoveNext())
+                {
+                    if (uint.TryParse(splits.Current, out uint gap))
+                    {
+                        chartSettings.gapInMilliseconds = gap;
+                    }
+                }
+            }
+        }
+
+        private static void ParsePlayerLine(ReadOnlySpan<char> lineText, ref ChartSettings chartSettings)
+        {
+            if (lineText.Length < 2)
+            {
+                return;
+            }
+
+            if (uint.TryParse(lineText[1].ToString(), out uint playerId))
+            {
+                chartSettings.currentPlayer = playerId - 1;
+            }
+        }
+
+        private static void ParseNoteLine(ReadOnlySpan<char> lineText, ChartSettings chartSettings, ref MoonSong song)
+        {
+            var chart = song.GetChart(MoonSong.MoonInstrument.Vocals, MoonSong.Difficulty.Expert);
+
+            var splits = lineText.Split(' ');
+            splits.MoveNext();
+            splits.MoveNext();
+
+            NoteType type = lineText[0] switch
+                {
+                    ':' or '*' => NoteType.Normal,
+                    'F' => NoteType.Freestyle,
+                    'R' or 'G' => NoteType.Rap,
+                    _ => NoteType.Normal
+                };
+
+            bool isGolden = lineText[0] == '*' || lineText[0] == 'G';
+
+            uint.TryParse(splits.Current, out uint startBeat);
+            splits.MoveNext();
+            uint.TryParse(splits.Current, out uint lengthInBeats);
+            splits.MoveNext();
+            int.TryParse(splits.Current, out int pitch);
+            splits.MoveNext();
+
+            int splitIndex = splits.Original.Length - (splits.Current.Length + splits.Remaining.Length) - 1;
+            string text = splits.Original[splitIndex..].ToString();
+
+            float timeOfStartBeat = GetTimeOfBeat(chartSettings, startBeat);
+            uint startTick = song.TimeToTick(timeOfStartBeat);
+
+            float timeOfSustainEnd = GetTimeOfBeat(chartSettings, startBeat + lengthInBeats);
+            uint sustainTicks = song.TimeToTick(timeOfSustainEnd) - startTick;
+
+            var note = new MoonNote(startTick, pitch + MIDI_OFFSET_C4, sustainTicks);
+            MoonObjectHelper.PushNote(note, chart.notes);
+
+            string lyricModifier = type switch
+            {
+                NoteType.Rap => LyricSymbols.NONPITCHED_SYMBOL.ToString(),
+                _ => ""
+            };
+
+            if (text.Length > 0 && text[0] == SLIDE_CHAR)
+            {
+                lyricModifier += LyricSymbols.PITCH_SLIDE_SYMBOL;
+                text = text[1..];
+            }
+
+            string lyricEvent = TextEvents.LYRIC_PREFIX_WITH_SPACE + text + lyricModifier;
+            chart.events.Add(new MoonText(lyricEvent, startTick));
+
+            if (chart.specialPhrases.Count == 1 && chart.specialPhrases.First().tick == 0)
+            {
+                chart.specialPhrases.First().tick = startTick;
+            }
+        }
+
+        private static void ParsePhraseEndLine(ReadOnlySpan<char> lineText, ChartSettings chartSettings, ref MoonSong song)
+        {
+            var splits = lineText.Split(' ');
+            splits.MoveNext();
+            splits.MoveNext();
+
+            var chart = song.GetChart(MoonSong.MoonInstrument.Vocals, MoonSong.Difficulty.Expert);
+
+            if (uint.TryParse(splits.Current, out uint nextPhraseStartBeat))
+            {
+                float timeOfNextPhraseStart = GetTimeOfBeat(chartSettings, nextPhraseStartBeat);
+                uint tickOfNextPhraseStart = song.TimeToTick(timeOfNextPhraseStart);
+
+                var lastPhrase = chart.specialPhrases.Last();
+                lastPhrase.length = tickOfNextPhraseStart - lastPhrase.tick;
+                
+                var nextPhrase = new MoonPhrase(tickOfNextPhraseStart, 0, MoonPhrase.Type.Vocals_LyricPhrase);
+                chart.specialPhrases.Add(nextPhrase);
+            }
+        }
+
+        private static float GetTimeOfBeat(ChartSettings chartSettings, uint beat)
+        {
+            float gapSeconds = chartSettings.gapInMilliseconds / 1000f;
+            float secondsPerBeat = 60 / chartSettings.bpm;
+            return gapSeconds + (secondsPerBeat * beat);
+        }
+
+        private static ReadOnlySpan<char> GetNextLine(ReadOnlySpan<char> chartText, ref int textIndex)
+        {
+            int startOffset = textIndex;
+
+            if (startOffset >= chartText.Length)
+                return ReadOnlySpan<char>.Empty;
+
+            int nextLineBreakOffset = chartText[startOffset..].IndexOfAny('\r', '\n');
+
+            if (nextLineBreakOffset == -1)
+            {
+                textIndex = chartText.Length;
+                return chartText[startOffset..];
+            }
+
+            textIndex = startOffset + nextLineBreakOffset;
+
+            if (textIndex + 1 < chartText.Length && chartText[textIndex] == '\r' && chartText[textIndex + 1] == '\n')
+            {
+                textIndex++;
+            }
+
+            return chartText.Slice(startOffset, nextLineBreakOffset);
+        }
+    }
+}

--- a/YARG.Core/Song/Cache/CacheGroups/UltrastarEntryGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UltrastarEntryGroup.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using YARG.Core.Extensions;
+using YARG.Core.Song.Entries.Ultrastar;
+
+namespace YARG.Core.Song.Cache
+{
+    internal sealed class UltrastarEntryGroup : IEntryGroup
+    {
+        private readonly string _directory;
+        private readonly List<UltrastarEntry> _entries = new();
+
+        public string Directory => _directory;
+
+        public UltrastarEntryGroup(string directory)
+        {
+            _directory = directory;
+        }
+
+        public void AddEntry(UltrastarEntry entry)
+        {
+            lock (_entries)
+            {
+                _entries.Add(entry);
+            }
+        }
+
+        public void Serialize(MemoryStream groupStream, Dictionary<SongEntry, CacheWriteIndices> nodes)
+        {
+            groupStream.Write(_directory);
+            using MemoryStream entryStream = new();
+            SerializeList(entryStream, _entries, groupStream, nodes);
+        }
+
+        private void SerializeList<TEntry>(MemoryStream entryStream, List<TEntry> entries, MemoryStream groupStream, Dictionary<SongEntry, CacheWriteIndices> nodes)
+            where TEntry : UltrastarEntry
+        {
+            groupStream.Write(entries.Count, Endianness.Little);
+            foreach (var entry in entries)
+            {
+                entryStream.SetLength(0);
+
+                // Validation block
+                string relativePath = Path.GetRelativePath(_directory, entry.ActualLocation);
+                if (relativePath == ".")
+                {
+                    relativePath = string.Empty;
+                }
+                entryStream.Write(relativePath);
+
+                entry.Serialize(entryStream, nodes[entry]);
+
+                groupStream.Write((int) entryStream.Length, Endianness.Little);
+                groupStream.Write(entryStream.GetBuffer(), 0, (int) entryStream.Length);
+            }
+        }
+    }
+}

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -16,6 +16,7 @@ namespace YARG.Core.Song
         Mid,
         Midi,
         Chart,
+        Ultrastar,
     };
 
     public enum EntryType
@@ -24,6 +25,7 @@ namespace YARG.Core.Song
         Sng,
         ExCON,
         CON,
+        Ultrastar,
     }
 
     public struct LoaderSettings

--- a/YARG.Core/Song/Entries/Types/ScanExpected.cs
+++ b/YARG.Core/Song/Entries/Types/ScanExpected.cs
@@ -8,6 +8,7 @@ namespace YARG.Core.Song
         DirectoryError,
         DuplicateFilesFound,
         IniEntryCorruption,
+        UltrastarEntryCorruption,
         NoName,
         NoNotes,
         DTAError,

--- a/YARG.Core/Song/Entries/Types/SongMetadata.cs
+++ b/YARG.Core/Song/Entries/Types/SongMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using YARG.Core.IO.Ini;
+using YARG.Core.IO.Ultrastar;
 
 namespace YARG.Core.Song
 {
@@ -250,6 +251,69 @@ namespace YARG.Core.Song
             if (modifiers.Extract("video_loop", out bool videoLoop))
             {
                 metadata.VideoLoop = videoLoop;
+            }
+        }
+
+        public static void FillFromUltrastar(ref SongMetadata metadata, UltrastarVersion version, UltrastarModifierCollection modifiers)
+        {
+            if (modifiers.Extract("title", out string title) && title.Length > 0)
+            {
+                metadata.Name = title;
+            }
+
+            if (modifiers.Extract("artist", out string artist) && artist.Length > 0)
+            {
+                metadata.Artist = artist;
+            }
+
+            if (modifiers.Extract("genre", out string genre) && genre.Length > 0)
+            {
+                metadata.Genre = genre;
+            }
+
+            if (modifiers.Extract("year", out string year) && year.Length > 0)
+            {
+                metadata.Year = year;
+            }
+
+            if (modifiers.Extract("creator", out string creator) && creator.Length > 0)
+            {
+                metadata.Charter = creator;
+            }
+
+            metadata.Source = "ultrastar";
+            metadata.PlaylistTrack = int.MaxValue;
+            metadata.AlbumTrack = int.MaxValue;
+
+            if (modifiers.Extract("videogap", out double videoStartTime))
+            {
+                // In version 2.0.0 this was changed to seconds, instead of milliseconds
+                if (version >= UltrastarVersion.V2_0_0)
+                {
+                    videoStartTime *= MILLISECOND_FACTOR;
+                }
+
+                metadata.Video.Start = (long) videoStartTime;
+            }
+
+            if (modifiers.Extract("previewstart", out double previewStart))
+            {
+                if (version >= UltrastarVersion.V2_0_0)
+                {
+                    previewStart *= MILLISECOND_FACTOR;
+                }
+
+                metadata.Preview.Start = (long) previewStart;
+            }
+
+            if (modifiers.Extract("previewend", out double previewEnd))
+            {
+                if (version >= UltrastarVersion.V2_0_0)
+                {
+                    previewEnd *= MILLISECOND_FACTOR;
+                }
+
+                metadata.Preview.End = (long) previewEnd;
             }
         }
     }

--- a/YARG.Core/Song/Entries/Ultrastar/SongEntry.Ultrastar.cs
+++ b/YARG.Core/Song/Entries/Ultrastar/SongEntry.Ultrastar.cs
@@ -334,9 +334,6 @@ namespace YARG.Core.Song.Entries.Ultrastar
         private static void ParseChart(UltrastarEntry entry, in FixedArray<byte> file)
         {
             // If we have an ultrastar chart, we have lead vocals
-            entry._parts.LeadVocals.ActivateSubtrack(0);
-            entry._parts.LeadVocals.Intensity = DEFAULT_INTENSITY;
-
             var textContainer = new YARGTextContainer<byte>(file, Encoding.UTF8);
             bool foundHarmony = false;
             bool foundHarmony2 = false;
@@ -427,6 +424,11 @@ namespace YARG.Core.Song.Entries.Ultrastar
                 {
                     entry._parts.HarmonyVocals.ActivateSubtrack(1);
                 }
+            }
+            else
+            {
+                entry._parts.LeadVocals.ActivateSubtrack(0);
+                entry._parts.LeadVocals.Intensity = DEFAULT_INTENSITY;
             }
 
             // Ultrastar by default (unless explictly specified) sets the preview start time at the start time of the note

--- a/YARG.Core/Song/Entries/Ultrastar/SongEntry.Ultrastar.cs
+++ b/YARG.Core/Song/Entries/Ultrastar/SongEntry.Ultrastar.cs
@@ -1,0 +1,412 @@
+﻿using Melanchall.DryWetMidi.Core;
+using MoonscraperChartEditor.Song.IO;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using YARG.Core.Audio;
+using YARG.Core.Chart;
+using YARG.Core.Extensions;
+using YARG.Core.IO;
+using YARG.Core.IO.Ini;
+using YARG.Core.IO.Ultrastar;
+using YARG.Core.Logging;
+using YARG.Core.Venue;
+
+namespace YARG.Core.Song.Entries.Ultrastar
+{
+    internal class UltrastarEntry : SongEntry
+    {
+        public ChartFormat _chartFormat => ChartFormat.Ultrastar;
+        private readonly DateTime _chartLastWrite;
+        private string _location;
+        private string _filename;
+        private string _cover;
+        private string _vocalStemLocation;
+        private string _audioLocation;
+        private string _video;
+        private string _background;
+        private UltrastarVersion _ultrastarVersion;
+
+        public override string SortBasedLocation => _location;
+        public override string ActualLocation => _location;
+
+        public override EntryType SubType => EntryType.Ultrastar;
+
+        private static readonly string[] ALBUMART_FILES;
+        private static readonly string[] DEFAULT_ALBUMART_FILENAMES = new string[4]
+        {
+            "cover",
+            "front",
+            "album",
+            "co"
+        };
+
+        static UltrastarEntry()
+        {
+            ALBUMART_FILES = new string[IMAGE_EXTENSIONS.Length * DEFAULT_ALBUMART_FILENAMES.Length];
+            for (int j = 0; j < DEFAULT_ALBUMART_FILENAMES.Length; j++)
+            {
+                for (int i = 0; i < IMAGE_EXTENSIONS.Length; i++)
+                {
+                    ALBUMART_FILES[(j * IMAGE_EXTENSIONS.Length) + i] = DEFAULT_ALBUMART_FILENAMES[j] + IMAGE_EXTENSIONS[i];
+                }
+            }
+        }
+
+        private UltrastarEntry(string location, string filename, in DateTime chartLastWrite)
+        {
+            _location = location;
+            _filename = filename;
+            _chartLastWrite = chartLastWrite;
+            _cover = string.Empty;
+            _vocalStemLocation = string.Empty;
+            _audioLocation = string.Empty;
+            _video = string.Empty;
+            _background = string.Empty;
+        }
+
+        internal override void Serialize(MemoryStream stream, CacheWriteIndices node)
+        {
+            stream.Write(_filename);
+            stream.Write(_chartLastWrite.ToBinary(), Endianness.Little);
+
+            base.Serialize(stream, node);
+
+            stream.Write(_cover);
+            stream.Write(_vocalStemLocation);
+            stream.Write(_audioLocation);
+            stream.Write(_video);
+            stream.Write(_background);
+        }
+
+        protected new void Deserialize(ref FixedArrayStream stream, CacheReadStrings strings)
+        {
+            base.Deserialize(ref stream, strings);
+
+            _cover = stream.ReadString();
+            _vocalStemLocation = stream.ReadString();
+            _audioLocation = stream.ReadString();
+            _video = stream.ReadString();
+            _background = stream.ReadString();
+            (_parsedYear, _yearAsNumber) = ParseYear(_metadata.Year);
+        }
+
+        public override SongChart? LoadChart()
+        {
+            using var data = GetChartData(_filename);
+            if (!data.IsAllocated)
+            {
+                return null;
+            }
+
+            var parseSettings = ParseSettings.Default;
+
+            using var stream = data.ToReferenceStream();
+            using var reader = new StreamReader(stream);
+            return SongChart.FromUltrastar(parseSettings, reader.ReadToEnd());
+        }
+
+        public override StemMixer? LoadAudio(float speed, double volume, params SongStem[] ignoreStems)
+        {
+            var mixer = GlobalAudioHandler.CreateMixer(ToString(), speed, volume, false);
+            if (mixer == null)
+            {
+                YargLogger.LogError("Failed to create mixer!");
+                return null;
+            }
+
+            var subFiles = GetSubFiles();
+
+            if (_audioLocation != string.Empty
+                && (_vocalStemLocation == string.Empty || !ignoreStems.Contains(SongStem.Song)))
+            {
+                if (subFiles.TryGetValue(_audioLocation, out var file))
+                {
+                    var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
+                    if (!mixer.AddChannel(SongStem.Song, stream))
+                    {
+                        stream.Dispose();
+                        YargLogger.LogFormatError("Failed to load song file {0}", file);
+                    }
+                }
+            }
+
+            if (_vocalStemLocation != string.Empty && !ignoreStems.Contains(SongStem.Vocals))
+            {
+                if (subFiles.TryGetValue(_vocalStemLocation, out var file))
+                {
+                    var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
+                    if (!mixer.AddChannel(SongStem.Vocals, stream))
+                    {
+                        stream.Dispose();
+                        YargLogger.LogFormatError("Failed to load vocal stem file {0}", file);
+                    }
+                }
+            }
+
+            if (mixer.Channels.Count == 0)
+            {
+                YargLogger.LogError("Failed to add any stems!");
+                mixer.Dispose();
+                return null;
+            }
+
+            if (GlobalAudioHandler.LogMixerStatus)
+            {
+                YargLogger.LogFormatInfo("Loaded {0} stems", mixer.Channels.Count);
+            }
+
+            return mixer;
+        }
+
+        public override StemMixer? LoadPreviewAudio(float speed)
+        {
+            return LoadAudio(speed, 0, SongStem.Crowd);
+        }
+
+        protected FixedArray<byte> GetChartData(string filename)
+        {
+            var data = FixedArray<byte>.Null;
+            string chartPath = Path.Combine(_location, filename);
+            if (AbridgedFileInfo.Validate(chartPath, in _chartLastWrite))
+            {
+                data = FixedArray.LoadFile(chartPath);
+            }
+            return data;
+        }
+
+        public static ScanExpected<UltrastarEntry> ProcessNewEntry(string directory, FileInfo chartInfo, string defaultPlaylist)
+        {
+            UltrastarModifierCollection ultrastarModifiers = SongUltrastarHandler.ReadSongUltrastarFile(chartInfo.FullName);
+
+            var entry = new UltrastarEntry(directory, chartInfo.Name, AbridgedFileInfo.NormalizedLastWrite(chartInfo));
+            entry._metadata.Playlist = defaultPlaylist;
+
+            using var file = FixedArray.LoadFile(chartInfo.FullName);
+            var result = ScanChart(entry, in file, ultrastarModifiers);
+            return result == ScanResult.Success ? entry : new ScanUnexpected(result);
+        }
+
+        public override YARGImage LoadAlbumData()
+        {
+            var subFiles = GetSubFiles();
+            if (!string.IsNullOrEmpty(_cover) && subFiles.TryGetValue(_cover, out var cover))
+            {
+                var image = YARGImage.Load(cover);
+                if (image.IsAllocated)
+                {
+                    return image;
+                }
+                YargLogger.LogFormatError("Image at {0} failed to load", cover);
+            }
+
+            foreach (string albumName in ALBUMART_FILES)
+            {
+                if (subFiles.TryGetValue(albumName, out var file))
+                {
+                    var image = YARGImage.Load(file);
+                    if (image.IsAllocated)
+                    {
+                        return image;
+                    }
+                    YargLogger.LogFormatError("Image at {0} failed to load", file);
+                }
+            }
+            return YARGImage.Null;
+        }
+
+        public override BackgroundResult? LoadBackground(BackgroundType options)
+        {
+            var subFiles = GetSubFiles();
+            if ((options & BackgroundType.Yarground) > 0)
+            {
+                if (subFiles.TryGetValue("bg.yarground", out var file))
+                {
+                    var stream = File.OpenRead(file);
+                    return new BackgroundResult(BackgroundType.Yarground, stream);
+                }
+            }
+
+            if ((options & BackgroundType.Video) > 0)
+            {
+                if (subFiles.TryGetValue(_video, out var video))
+                {
+                    var stream = File.OpenRead(video);
+                    return new BackgroundResult(BackgroundType.Video, stream);
+                }
+
+                foreach (var stem in BACKGROUND_FILENAMES)
+                {
+                    foreach (var format in VIDEO_EXTENSIONS)
+                    {
+                        if (subFiles.TryGetValue(stem + format, out var file))
+                        {
+                            var stream = File.OpenRead(file);
+                            return new BackgroundResult(BackgroundType.Video, stream);
+                        }
+                    }
+                }
+            }
+
+            if ((options & BackgroundType.Image) > 0)
+            {
+                if (subFiles.TryGetValue(_background, out var file))
+                {
+                    var image = YARGImage.Load(file!);
+                    if (image.IsAllocated)
+                    {
+                        return new BackgroundResult(image);
+                    }
+                }
+            }
+            return null;
+        }
+
+        public override FixedArray<byte> LoadMiloData()
+        {
+            return FixedArray<byte>.Null;
+        }
+
+        public override DateTime GetLastWriteTime()
+        {
+            return _chartLastWrite;
+        }
+
+        private Dictionary<string, string> GetSubFiles()
+        {
+            Dictionary<string, string> files = new();
+            if (Directory.Exists(_location))
+            {
+                foreach (var file in Directory.EnumerateFiles(_location))
+                {
+                    files.Add(file[(_location.Length + 1)..], file);
+                }
+            }
+            return files;
+        }
+
+        protected internal static ScanResult ScanChart(UltrastarEntry entry, in FixedArray<byte> file, UltrastarModifierCollection modifiers)
+        {
+            entry._parts.LeadVocals.ActivateSubtrack(0);
+            entry._parts.LeadVocals.Intensity = 2;
+
+            // TODO: Get chart metadata here (number of players, etc.)
+
+            if (!modifiers.Contains("title"))
+            {
+                return ScanResult.NoName;
+            }
+
+            if (modifiers.Extract("version", out string versionString))
+            {
+                entry._ultrastarVersion = SongUltrastarHandler.ConvertVersionToEnum(versionString);
+            }
+            else
+            {
+                entry._ultrastarVersion = UltrastarVersion.V1_0_0;
+            }
+
+            SongMetadata.FillFromUltrastar(ref entry._metadata, entry._ultrastarVersion, modifiers);
+
+            (entry._parsedYear, entry._yearAsNumber) = ParseYear(entry._metadata.Year);
+            entry._hash = HashWrapper.Hash(file.ReadOnlySpan);
+            entry.SetSortStrings();
+
+            UpdateEntryWithModifiers(ref entry, modifiers);
+
+            if (entry._metadata.SongLength <= 0)
+            {
+                using var mixer = entry.LoadAudio(0, 0);
+                if (mixer != null)
+                {
+                    entry._metadata.SongLength = (long) (mixer.Length * SongMetadata.MILLISECOND_FACTOR);
+
+                    if (entry._metadata.Preview == (-1, -1))
+                    {
+                        // TODO: This is not technically correct, rather the preview audio starts 1/3rd of the way through the song
+                        // in terms of the part of the song that is playable. So if a song is 300 seconds long, but vocals are
+                        // from 0-200, the preview would be at 66.66s not 100s in.
+                        // Unless specified otherwise in the ultrastar file.
+                        entry._metadata.Preview.Start = entry._metadata.SongLength / 3;
+                    }
+                }
+            }
+            return ScanResult.Success;
+        }
+
+        private static void UpdateEntryWithModifiers(ref UltrastarEntry entry, UltrastarModifierCollection modifiers)
+        {
+            if (modifiers.Extract("audio", out string audioLocation))
+            {
+                entry._audioLocation = audioLocation;
+            }
+
+            if (modifiers.Extract("background", out string background))
+            {
+                entry._background = background;
+            }
+
+            if (modifiers.Extract("cover", out string cover))
+            {
+                entry._cover = cover;
+            }
+
+            if (modifiers.Extract("video", out string video))
+            {
+                entry._video = video;
+            }
+        }
+
+        private static (string Parsed, int AsNumber) ParseYear(string str)
+        {
+            const int MINIMUM_YEAR_DIGITS = 4;
+            for (int start = 0; start <= str.Length - MINIMUM_YEAR_DIGITS; ++start)
+            {
+                int curr = start;
+                int number = 0;
+                while (curr < str.Length && char.IsDigit(str[curr]))
+                {
+                    unchecked
+                    {
+                        number = 10 * number + str[curr] - '0';
+                    }
+                    ++curr;
+                }
+
+                if (curr >= start + MINIMUM_YEAR_DIGITS)
+                {
+                    return (str[start..curr], number);
+                }
+            }
+            return (str, int.MaxValue);
+        }
+
+        public static UltrastarEntry? TryDeserialize(string baseDirectory, ref FixedArrayStream stream, CacheReadStrings strings)
+        {
+            string directory = Path.Combine(baseDirectory, stream.ReadString());
+            var chartFileName = stream.ReadString();
+            var chartLastWrite = DateTime.FromBinary(stream.Read<long>(Endianness.Little));
+            if (!AbridgedFileInfo.Validate(Path.Combine(directory, chartFileName), chartLastWrite))
+            {
+                return null;
+            }
+
+            var entry = new UltrastarEntry(directory, chartFileName, in chartLastWrite);
+            entry.Deserialize(ref stream, strings);
+            return entry;
+        }
+
+        public static UltrastarEntry ForceDeserialize(string baseDirectory, ref FixedArrayStream stream, CacheReadStrings strings)
+        {
+            string directory = Path.Combine(baseDirectory, stream.ReadString());
+            var chartFileName = stream.ReadString();
+            var chartLastWrite = DateTime.FromBinary(stream.Read<long>(Endianness.Little));
+            
+            var entry = new UltrastarEntry(directory, chartFileName, in chartLastWrite);
+            entry.Deserialize(ref stream, strings);
+            return entry;
+        }
+    }
+}


### PR DESCRIPTION
This draft PR adds support for importing Ultrastar vocal tracks (either solo, or duet) to become playable in YARG.  I found this on the backlog and thought it would be a cool to add. https://yarg.youtrack.cloud/issue/YARG-78/Ultrastar-format-support

The reason I have this as a draft PR is to mainly get feedback on the overall layout of what I added, especially in regards to caching. The caching logic was mostly copy-paste from INI, but separate, so I may have missed something. The parsing logic is fairly simple as the Ultrastar format is just text, though with the combination of metadata and chart in one file, it resulted in having to parse the text file multiple times to get the specific data that we want out of it (one pass for metadata, another for the available players / preview time, and another for the chart). This can be optimized into one pass if needed.

Additionally, a question for how to handle preview start time. The documentation for Ultrastar Play says, "Defaults to halfway through the song." (https://github.com/UltraStar-Deluxe/Play/wiki/UltraStar-txt-File-Format) but that is not what is done in reality. What is done inside the game is that it takes every vocal note, puts them all in a list sorted by their beat, gets the note that has the index 1/3rd of the way in, gets the beat of said note, and the preview starts at that time ☨( https://github.com/UltraStar-Deluxe/Play/blob/master/UltraStar%20Play/Assets/Common/SongPreviewControl.cs#L154 ). That is how it is currently implemented in Ultrastar Play. Is this the behavior we want in YARG? I would say yes for consistency, but it also is an edge case that we may not want to deal with.

☨ - Ultrastar Play is on a build of Unity that has an issue that makes the preview timing even worse as there is an issue when decoding MP3 files where the time reported by unity is not the actual time inside the MP3. I don't think we want to mimic this as it's an engine bug, but just wanted to point this out if anyone sees it during testing ( https://discussions.unity.com/t/audioclip-length-is-incorrect-when-loading-from-webrequest-getaudioclip/834321/22 | https://github.com/UltraStar-Deluxe/Play/issues/504 )