### PR TITLE
Rework binary search utilities to be better documented and more generic

### DIFF
--- a/YARG.Core.UnitTests/Extensions/CollectionExtensionTests.cs
+++ b/YARG.Core.UnitTests/Extensions/CollectionExtensionTests.cs
@@ -1,0 +1,248 @@
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using YARG.Core.Extensions;
+
+using TimeData = (double time, int value);
+
+namespace YARG.Core.UnitTests.Extensions;
+
+[SuppressMessage(
+    "Assertion",
+    "NUnit2045:Use Assert.Multiple",
+    Justification = @"Does more harm than good in this particular test set.
+        Obscures exact failure points, making troubleshooting and debugging harder."
+)]
+public class CollectionExtensionTests
+{
+    private static SearchComparison<TimeData, double> _timeComparer = (ev, target) => ev.time.CompareTo(target);
+    private static SearchComparison<TimeData, int> _valueComparer = (ev, target) => ev.value.CompareTo(target);
+
+    private List<TimeData> _items = [
+        (0.0, 1),  // 0
+        (5.0, 2),  // 1
+        (8.0, 2),  // 2
+        (10.0, 4), // 3
+        (12.0, 4), // 4
+        (16.0, 5), // 5
+        (19.0, 7), // 6
+        (20.0, 7), // 7
+    ];
+
+    [Test]
+    public void BinarySearch()
+    {
+        Assert.That(_items.BinarySearch(5.0, _timeComparer), Is.EqualTo(1));
+        Assert.That(_items.BinarySearch(8.0, _timeComparer), Is.EqualTo(2));
+        Assert.That(_items.BinarySearch(10.0, _timeComparer), Is.EqualTo(3));
+        Assert.That(_items.BinarySearch(12.0, _timeComparer), Is.EqualTo(4));
+        Assert.That(_items.BinarySearch(16.0, _timeComparer), Is.EqualTo(5));
+        Assert.That(_items.BinarySearch(19.0, _timeComparer), Is.EqualTo(6));
+        Assert.That(_items.BinarySearch(20.0, _timeComparer), Is.EqualTo(7));
+
+        Assert.That(_items.BinarySearch(1, _valueComparer), Is.EqualTo(0));
+        Assert.That(_items.BinarySearch(2, _valueComparer), Is.EqualTo(1));
+        Assert.That(_items.BinarySearch(4, _valueComparer), Is.EqualTo(3));
+        Assert.That(_items.BinarySearch(5, _valueComparer), Is.EqualTo(5));
+        Assert.That(_items.BinarySearch(7, _valueComparer), Is.EqualTo(6));
+
+        // Behavior of in-between values varies depending on the length of the list
+        // and the relative position of the value, so those are not tested here
+    }
+
+    [Test]
+    public void LowerBound()
+    {
+        void AssertTimeBound(double value, int beforeIndex, int afterIndex)
+        {
+            Assert.That(_items.LowerBound(value, _timeComparer, before: true), Is.EqualTo(beforeIndex));
+            Assert.That(_items.LowerBound(value, _timeComparer, before: false), Is.EqualTo(afterIndex));
+        }
+
+        void AssertValueBound(int value, int beforeIndex, int afterIndex)
+        {
+            Assert.That(_items.LowerBound(value, _valueComparer, before: true), Is.EqualTo(beforeIndex));
+            Assert.That(_items.LowerBound(value, _valueComparer, before: false), Is.EqualTo(afterIndex));
+        }
+
+        // Exact values
+        AssertTimeBound(0.0, 0, 0);
+        AssertTimeBound(5.0, 1, 1);
+        AssertTimeBound(8.0, 2, 2);
+        AssertTimeBound(10.0, 3, 3);
+        AssertTimeBound(12.0, 4, 4);
+        AssertTimeBound(16.0, 5, 5);
+        AssertTimeBound(19.0, 6, 6);
+        AssertTimeBound(20.0, 7, 7);
+
+        AssertValueBound(1, 0, 0);
+        AssertValueBound(2, 1, 1);
+        AssertValueBound(4, 3, 3);
+        AssertValueBound(5, 5, 5);
+        AssertValueBound(7, 6, 6);
+
+        // Between/missing values
+        AssertTimeBound(-1.0, -1, 0);
+        AssertTimeBound(3.0, 0, 1);
+        AssertTimeBound(11.0, 3, 4);
+        AssertTimeBound(18.0, 5, 6);
+        AssertTimeBound(23.0, 7, 8);
+
+        AssertValueBound(-1, -1, 0);
+        AssertValueBound(3, 2, 3);
+        AssertValueBound(6, 5, 6);
+        AssertValueBound(8, 7, 8);
+    }
+
+    [Test]
+    public void UpperBound()
+    {
+        // Exact values
+        Assert.That(_items.UpperBound(0.0, _timeComparer), Is.EqualTo(1));
+        Assert.That(_items.UpperBound(5.0, _timeComparer), Is.EqualTo(2));
+        Assert.That(_items.UpperBound(8.0, _timeComparer), Is.EqualTo(3));
+        Assert.That(_items.UpperBound(10.0, _timeComparer), Is.EqualTo(4));
+        Assert.That(_items.UpperBound(12.0, _timeComparer), Is.EqualTo(5));
+        Assert.That(_items.UpperBound(16.0, _timeComparer), Is.EqualTo(6));
+        Assert.That(_items.UpperBound(19.0, _timeComparer), Is.EqualTo(7));
+        Assert.That(_items.UpperBound(20.0, _timeComparer), Is.EqualTo(8));
+
+        Assert.That(_items.UpperBound(1, _valueComparer), Is.EqualTo(1));
+        Assert.That(_items.UpperBound(2, _valueComparer), Is.EqualTo(3));
+        Assert.That(_items.UpperBound(4, _valueComparer), Is.EqualTo(5));
+        Assert.That(_items.UpperBound(5, _valueComparer), Is.EqualTo(6));
+        Assert.That(_items.UpperBound(7, _valueComparer), Is.EqualTo(8));
+
+        // Between/missing values
+        Assert.That(_items.UpperBound(-1.0, _timeComparer), Is.EqualTo(0));
+        Assert.That(_items.UpperBound(3.0, _timeComparer), Is.EqualTo(1));
+        Assert.That(_items.UpperBound(11.0, _timeComparer), Is.EqualTo(4));
+        Assert.That(_items.UpperBound(18.0, _timeComparer), Is.EqualTo(6));
+        Assert.That(_items.UpperBound(23.0, _timeComparer), Is.EqualTo(8));
+
+        Assert.That(_items.UpperBound(-1, _valueComparer), Is.EqualTo(0));
+        Assert.That(_items.UpperBound(3, _valueComparer), Is.EqualTo(3));
+        Assert.That(_items.UpperBound(6, _valueComparer), Is.EqualTo(6));
+        Assert.That(_items.UpperBound(8, _valueComparer), Is.EqualTo(8));
+    }
+
+    [Test]
+    public void FindEqualRange()
+    {
+        void AssertTimeRange(double value, Range range)
+        {
+            Assert.That(_items.FindEqualRange(value, _timeComparer, out var found), Is.True);
+            Assert.That(found, Is.EqualTo(range));
+        }
+
+        void AssertValueRange(int value, Range range)
+        {
+            Assert.That(_items.FindEqualRange(value, _valueComparer, out var found), Is.True);
+            Assert.That(found, Is.EqualTo(range));
+        }
+
+        // Exact values
+        AssertTimeRange(0.0, 0..1);
+        AssertTimeRange(5.0, 1..2);
+        AssertTimeRange(8.0, 2..3);
+        AssertTimeRange(10.0, 3..4);
+        AssertTimeRange(12.0, 4..5);
+        AssertTimeRange(16.0, 5..6);
+        AssertTimeRange(19.0, 6..7);
+        AssertTimeRange(20.0, 7..8);
+
+        AssertValueRange(1, 0..1);
+        AssertValueRange(2, 1..3);
+        AssertValueRange(4, 3..5);
+        AssertValueRange(5, 5..6);
+        AssertValueRange(7, 6..8);
+
+        // Between/missing values
+        Assert.That(_items.FindEqualRange(-1.0, _timeComparer, out _), Is.False);
+        Assert.That(_items.FindEqualRange(3.0, _timeComparer, out _), Is.False);
+        Assert.That(_items.FindEqualRange(11.0, _timeComparer, out _), Is.False);
+        Assert.That(_items.FindEqualRange(18.0, _timeComparer, out _), Is.False);
+        Assert.That(_items.FindEqualRange(23.0, _timeComparer, out _), Is.False);
+
+        Assert.That(_items.FindEqualRange(-1, _valueComparer, out _), Is.False);
+        Assert.That(_items.FindEqualRange(3, _valueComparer, out _), Is.False);
+        Assert.That(_items.FindEqualRange(6, _valueComparer, out _), Is.False);
+        Assert.That(_items.FindEqualRange(8, _valueComparer, out _), Is.False);
+    }
+
+    [Test]
+    public void FindRange()
+    {
+        void AssertRange<T>(T start, T end, SearchComparison<TimeData, T> comparison, bool endInclusive, Range? _range)
+            where T : IComparable<T>
+        {
+            if (_range is {} range)
+            {
+                Assert.That(_items.FindRange(start, end, comparison, endInclusive, out var found), Is.True);
+                Assert.That(found, Is.EqualTo(range));
+            }
+            else
+            {
+                Assert.That(_items.FindRange(start, end, comparison, endInclusive, out _), Is.False);
+            }
+        }
+
+        void AssertTimeRange(double start, double end, Range? rangeExclusive, Range? rangeInclusive)
+        {
+            AssertRange(start, end, _timeComparer, endInclusive: false, rangeExclusive);
+            AssertRange(start, end, _timeComparer, endInclusive: true, rangeInclusive);
+        }
+
+        void AssertValueRange(int start, int end, Range? rangeExclusive, Range? rangeInclusive)
+        {
+            AssertRange(start, end, _valueComparer, endInclusive: false, rangeExclusive);
+            AssertRange(start, end, _valueComparer, endInclusive: true, rangeInclusive);
+        }
+
+        Assert.Throws<InvalidOperationException>(() => _items.FindRange(0.0, -1.0, _timeComparer, endInclusive: false, out _));
+        Assert.Throws<InvalidOperationException>(() => _items.FindRange(0, -1, _valueComparer, endInclusive: false, out _));
+
+        // Exact values
+        AssertTimeRange(0.0, 0.0, null, 0..1);
+        AssertTimeRange(5.0, 5.0, null, 1..2);
+        AssertTimeRange(8.0, 8.0, null, 2..3);
+        AssertTimeRange(10.0, 10.0, null, 3..4);
+        AssertTimeRange(12.0, 12.0, null, 4..5);
+        AssertTimeRange(16.0, 16.0, null, 5..6);
+        AssertTimeRange(19.0, 19.0, null, 6..7);
+        AssertTimeRange(20.0, 20.0, null, 7..8);
+
+        AssertValueRange(1, 1, null, 0..1);
+        AssertValueRange(2, 2, null, 1..3);
+        AssertValueRange(4, 4, null, 3..5);
+        AssertValueRange(5, 5, null, 5..6);
+        AssertValueRange(7, 7, null, 6..8);
+
+        // Broad ranges
+        AssertTimeRange(-10.0, 0.0, null, 0..1);
+        AssertTimeRange(0.0, 10.0, 0..3, 0..4);
+        AssertTimeRange(10.0, 20.0, 3..7, 3..8);
+        AssertTimeRange(20.0, 30.0, 7..8, 7..8);
+        AssertTimeRange(30.0, 40.0, null, null);
+
+        AssertValueRange(-5, 0, null, null);
+        AssertValueRange(0, 5, 0..5, 0..6);
+        AssertValueRange(5, 10, 5..8, 5..8);
+        AssertValueRange(10, 15, null, null);
+
+        // Specific ranges
+        AssertTimeRange(0.0, 5.0, 0..1, 0..2);
+        AssertTimeRange(5.0, 8.0, 1..2, 1..3);
+        AssertTimeRange(8.0, 10.0, 2..3, 2..4);
+        AssertTimeRange(10.0, 12.0, 3..4, 3..5);
+        AssertTimeRange(12.0, 16.0, 4..5, 4..6);
+        AssertTimeRange(16.0, 19.0, 5..6, 5..7);
+        AssertTimeRange(19.0, 20.0, 6..7, 6..8);
+        AssertTimeRange(20.0, 25.0, 7..8, 7..8);
+
+        AssertValueRange(1, 2, 0..1, 0..3);
+        AssertValueRange(2, 4, 1..3, 1..5);
+        AssertValueRange(4, 5, 3..5, 3..6);
+        AssertValueRange(5, 7, 5..6, 5..8);
+        AssertValueRange(7, 8, 6..8, 6..8);
+    }
+}

--- a/YARG.Core/Chart/ChartEventTrackers.cs
+++ b/YARG.Core/Chart/ChartEventTrackers.cs
@@ -75,7 +75,7 @@ namespace YARG.Core.Chart
         /// </summary>
         public void ResetToTick(uint tick)
         {
-            _eventIndex = _events.GetIndexOfPrevious(tick);
+            _eventIndex = _events.LowerBound(tick);
         }
     }
 
@@ -142,7 +142,7 @@ namespace YARG.Core.Chart
         /// </summary>
         public void ResetToTime(double time)
         {
-            _eventIndex = _events.GetIndexOfPrevious(time);
+            _eventIndex = _events.LowerBound(time);
         }
     }
 

--- a/YARG.Core/Chart/ChartEventTrackers.t4
+++ b/YARG.Core/Chart/ChartEventTrackers.t4
@@ -86,7 +86,7 @@ foreach (var (upper, lower, type) in types)
         /// </summary>
         public void ResetTo<#= upper #>(<#= type #> <#= lower #>)
         {
-            _eventIndex = _events.GetIndexOfPrevious(<#= lower #>);
+            _eventIndex = _events.LowerBound(<#= lower #>);
         }
     }
 

--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using YARG.Core.Extensions;
 
 namespace YARG.Core.Chart
@@ -84,205 +85,185 @@ namespace YARG.Core.Chart
             return chartEvent.TickEnd;
         }
 
-        public static TEvent? GetPrevious<TEvent>(this List<TEvent> events, double time)
+        /// <summary>
+        /// Searches for the first event that occurs before (or at) the given time.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.LowerBound"/>
+        public static int LowerBound<TEvent>(this List<TEvent> events, double time)
             where TEvent : ChartEvent
         {
-            int index = GetIndexOfPrevious(events, time);
-            if (index < 0)
-                return null;
-
-            return events[index];
+            return events.LowerBound(time, EventComparer<TEvent>.CompareTime, before: true);
         }
 
-        public static TEvent? GetPrevious<TEvent>(this List<TEvent> events, uint tick)
+        /// <summary>
+        /// Searches for the first event that occurs before (or at) the given tick.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.LowerBound"/>
+        public static int LowerBound<TEvent>(this List<TEvent> events, uint tick)
             where TEvent : ChartEvent
         {
-            int index = GetIndexOfPrevious(events, tick);
-            if (index < 0)
-                return null;
-
-            return events[index];
+            return events.LowerBound(tick, EventComparer<TEvent>.CompareTick, before: true);
         }
 
-        public static TEvent? GetNext<TEvent>(this List<TEvent> events, double time)
+        /// <summary>
+        /// Searches for the first event that occurs before (or at) the given time.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.LowerBoundElement"/>
+        public static bool LowerBoundElement<TEvent>(
+            this List<TEvent> events, double time, [MaybeNullWhen(false)] out TEvent value
+        )
             where TEvent : ChartEvent
         {
-            int index = GetIndexOfNext(events, time);
-            if (index < 0)
-                return null;
-
-            return events[index];
+            return events.LowerBoundElement(time, EventComparer<TEvent>.CompareTime, before: true, out value);
         }
 
-        public static TEvent? GetNext<TEvent>(this List<TEvent> events, uint tick)
+        /// <summary>
+        /// Searches for the first event that occurs before (or at) the given tick.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.LowerBoundElement"/>
+        public static bool LowerBoundElement<TEvent>(
+            this List<TEvent> events, uint tick, [MaybeNullWhen(false)] out TEvent value
+        )
             where TEvent : ChartEvent
         {
-            int index = GetIndexOfNext(events, tick);
-            if (index < 0)
-                return null;
-
-            return events[index];
+            return events.LowerBoundElement(tick, EventComparer<TEvent>.CompareTick, before: true, out value);
         }
 
-        public static int GetIndexOfPrevious<TEvent>(this List<TEvent> events, double time)
+        /// <summary>
+        /// Searches for the first event that occurs before (or at) the given time.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.LowerBoundElement"/>
+        public static TEvent? LowerBoundElement<TEvent>(this List<TEvent> events, double time)
             where TEvent : ChartEvent
         {
-            int closestIndex = events.FindClosestEventIndex(time);
-            if (closestIndex < 0)
-                return -1;
-
-            // Ensure the index we return is for an event that occurs before (or at) the given time
-            while (closestIndex >= 0 && events[closestIndex].Time > time)
-                closestIndex--;
-
-            return closestIndex;
+            return events.LowerBoundElement(time, EventComparer<TEvent>.CompareTime, before: true);
         }
 
-        public static int GetIndexOfPrevious<TEvent>(this List<TEvent> events, uint tick)
+        /// <summary>
+        /// Searches for the first event that occurs before (or at) the given tick.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.LowerBoundElement"/>
+        public static TEvent? LowerBoundElement<TEvent>(this List<TEvent> events, uint tick)
             where TEvent : ChartEvent
         {
-            int closestIndex = events.FindClosestEventIndex(tick);
-            if (closestIndex < 0)
-                return -1;
-
-            // Ensure the index we return is for an event that occurs before (or at) the given tick
-            while (closestIndex >= 0 && events[closestIndex].Tick > tick)
-                closestIndex--;
-
-            return closestIndex;
+            return events.LowerBoundElement(tick, EventComparer<TEvent>.CompareTick, before: true);
         }
 
-        public static int GetIndexOfNext<TEvent>(this List<TEvent> events, double time)
+        /// <summary>
+        /// Searches for the first event that occurs after the given time.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.UpperBound"/>
+        public static int UpperBound<TEvent>(this List<TEvent> events, double time)
             where TEvent : ChartEvent
         {
-            int closestIndex = events.FindClosestEventIndex(time);
-            if (closestIndex < 0)
-                return -1;
-
-            // Ensure the index we return is for an event that occurs after the given time
-            int count = events.Count;
-            while (closestIndex < count && events[closestIndex].Time <= time)
-                closestIndex++;
-
-            return closestIndex < count ? closestIndex : -1;
+            return events.UpperBound(time, EventComparer<TEvent>.CompareTime);
         }
 
-        public static int GetIndexOfNext<TEvent>(this List<TEvent> events, uint tick)
+        /// <summary>
+        /// Searches for the first event that occurs after the given tick.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.UpperBound"/>
+        public static int UpperBound<TEvent>(this List<TEvent> events, uint tick)
             where TEvent : ChartEvent
         {
-            int closestIndex = events.FindClosestEventIndex(tick);
-            if (closestIndex < 0)
-                return -1;
-
-            // Ensure the index we return is for an event that occurs after the given tick
-            int count = events.Count;
-            while (closestIndex < count && events[closestIndex].Tick <= tick)
-                closestIndex++;
-
-            return closestIndex < count ? closestIndex : -1;
+            return events.UpperBound(tick, EventComparer<TEvent>.CompareTick);
         }
 
-        public static bool GetEventRange<TEvent>(this List<TEvent> events, double startTime, double endTime,
-            out Range range)
+        /// <summary>
+        /// Searches for the first event that occurs after the given time.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.UpperBoundElement"/>
+        public static bool UpperBoundElement<TEvent>(
+            this List<TEvent> events, double time, [MaybeNullWhen(false)] out TEvent value
+        )
             where TEvent : ChartEvent
         {
-            range = default;
-
-            int startIndex = events.FindClosestEventIndex(startTime);
-            int endIndex = events.FindClosestEventIndex(endTime);
-            if (startIndex < 0 || endIndex < 0)
-                return false;
-
-            // Ensure indexes are within time bounds
-            int count = events.Count;
-            while (startIndex < count && events[startIndex].Time < startTime)
-                startIndex++;
-            while (endIndex >= 0 && events[endIndex].Time >= endTime)
-                endIndex--;
-
-            // Ensure indexes are still in bounds
-            if (startIndex >= count || endIndex < 0 || startIndex > endIndex)
-                return false;
-
-            range = new Range(startIndex, endIndex + 1);
-            return true;
+            return events.UpperBoundElement(time, EventComparer<TEvent>.CompareTime, out value);
         }
 
-        public static bool GetEventRange<TEvent>(this List<TEvent> events, uint startTick, uint endTick,
-            out Range range)
+        /// <summary>
+        /// Searches for the first event that occurs after the given tick.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.UpperBoundElement"/>
+        public static bool UpperBoundElement<TEvent>(
+            this List<TEvent> events, uint tick, [MaybeNullWhen(false)] out TEvent value
+        )
             where TEvent : ChartEvent
         {
-            range = default;
-
-            int startIndex = events.FindClosestEventIndex(startTick);
-            int endIndex = events.FindClosestEventIndex(endTick);
-            if (startIndex < 0 || endIndex < 0)
-                return false;
-
-            // Ensure indexes are within tick bounds
-            int count = events.Count;
-            while (startIndex < count && events[startIndex].Tick < startTick)
-                startIndex++;
-            while (endIndex >= 0 && events[endIndex].Tick >= endTick)
-                endIndex--;
-
-            // Ensure indexes are still in bounds
-            if (startIndex >= count || endIndex < 0 || startIndex > endIndex)
-                return false;
-
-            range = new Range(startIndex, endIndex + 1);
-            return true;
+            return events.UpperBoundElement(tick, EventComparer<TEvent>.CompareTick, out value);
         }
 
-        public static TEvent? FindClosestEvent<TEvent>(this List<TEvent> events, double time)
+        /// <summary>
+        /// Searches for the first event that occurs after the given time.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.UpperBoundElement"/>
+        public static TEvent? UpperBoundElement<TEvent>(this List<TEvent> events, double time)
             where TEvent : ChartEvent
         {
-            return events.BinarySearch(time, EventComparer<TEvent>.CompareTime);
+            return events.UpperBoundElement(time, EventComparer<TEvent>.CompareTime);
         }
 
-        public static TEvent? FindClosestEvent<TEvent>(this List<TEvent> events, uint tick)
+        /// <summary>
+        /// Searches for the first event that occurs after the given tick.
+        /// </summary>
+        /// <seealso cref="Extensions.CollectionExtensions.UpperBoundElement"/>
+        public static TEvent? UpperBoundElement<TEvent>(this List<TEvent> events, uint tick)
             where TEvent : ChartEvent
         {
-            return events.BinarySearch(tick, EventComparer<TEvent>.CompareTick);
+            return events.UpperBoundElement(tick, EventComparer<TEvent>.CompareTick);
         }
 
-        public static int FindClosestEventIndex<TEvent>(this List<TEvent> events, double time)
+        /// <summary>
+        /// Searches for all events that occur at the given time.
+        /// </summary>
+        public static bool FindEqualRange<TEvent>(this List<TEvent> events, double time, out Range range)
             where TEvent : ChartEvent
         {
-            return events.BinarySearchIndex(time, EventComparer<TEvent>.CompareTime);
+            return events.FindEqualRange(time, EventComparer<TEvent>.CompareTime, out range);
         }
 
-        public static int FindClosestEventIndex<TEvent>(this List<TEvent> events, uint tick)
+        /// <summary>
+        /// Searches for all events that occur at the given tick.
+        /// </summary>
+        public static bool FindEqualRange<TEvent>(this List<TEvent> events, uint tick, out Range range)
             where TEvent : ChartEvent
         {
-            return events.BinarySearchIndex(tick, EventComparer<TEvent>.CompareTick);
+            return events.FindEqualRange(tick, EventComparer<TEvent>.CompareTick, out range);
+        }
+
+        /// <summary>
+        /// Searches for all events that occur between the given start and end time.
+        /// </summary>
+        /// <param name="endInclusive">
+        /// Whether the end value should be treated as inclusive, rather than exclusive.
+        /// </param>
+        public static bool FindRange<TEvent>(
+            this List<TEvent> events, double startTime, double endTime, bool endInclusive, out Range range
+        )
+            where TEvent : ChartEvent
+        {
+            return events.FindRange(startTime, endTime, EventComparer<TEvent>.CompareTime, endInclusive, out range);
+        }
+
+        /// <summary>
+        /// Searches for all events that occur between the given start and end tick.
+        /// </summary>
+        /// <param name="endInclusive">
+        /// Whether the end value should be treated as inclusive, rather than exclusive.
+        /// </param>
+        public static bool FindRange<TEvent>(
+            this List<TEvent> events, uint startTick, uint endTick, bool endInclusive, out Range range
+        )
+            where TEvent : ChartEvent
+        {
+            return events.FindRange(startTick, endTick, EventComparer<TEvent>.CompareTick, endInclusive, out range);
         }
 
         private static class EventComparer<TEvent>
             where TEvent : ChartEvent
         {
-            public static readonly Func<TEvent, double, int> CompareTime = _CompareTime;
-            public static readonly Func<TEvent, uint, int> CompareTick = _CompareTick;
-
-            private static int _CompareTime(TEvent currentEvent, double targetTime)
-            {
-                if (currentEvent.Time == targetTime)
-                    return 0;
-                else if (currentEvent.Time < targetTime)
-                    return -1;
-                else
-                    return 1;
-            }
-
-            private static int _CompareTick(TEvent currentEvent, uint targetTick)
-            {
-                if (currentEvent.Tick == targetTick)
-                    return 0;
-                else if (currentEvent.Tick < targetTick)
-                    return -1;
-                else
-                    return 1;
-            }
+            public static readonly SearchComparison<TEvent, double> CompareTime = (ev, time) => ev.Time.CompareTo(time);
+            public static readonly SearchComparison<TEvent, uint> CompareTick = (ev, tick) => ev.Tick.CompareTo(tick);
         }
     }
 }

--- a/YARG.Core/Chart/Events/WaitCountdown.cs
+++ b/YARG.Core/Chart/Events/WaitCountdown.cs
@@ -48,7 +48,7 @@ namespace YARG.Core.Chart
             }
             else
             {
-                newMeasuresLeft = TotalMeasures - _measureBeatlines.GetIndexOfNext(currentTick);
+                newMeasuresLeft = TotalMeasures - _measureBeatlines.UpperBound(currentTick);
             }
 
             MeasuresLeft = newMeasuresLeft;

--- a/YARG.Core/Chart/Sync/SyncTrack.cs
+++ b/YARG.Core/Chart/Sync/SyncTrack.cs
@@ -193,7 +193,7 @@ namespace YARG.Core.Chart
         public double TickToTime(uint tick)
         {
             // Find the current tempo marker at the given tick
-            var currentTempo = Tempos.GetPrevious(tick);
+            var currentTempo = Tempos.LowerBoundElement(tick);
             if (currentTempo is null)
                 return 0;
 
@@ -211,7 +211,7 @@ namespace YARG.Core.Chart
                 return 0;
 
             // Find the current tempo marker at the given time
-            var currentTempo = Tempos.GetPrevious(time);
+            var currentTempo = Tempos.LowerBoundElement(time);
             if (currentTempo is null)
                 return 0;
 

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -939,7 +939,7 @@ namespace YARG.Core.Engine
                     // Increasing measure index if there's no more measures causes an exception
                     // Temporary fix by adding a check for the last measure
                     // Affects 1/1 time signatures
-                    int curMeasureIndex = allMeasureBeatLines.GetIndexOfPrevious(noteOneTickEnd);
+                    int curMeasureIndex = allMeasureBeatLines.LowerBound(noteOneTickEnd);
                     if (curMeasureIndex == -1)
                     {
                         // In songs with no events at time 0, it's possible to have no previous note.

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -181,8 +181,8 @@ namespace YARG.Core.Engine
 
                 double deltaTime = change.Time - prevChange.Time;
 
-                var tempo = syncTrack.Tempos.GetPrevious(change.Tick - 1);
-                var ts = syncTrack.TimeSignatures.GetPrevious(change.Tick - 1);
+                var tempo = syncTrack.Tempos.LowerBoundElement(change.Tick - 1);
+                var ts = syncTrack.TimeSignatures.LowerBoundElement(change.Tick - 1);
 
                 // Calculate the number of star power ticks that occur during this tempo
                 var starPowerTicks = GetStarPowerDrainPeriodToTicks(deltaTime, tempo!, ts!);

--- a/YARG.Core/Extensions/CollectionExtensions.cs
+++ b/YARG.Core/Extensions/CollectionExtensions.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace YARG.Core.Extensions
 {
+    public delegate int SearchComparison<in TItem, in TSearch>(TItem item, TSearch target);
+
     public static class CollectionExtensions
     {
         /// <summary>
@@ -49,61 +52,337 @@ namespace YARG.Core.Extensions
         }
 
         /// <summary>
-        /// Searches for an item in the list using the given search object and comparer function.
+        /// Searches for an item in the sorted list, using the given target value and comparer function.
         /// </summary>
         /// <returns>
-        /// The item from the list, or default if the list contains no elements.<br/>
-        /// If no exact match was found, the item returned is the one that matches the most closely.
+        /// The index of the item in the list, or -1 if the list contains no elements.
+        /// If no match was found, or multiple matches exist, the exact pick is unspecified, but will be
+        /// as close to the target value index-wise as possible.
+        /// Use <see cref="LowerBound"/> or <see cref="UpperBound"/> if precise behavior is needed.
         /// </returns>
-        public static TItem? BinarySearch<TItem, TSearch>(this List<TItem> list, TSearch searchObject,
-            Func<TItem, TSearch, int> comparer)
+        public static int BinarySearch<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer
+        )
+            where TList : IReadOnlyList<TItem>
         {
-            int index = list.BinarySearchIndex(searchObject, comparer);
-            if (index < 0)
-                return default;
-
-            return list[index];
-        }
-
-        /// <summary>
-        /// Searches for an item in the list using the given search object and comparer function.
-        /// </summary>
-        /// <returns>
-        /// The index of the item in the list, or -1 if the list contains no elements.<br/>
-        /// If no exact match was found, the index returned is that of the item that matches the most closely.
-        /// </returns>
-        public static int BinarySearchIndex<TItem, TSearch>(this List<TItem> list, TSearch searchObject,
-            Func<TItem, TSearch, int> comparer)
-        {
-            int low = 0;
-            int high = list.Count - 1;
+            int min = 0;
+            int max = list.Count - 1;
             int index = -1;
 
-            while (low <= high)
+            while (min <= max)
             {
-                int mid = (low + high) / 2;
-                index = mid;
+                // Select the midpoint of the current bounds
+                index = (min + max) / 2;
 
-                var current = list[mid];
-                int comparison = comparer(current, searchObject);
-                if (comparison == 0)
+                switch (comparer(list[index], target))
                 {
-                    // The objects are equal
-                    return index;
-                }
-                else if (comparison < 0)
-                {
-                    // The current object is less than the search object, exclude current lower bound
-                    low = mid + 1;
-                }
-                else
-                {
-                    // The current object is greater than the search object, exclude current higher bound
-                    high = mid - 1;
+                    case < 0:
+                    {
+                        // We're below the target, exclude current lower bound
+                        min = index + 1;
+                        break;
+                    }
+                    case > 0:
+                    {
+                        // We're above the target, exclude current higher bound
+                        max = index - 1;
+                        break;
+                    }
+                    default:
+                    {
+                        // Found a match
+                        return index;
+                    }
                 }
             }
 
             return index;
+        }
+
+        /// <summary>
+        /// Adjusts an index found through binary searching to the first occurence of the target value.
+        /// If the target value does not exist in the list, adjusts according to the
+        /// <c><paramref name="before"/></c> parameter.
+        /// </summary>
+        /// <param name="before">
+        /// If no exact match is found, whether to further adjust the final index to be below the target value.
+        /// Note that this may result in the index being outside the bounds of the list.
+        /// </param>
+        private static int AdjustToLowerBound<TList, TItem, TSearch>(
+            TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer,
+            int index,
+            bool before
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            while (index - 1 >= 0 && comparer(list[index - 1], target) >= 0)
+            {
+                index--;
+            }
+
+            // Further correct final position based on the given bias
+            if (before && comparer(list[index], target) > 0)
+            {
+                index--;
+            }
+            else if (!before && comparer(list[index], target) < 0)
+            {
+                index++;
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Adjusts an index found through binary searching to the first occurence of the next value
+        /// that is higher than the target value. Does nothing if the index value is already above the target.
+        /// </summary>
+        private static int AdjustToUpperBound<TList, TItem, TSearch>(
+            TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer,
+            int index
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            int count = list.Count;
+            while (index < count && comparer(list[index], target) <= 0)
+            {
+                index++;
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Searches for the first item in the sorted list that matches the target value,
+        /// determined using the given comparer function.
+        /// </summary>
+        /// <param name="before">
+        /// If no exact match is found, whether to further adjust the final index to be below the target value.
+        /// A value of <see langword="false"/> produces an index that can be used as a sorted insertion index
+        /// for the target value.
+        /// </param>
+        /// <returns>
+        /// The index of the first matching item in the list.
+        /// If multiple matches exist, the first occurrence (i.e. the lower bound) is picked.
+        /// If no match was found, the index returned is that of the last item that matches the closest,
+        /// with above/below being determined by the <c><paramref name="before"/></c> parameter.
+        /// <br/>
+        /// Note that the result index may be outside the bounds of the list depending on the exact
+        /// value and the value of <c><paramref name="before"/></c>. Use
+        /// <see cref="LowerBoundElement">LowerBoundElement</see> for a bounds-checked version that
+        /// also retrieves the element value directly.
+        /// </returns>
+        public static int LowerBound<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer,
+            bool before
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            int index = list.BinarySearch(target, comparer);
+            if (index >= 0)
+            {
+                index = AdjustToLowerBound(list, target, comparer, index, before);
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Searches for the first item in the sorted list that is greater than the target value,
+        /// determined using the given comparer function.
+        /// </summary>
+        /// <returns>
+        /// The index of the first matching item in the list, or -1 if the list contains no elements.
+        /// If no higher value exists, an index past the bounds of the list is returned
+        /// (i.e. <see cref="List{TItem}.Count"/>).
+        /// <br/>
+        /// Note that the result index may be outside the bounds of the list depending on the exact
+        /// value. Use <see cref="UpperBoundElement">UpperBoundElement</see> for a bounds-checked version
+        /// that also retrieves the element value directly.
+        /// </returns>
+        public static int UpperBound<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            int index = list.BinarySearch(target, comparer);
+            if (index >= 0)
+            {
+                index = AdjustToUpperBound(list, target, comparer, index);
+            }
+
+            return index;
+        }
+
+        /// <summary>
+        /// Searches for the first item in the sorted list that matches the target value,
+        /// determined using the given comparer function.
+        /// </summary>
+        /// <param name="before">
+        /// If no exact match is found, whether to further adjust the final result to be below the target value.
+        /// </param>
+        /// <returns>
+        /// True if the value was found, false otherwise.
+        /// </returns>
+        public static bool LowerBoundElement<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer,
+            bool before,
+            out TItem? value
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            int index = list.LowerBound(target, comparer, before);
+            if (index >= 0 && index < list.Count)
+            {
+                value = list[index];
+                return true;
+            }
+            else
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <inheritdoc cref="LowerBoundElement{TList, TItem, TSearch}(TList, TSearch, SearchComparison{TItem, TSearch}, bool, out TItem)"/>
+        /// <returns>
+        /// The value, if found; <c><see langword="default"/></c> otherwise.
+        /// </returns>
+        public static TItem? LowerBoundElement<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer,
+            bool before
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            list.LowerBoundElement(target, comparer, before, out var value);
+            return value;
+        }
+
+        /// <summary>
+        /// Searches for the first item in the sorted list that is greater than the target value,
+        /// determined using the given comparer function.
+        /// </summary>
+        /// <returns>
+        /// True if the value was found, false otherwise.
+        /// </returns>
+        public static bool UpperBoundElement<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer,
+            [MaybeNullWhen(false)] out TItem value
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            int index = list.UpperBound(target, comparer);
+            if (index >= 0 && index < list.Count)
+            {
+                value = list[index];
+                return true;
+            }
+            else
+            {
+                value = default;
+                return false;
+            }
+        }
+
+        /// <inheritdoc cref="UpperBoundElement{TList, TItem, TSearch}(TList, TSearch, SearchComparison{TItem, TSearch}, out TItem)"/>
+        /// <returns>
+        /// The value, if found; <c><see langword="default"/></c> otherwise.
+        /// </returns>
+        public static TItem? UpperBoundElement<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            list.UpperBoundElement(target, comparer, out var value);
+            return value;
+        }
+
+        /// <summary>
+        /// Searches for all contiguous items in the sorted list that match the target value,
+        /// determined using the given comparer function.
+        /// </summary>
+        /// <returns>
+        /// True if at least one matching value was found, false otherwise.
+        /// </returns>
+        public static bool FindEqualRange<TList, TItem, TSearch>(
+            this TList list,
+            TSearch target,
+            SearchComparison<TItem, TSearch> comparer,
+            out Range range
+        )
+            where TList : IReadOnlyList<TItem>
+        {
+            int index = list.BinarySearch(target, comparer);
+            if (index < 0 || comparer(list[index], target) != 0)
+            {
+                range = default;
+                return false;
+            }
+
+            int startIndex = AdjustToLowerBound(list, target, comparer, index, before: false);
+            int endIndex = AdjustToUpperBound(list, target, comparer, index);
+
+            range = startIndex..endIndex;
+            return true;
+        }
+
+        /// <summary>
+        /// Searches for all items in the sorted list that lie between the given start and end values,
+        /// determined using the given comparer function.
+        /// </summary>
+        /// <param name="endInclusive">
+        /// Whether the end value should be treated as inclusive, rather than exclusive.
+        /// </param>
+        /// <returns>
+        /// True if at least one value exists in the range, false otherwise.
+        /// </returns>
+        public static bool FindRange<TList, TItem, TSearch>(
+            this TList list,
+            TSearch start,
+            TSearch end,
+            SearchComparison<TItem, TSearch> comparer,
+            bool endInclusive,
+            out Range range
+        )
+            where TList : IReadOnlyList<TItem>
+            where TSearch : IComparable<TSearch>
+        {
+            if (start.CompareTo(end) > 0)
+            {
+                throw new InvalidOperationException("Range start cannot be greater than range end");
+            }
+
+            int startIndex = list.LowerBound(start, comparer, before: false);
+            int endIndex = endInclusive
+                ? list.UpperBound(end, comparer)
+                : list.LowerBound(end, comparer, before: false);
+
+            if (startIndex < 0 || endIndex < 0 || startIndex >= endIndex)
+            {
+                range = default;
+                return false;
+            }
+
+            range = startIndex..endIndex;
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
After some thinking recently, I realized the current binary search methods for chart events didn't have very well-defined semantics, and overall was dissatisfied with the names I chose for the methods in ChartEventExtensions, as they don't necessarily clearly indicate their intended use. So, I reworked things to hopefully make a little more sense and be more clearly documented.

None of the search methods are specific to chart events anymore, and they are all generic over `IReadOnlyList<T>`, so they aren't limited to just `List<T>`. (There's a small performance caveat for that due to technical reasons with using reference types as generic parameters, but in practice it should be negligible compared to everything else the game is already doing, especially currently.)

The new names are not all as self-evident as to what their use case is, but they have existing precedence by way of e.g. the C++ standard library, and they more clearly describe what the actual behavior of the search will be through that precedence and the accompanying doc comments.

Note for after merging: there's only one reference to any of these on the Unity side of things, so I don't really feel like going through a pull request over there lol. The necessary change is in `VocalTrack.cs` on line 493:
```diff
            // The most recent range shift before the start tick should still be preserved
-           uint rangesStart = _vocalsTrack.RangeShifts.GetPrevious(start).Tick;
+           uint rangesStart = _vocalsTrack.RangeShifts.LowerBoundElement(start).Tick;
            _vocalsTrack.RangeShifts.RemoveAll(n => n.Tick < rangesStart || n.Tick >= end);
```