### PR TITLE
Add support for "No Vocal Percussion" modifier

### DIFF
--- a/YARG.Core/Chart/Notes/VocalNote.cs
+++ b/YARG.Core/Chart/Notes/VocalNote.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Linq;
 
 namespace YARG.Core.Chart
 {
@@ -69,6 +70,11 @@ namespace YARG.Core.Chart
         /// Whether or not this note is a vocal phrase.
         /// </summary>
         public bool IsPhrase => Type == VocalNoteType.Phrase;
+
+        /// <summary>
+        /// Whether or not this note is a vocal phrase that contains no notes.
+        /// </summary>
+        public bool IsEmptyPhrase => Type == VocalNoteType.Phrase && ChildNotes.Count == 0;
 
         /// <summary>
         /// Creates a new <see cref="VocalNote"/> with the given properties.
@@ -202,6 +208,11 @@ namespace YARG.Core.Chart
         protected override VocalNote CloneNote()
         {
             return new(this);
+        }
+
+        public void RemovePercussionChildNotes()
+        {
+            _childNotes.RemoveAll(e => e.Type == VocalNoteType.Percussion);
         }
     }
 

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-
-namespace YARG.Core.Chart
+﻿namespace YARG.Core.Chart
 {
     public static class VocalsPartExtensions
     {
@@ -48,19 +44,19 @@ namespace YARG.Core.Chart
 
         public static void RemovePercussion(this VocalsPart vocalsTrack)
         {
-            var phrasesToRemove = new List<VocalsPhrase>();
-            foreach (var phrase in vocalsTrack.NotePhrases)
+            int i = 0;
+            while (i < vocalsTrack.NotePhrases.Count)
             {
+                var phrase = vocalsTrack.NotePhrases[i];
                 phrase.PhraseParentNote.RemovePercussionChildNotes();
+
                 if (phrase.IsEmpty)
                 {
-                    phrasesToRemove.Add(phrase);
+                    vocalsTrack.NotePhrases.RemoveAt(i);
+                    continue;
                 }
-            }
 
-            foreach (var phrase in phrasesToRemove)
-            {
-                vocalsTrack.NotePhrases.Remove(phrase);
+                i++;
             }
         }
     }

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace YARG.Core.Chart
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace YARG.Core.Chart
 {
     public static class VocalsPartExtensions
     {
@@ -39,6 +43,24 @@
                 var newPhrase = new VocalsPhrase(phrase.Time, phrase.TimeLength, phrase.Tick, phrase.TickLength,
                     newPhraseParent, phrase.Lyrics);
                 vocalsTrack.NotePhrases[i] = newPhrase;
+            }
+        }
+
+        public static void RemovePercussion(this VocalsPart vocalsTrack)
+        {
+            var phrasesToRemove = new List<VocalsPhrase>();
+            foreach (var phrase in vocalsTrack.NotePhrases)
+            {
+                phrase.PhraseParentNote.RemovePercussionChildNotes();
+                if (phrase.IsEmpty)
+                {
+                    phrasesToRemove.Add(phrase);
+                }
+            }
+
+            foreach (var phrase in phrasesToRemove)
+            {
+                vocalsTrack.NotePhrases.Remove(phrase);
             }
         }
     }

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPhrase.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPhrase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using YARG.Core.Extensions;
 
@@ -16,6 +16,8 @@ namespace YARG.Core.Chart
         public bool IsPercussion => PhraseParentNote.IsPercussion;
 
         public bool IsStarPower => PhraseParentNote.IsStarPower;
+
+        public bool IsEmpty => PhraseParentNote.IsEmptyPhrase;
 
         public VocalsPhrase(double time, double timeLength, uint tick, uint tickLength,
             VocalNote phraseParentNote, List<LyricEvent> lyrics)

--- a/YARG.Core/Game/Modifier.cs
+++ b/YARG.Core/Game/Modifier.cs
@@ -16,6 +16,7 @@ namespace YARG.Core.Game
         NoKicks       = 1 << 6,
         UnpitchedOnly = 1 << 7,
         NoDynamics    = 1 << 8,
+        NoVocalPercussion = 1 << 9,
     }
 
     public static class ModifierConflicts
@@ -51,7 +52,8 @@ namespace YARG.Core.Game
                     Modifier.NoDynamics,
 
                 GameMode.Vocals =>
-                    Modifier.UnpitchedOnly,
+                    Modifier.UnpitchedOnly |
+                    Modifier.NoVocalPercussion,
 
                 GameMode.SixFretGuitar or
             //  GameMode.EliteDrums    or

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using Newtonsoft.Json;
 using YARG.Core.Chart;
@@ -220,6 +220,11 @@ namespace YARG.Core.Game
             if (IsModifierActive(Modifier.UnpitchedOnly))
             {
                 vocalsPart.ConvertAllToUnpitched();
+            }
+
+            if (IsModifierActive(Modifier.NoVocalPercussion))
+            {
+                vocalsPart.RemovePercussion();
             }
         }
 


### PR DESCRIPTION
This PR adds a new modifier for vocals: No Vocal Percussion. This removes all percussion (tambourine, cowbell, etc) notes from the vocals track. Solves https://discord.com/channels/1086048856678084609/1297003257088184330