### PR TITLE
Harmonies: Track notes that cross over phrase boundaries

### DIFF
--- a/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using YARG.Core.Chart;
 using YARG.Core.Input;
 using YARG.Core.Logging;
@@ -118,6 +120,8 @@ namespace YARG.Core.Engine.Vocals.Engines
                 {
                     OnPhraseHit?.Invoke(percentHit / EngineParameters.PhraseHitPercent, hit);
                 }
+
+                UpdateCarriedNote(phrase);
             }
         }
 

--- a/YARG.Core/Engine/Vocals/VocalsStats.cs
+++ b/YARG.Core/Engine/Vocals/VocalsStats.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using YARG.Core.Extensions;
 using YARG.Core.IO;
 using YARG.Core.Replays;
@@ -22,6 +23,8 @@ namespace YARG.Core.Engine.Vocals
         /// </summary>
         public uint TotalTicks => TicksHit + TicksMissed;
 
+        public bool HasCarryNote;
+
         public override float Percent => TotalTicks == 0 ? 1f : (float) TicksHit / TotalTicks;
 
         public override int BandComboUnits => 10;
@@ -34,6 +37,7 @@ namespace YARG.Core.Engine.Vocals
         {
             TicksHit = stats.TicksHit;
             TicksMissed = stats.TicksMissed;
+            HasCarryNote = stats.HasCarryNote;
         }
 
         public VocalsStats(ref FixedArrayStream stream, int version)
@@ -41,6 +45,7 @@ namespace YARG.Core.Engine.Vocals
         {
             TicksHit = stream.Read<uint>(Endianness.Little);
             TicksMissed = stream.Read<uint>(Endianness.Little);
+            HasCarryNote = stream.ReadBoolean();
         }
 
         public override void Reset()
@@ -48,6 +53,7 @@ namespace YARG.Core.Engine.Vocals
             base.Reset();
             TicksHit = 0;
             TicksMissed = 0;
+            HasCarryNote = false;
         }
 
         public override void Serialize(BinaryWriter writer)
@@ -56,6 +62,7 @@ namespace YARG.Core.Engine.Vocals
 
             writer.Write(TicksHit);
             writer.Write(TicksMissed);
+            writer.Write(HasCarryNote);
         }
 
         public override ReplayStats ConstructReplayStats(string name)


### PR DESCRIPTION
This PR fixes a long standing issue with harmony charts that have notes that cross over phrase boundaries, such as this one:

![image](https://github.com/user-attachments/assets/e994b841-0a0f-424f-9efd-2ee11602c020)

This situation will cause two bugs to occur. Firstly, the full length of the affected note is counted as part of the left phrase. Depending on how much of that note happens to be in the next phrase, this can cause the left phrase to be more difficult, or even completely impossible, to obtain an AWESOME rating. Secondly, during the following phrase, the note is ignored entirely and cannot be hit at all. If this is the only note in that phrase, then the phrase is essentially considered "empty", and won't award any points.

Solves issue YARG-104. This PR also fixes an unrelated issue where the total number of SP phrases in a chart would be incorrect on the result screen for harmony players. Note that due to this PR, some harmony charts will have more valid phrases in them than before, raising the maximum possible score for them.

![Screenshot 2025-03-25 115145](https://github.com/user-attachments/assets/49002b6d-890c-424f-bf54-75bc9dcd0b35)
