### PR TITLE
Generate weak beatlines from sync track MIDI note 14

### DIFF
--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidIOHelper.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidIOHelper.cs
@@ -110,8 +110,9 @@ namespace MoonscraperChartEditor.Song.IO
         public const byte PRO_GUITAR_CHANNEL_PINCH_HARMONIC = 6;
 
         // Beat track notes
-        public const byte BEAT_STRONG = 12;
-        public const byte BEAT_WEAK = 13;
+        public const byte BEAT_MEASURE = 12;
+        public const byte BEAT_STRONG = 13;
+        public const byte BEAT_WEAK = 14;
 
         // These events are valid both with and without brackets.
         // The bracketed versions follow the style of other existing .mid text events.

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -110,7 +110,7 @@ namespace MoonscraperChartEditor.Song.IO
             // Apply settings
             song.hopoThreshold = settings.HopoThreshold > ParseSettings.SETTING_DEFAULT
                 // +1 for a small bit of leniency
-                ? (uint)settings.HopoThreshold + 1 
+                ? (uint)settings.HopoThreshold + 1
                 : (song.resolution / 3) + 1;
 
             if (settings.SustainCutoffThreshold <= ParseSettings.SETTING_DEFAULT)
@@ -236,11 +236,14 @@ namespace MoonscraperChartEditor.Song.IO
                     BeatlineType beatType;
                     switch ((byte)note.NoteNumber)
                     {
-                        case MidIOHelper.BEAT_STRONG:
+                        case MidIOHelper.BEAT_MEASURE:
                             beatType = BeatlineType.Measure;
                             break;
-                        case MidIOHelper.BEAT_WEAK:
+                        case MidIOHelper.BEAT_STRONG:
                             beatType = BeatlineType.Strong;
+                            break;
+                        case MidIOHelper.BEAT_WEAK:
+                            beatType = BeatlineType.Weak;
                             break;
                         default:
                             continue;


### PR DESCRIPTION
Per charting team request, this PR adds support for specifying weak beats using MIDI note 14.

Before:
![weak beatline off comparison](https://github.com/user-attachments/assets/2ec1e535-e204-482d-88c4-5b490e380a49)


After:
![weak beatline on comparison](https://github.com/user-attachments/assets/88c80123-7ad6-48a7-abdd-4e2c61533fe8)

