### PR TITLE
Add modifier to shift all notes into starting range, etc.

### DIFF
--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -154,41 +154,6 @@ namespace YARG.Core.Chart
             }
         }
 
-        /// <summary>
-        /// Creates a new note group not including the indicated child
-        /// </summary>
-        /// <param name="notes"></param>
-        /// <param name="index"></param>
-        /// <param name="childIndex"></param>
-        public static void RemoveChildFromNote(this List<GuitarNote> notes, int index, int childIndex)
-        {
-            var oldNote = notes[index];
-            var newNote = notes[index].CloneWithoutChildNotes();
-
-            for(int i = 0; i < oldNote.ChildNotes.Count; i++)
-            {
-                if (childIndex != i)
-                {
-                    newNote.AddChildNote(oldNote.ChildNotes[i]);
-                }
-            }
-
-            // Stitch references
-            if (oldNote.PreviousNote != null)
-            {
-                newNote.PreviousNote = oldNote.PreviousNote;
-                oldNote.PreviousNote.NextNote = newNote;
-            }
-
-            if (oldNote.NextNote != null)
-            {
-                newNote.NextNote = oldNote.NextNote;
-                oldNote.NextNote.PreviousNote = newNote;
-            }
-
-            notes[index] = newNote;
-        }
-
         public static double GetStartTime<TEvent>(this List<TEvent> events)
             where TEvent : ChartEvent
         {

--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -118,58 +118,36 @@ namespace YARG.Core.Chart
 
                 notes.RemoveAt(index);
 
-                // If there is now only one note, previous and next both need to be set to null
-                if (notes.Count == 1)
-                {
-                    notes[0].PreviousNote = null;
-                    notes[0].NextNote = null;
-                    return;
-                }
-
-                // Past this point, we can be assured that notes[0] and notes[^1] are valid and don't refer
-                // to the same note
-
-                // Fix Previous/Next references
-                if (index == 0)
-                {
-                    // We were the first, so new 0's previous becomes null and everything else is fine
-                    notes[0].PreviousNote = null;
-                    return;
-                }
-
-                // We have already removed a note so index will equal notes.Count if it is referring
-                // to what was previously the last note in the chart
-                if (index == notes.Count)
-                {
-                    // We were the last, so new last's next becomes null and everything else is fine
-                    notes[^1].NextNote = null;
-                    return;
-                }
-
-                // We're somewhere in the middle, so we have to stitch references back together
-                // note is no longer good, so back to indexed access
-                notes[index - 1].NextNote = notes[index];
-                notes[index].PreviousNote = notes[index].PreviousNote;
-            }
-            else
-            {
-                // Promote first child to parent, reparent other children, and stitch references
-                var newParent = notes[index].ChildNotes[0].Clone();
-                for (var i = 1; i < notes[index].ChildNotes.Count; i++)
-                {
-                    newParent.AddChildNote(notes[index].ChildNotes[i]);
-                }
-
                 if (note.PreviousNote != null)
                 {
-                    newParent.PreviousNote = note.PreviousNote;
-                    note.PreviousNote.NextNote = newParent;
+                    note.PreviousNote.NextNote = note.NextNote;
                 }
 
                 if (note.NextNote != null)
                 {
-                    newParent.NextNote = note.NextNote;
-                    note.NextNote.PreviousNote = newParent;
+                    note.NextNote.PreviousNote = note.PreviousNote;
+                }
+            }
+            else
+            {
+                // Promote first child to parent, reparent other children, and stitch references
+                var newParent = note.ChildNotes[0].Clone();
+                for (var i = 1; i < note.ChildNotes.Count; i++)
+                {
+                    newParent.AddChildNote(note.ChildNotes[i]);
+                }
+
+                newParent.PreviousNote = note.PreviousNote;
+                newParent.NextNote = note.NextNote;
+
+                if (newParent.PreviousNote != null)
+                {
+                    newParent.PreviousNote.NextNote = newParent;
+                }
+
+                if (newParent.NextNote != null)
+                {
+                    newParent.NextNote.PreviousNote = newParent;
                 }
 
                 notes[index] = newParent;

--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -41,6 +41,171 @@ namespace YARG.Core.Chart
             return newNotes;
         }
 
+        // Remove note from list in place, adjusting references as required
+        public static void RemoveNoteAt(this List<GuitarNote> notes, int index)
+        {
+            if (notes[index].ChildNotes.Count == 0)
+            {
+                // The simple case, when there are no children
+                // Well, simple except for having to deal with all the flags that may need to move
+                if (notes[index].IsSoloStart && !notes[index].IsSoloEnd)
+                {
+                    // This is a single note that is a solo start, we have to move it to the
+                    // NEXT note (we don't want to extend the solo).
+                    if (index < notes.Count)
+                    {
+                        notes[index + 1].Flags |= NoteFlags.SoloStart;
+                        // Also add it to the child notes
+                        foreach (var childNote in notes[index].ChildNotes)
+                        {
+                            childNote.Flags |= NoteFlags.SoloStart;
+                        }
+                    }
+                }
+
+                if (notes[index].IsSoloEnd)
+                {
+                    // This is a single kick drum note that is a solo end, we have to move it to the
+                    // PREVIOUS note (we don't want to extend the solo).
+                    if (index > 0)
+                    {
+                        notes[index - 1].Flags |= NoteFlags.SoloEnd;
+                        // Also add it to the child notes
+                        foreach (var childNote in notes[index - 1].ChildNotes)
+                        {
+                            childNote.Flags |= NoteFlags.SoloEnd;
+                        }
+                    }
+                }
+
+
+                if (notes[index].IsStarPowerStart && !notes[index].IsStarPowerEnd)
+                {
+                    // Make the next note the SP start, so as to not extend the SP section
+                    if (index < notes.Count)
+                    {
+                        notes[index + 1].Flags |= NoteFlags.StarPowerStart;
+                        // Also add it to the child notes
+                        foreach (var childNote in notes[index].ChildNotes)
+                        {
+                            childNote.Flags |= NoteFlags.StarPowerStart;
+                        }
+                    }
+                }
+
+                if (notes[index].IsStarPowerEnd)
+                {
+                    // This is a single kick drum note that is a starpower end, we have to move it to the
+                    // PREVIOUS note (we don't want to extend the starpower section).
+                    if (index > 0)
+                    {
+                        notes[index - 1].Flags |= NoteFlags.StarPowerEnd;
+                        // Also add it to the child notes
+                        foreach (var childNote in notes[index - 1].ChildNotes)
+                        {
+                            childNote.Flags |= NoteFlags.StarPowerEnd;
+                        }
+                    }
+                }
+
+                notes.RemoveAt(index);
+
+                // Fix Previous/Next references
+                if (index == 0)
+                {
+                    // We were the first, so new 0's previous becomes null and everything else is fine
+                    notes[0].PreviousNote = null;
+                    return;
+                }
+
+                if (index == notes.Count)
+                {
+                    // We were the last, so new last's next becomes null and everything else is fine
+                    notes[^1].NextNote = null;
+                    return;
+                }
+
+                // We're somewhere in the middle, so we have to stitch references back together
+                notes[index - 1].NextNote = notes[index];
+                notes[index].PreviousNote = notes[index - 1];
+            }
+            else
+            {
+                // Promote first child to parent, reparent other children, and stitch references
+                var newParent = notes[index].ChildNotes[0].Clone();
+                for (var i = 1; i < notes[index].ChildNotes.Count; i++)
+                {
+                    newParent.AddChildNote(notes[index].ChildNotes[i]);
+                }
+
+                if (index > 0)
+                {
+                    newParent.PreviousNote = notes[index - 1];
+                    notes[index - 1].NextNote = newParent;
+                }
+                else
+                {
+                    newParent.PreviousNote = null;
+                }
+
+                if (index < notes.Count - 1)
+                {
+                    newParent.NextNote = notes[index + 1];
+                    notes[index + 1].PreviousNote = newParent;
+                }
+                else
+                {
+                    newParent.NextNote = null;
+                }
+
+                notes[index] = newParent;
+            }
+        }
+
+        /// <summary>
+        /// Creates a new note group not including the indicated child
+        /// </summary>
+        /// <param name="notes"></param>
+        /// <param name="index"></param>
+        /// <param name="childIndex"></param>
+        public static void RemoveChildFromNote(this List<GuitarNote> notes, int index, int childIndex)
+        {
+            var newNote = notes[index].CloneWithoutChildNotes();
+
+            for(int i = 0; i < notes[index].ChildNotes.Count; i++)
+            {
+                if (childIndex == i)
+                {
+                    continue;
+                }
+
+                newNote.AddChildNote(notes[index].ChildNotes[i]);
+            }
+
+            // Stitch references
+            if (index > 0)
+            {
+                newNote.PreviousNote = notes[index - 1];
+                notes[index - 1].NextNote = newNote;
+            }
+            else
+            {
+                newNote.PreviousNote = null;
+            }
+
+            if (index < notes.Count - 1)
+            {
+                newNote.NextNote = notes[index + 1];
+                notes[index + 1].PreviousNote = newNote;
+            }
+            else
+            {
+                newNote.NextNote = null;
+            }
+
+            notes[index] = newNote;
+        }
+
         public static double GetStartTime<TEvent>(this List<TEvent> events)
             where TEvent : ChartEvent
         {

--- a/YARG.Core/Chart/Events/RangeShift.cs
+++ b/YARG.Core/Chart/Events/RangeShift.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace YARG.Core.Chart
+{
+    public class RangeShift : ChartEvent, ICloneable<RangeShift>
+    {
+        public int Range;
+        public int Size;
+
+        public RangeShift(double time, double timeLength, uint tick, uint tickLength, int range, int size)
+            : base(time, timeLength, tick, tickLength)
+        {
+            Range = range;
+            Size = size;
+        }
+
+        public RangeShift(RangeShift other) : base(other)
+        {
+            Range = other.Range;
+            Size = other.Size;
+        }
+
+        public RangeShift Clone()
+        {
+            return new RangeShift(this);
+        }
+    }
+}

--- a/YARG.Core/Chart/Notes/GuitarNote.cs
+++ b/YARG.Core/Chart/Notes/GuitarNote.cs
@@ -7,9 +7,9 @@ namespace YARG.Core.Chart
         private GuitarNoteFlags _guitarFlags;
         public GuitarNoteFlags GuitarFlags;
 
-        public int Fret         { get; }
-        public int DisjointMask { get; }
-        public int NoteMask     { get; private set; }
+        public int Fret         { get; set; }
+        public int DisjointMask { get; set; }
+        public int NoteMask     { get; set; }
 
         public GuitarNoteType Type { get; set; }
 

--- a/YARG.Core/Chart/Notes/Note.cs
+++ b/YARG.Core/Chart/Notes/Note.cs
@@ -67,7 +67,7 @@ namespace YARG.Core.Chart
         public uint SustainTicksHeld;
 
         public TNote? Parent { get; private set; }
-        public IReadOnlyList<TNote> ChildNotes => _childNotes;
+        public List<TNote> ChildNotes => _childNotes;
 
         /// <summary>
         /// Returns this note's parent, and if it's null, returns itself instead.

--- a/YARG.Core/Chart/SongChart.AutoGeneration.cs
+++ b/YARG.Core/Chart/SongChart.AutoGeneration.cs
@@ -508,7 +508,10 @@ namespace YARG.Core.Chart
 
                         var range = int.Parse(splitEvent[2]);
 
-                        if (!int.TryParse(splitEvent[3], out size))
+                        // If the third param doesn't exist or can't be parsed, use a default
+                        // The event has already been validated as being not entirely malformed by the time we reach
+                        // this point, so we can rely on splitEvent.Length being exactly 3 or 4 here.
+                        if (splitEvent.Length == 3 || !int.TryParse(splitEvent[3], out size))
                         {
                             size = instrumentDifficulty.Difficulty switch
                             {

--- a/YARG.Core/Chart/SongChart.AutoGeneration.cs
+++ b/YARG.Core/Chart/SongChart.AutoGeneration.cs
@@ -519,7 +519,7 @@ namespace YARG.Core.Chart
                         }
 
                         var newPhrase = new RangeShift(time, timeEnd - time, tick, tickEnd - tick, range, size);
-                        int newPhraseIndex = instrumentDifficulty.RangeShiftEvents.GetIndexOfNext(newPhrase.Tick);
+                        int newPhraseIndex = instrumentDifficulty.RangeShiftEvents.UpperBound(newPhrase.Tick);
 
                         // Add or insert the new event into the list for the given instrument difficulty
                         if (newPhraseIndex == -1)

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -155,6 +155,8 @@ namespace YARG.Core.Chart
 
             // Use beatlines to place auto-generated drum activation phrases for charts without manually authored phrases
             CreateDrumActivationPhrases();
+            // Add range shift phrases, done here since they are parsed from text events
+            CreateRangeShiftPhrases();
 
             PostProcessSections();
             FixDrumPhraseEnds();

--- a/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
+++ b/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
@@ -13,9 +13,10 @@ namespace YARG.Core.Chart
         public Instrument Instrument { get; }
         public Difficulty Difficulty { get; }
 
-        public List<TNote> Notes { get; } = new();
-        public List<Phrase> Phrases { get; } = new();
-        public List<TextEvent> TextEvents { get; } = new();
+        public List<TNote>      Notes            { get; } = new();
+        public List<Phrase>     Phrases          { get; } = new();
+        public List<TextEvent>  TextEvents       { get; } = new();
+        public List<RangeShift> RangeShiftEvents { get; } = new();
 
         /// <summary>
         /// Whether or not this difficulty contains any data.
@@ -39,11 +40,22 @@ namespace YARG.Core.Chart
             Notes = notes;
             Phrases = phrases;
             TextEvents = text;
+            RangeShiftEvents = new List<RangeShift>();
+        }
+
+        public InstrumentDifficulty(Instrument instrument, Difficulty difficulty,
+            List<TNote> notes, List<Phrase> phrases, List<TextEvent> text, List<RangeShift> shifts)
+            : this(instrument, difficulty)
+        {
+            Notes = notes;
+            Phrases = phrases;
+            TextEvents = text;
+            RangeShiftEvents = shifts;
         }
 
         public InstrumentDifficulty(InstrumentDifficulty<TNote> other)
             : this(other.Instrument, other.Difficulty, other.Notes.DuplicateNotes(), other.Phrases.Duplicate(),
-                other.TextEvents.Duplicate())
+                other.TextEvents.Duplicate(), other.RangeShiftEvents.Duplicate())
         {
         }
 

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -8,7 +8,7 @@ namespace YARG.Core.Engine.Guitar
     public abstract class GuitarEngine : BaseEngine<GuitarNote, GuitarEngineParameters,
         GuitarStats>
     {
-        protected const byte OPEN_MASK = 64;
+        public const byte OPEN_MASK = 64;
 
         public delegate void OverstrumEvent();
 

--- a/YARG.Core/Game/Modifier.cs
+++ b/YARG.Core/Game/Modifier.cs
@@ -17,6 +17,7 @@ namespace YARG.Core.Game
         UnpitchedOnly = 1 << 7,
         NoDynamics    = 1 << 8,
         NoVocalPercussion = 1 << 9,
+        RangeCompress = 1 << 10,
     }
 
     public static class ModifierConflicts
@@ -40,11 +41,12 @@ namespace YARG.Core.Game
             return gameMode switch
             {
                 GameMode.FiveFretGuitar =>
-                    Modifier.AllStrums   |
-                    Modifier.AllHopos    |
-                    Modifier.AllTaps     |
-                    Modifier.HoposToTaps |
-                    Modifier.TapsToHopos,
+                    Modifier.AllStrums     |
+                    Modifier.AllHopos      |
+                    Modifier.AllTaps       |
+                    Modifier.HoposToTaps   |
+                    Modifier.TapsToHopos   |
+                    Modifier.RangeCompress,
 
                 GameMode.FourLaneDrums or
                 GameMode.FiveLaneDrums =>

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -11,7 +11,7 @@ namespace YARG.Core.Game
 {
     public class YargProfile
     {
-        private const int PROFILE_VERSION = 2;
+        private const int PROFILE_VERSION = 3;
 
         public Guid Id;
         public string Name;
@@ -24,6 +24,8 @@ namespace YARG.Core.Game
         public float HighwayLength;
 
         public bool LeftyFlip;
+
+        public bool RangeEnabled;
 
         public int? AutoConnectOrder;
 
@@ -55,7 +57,7 @@ namespace YARG.Core.Game
 
         /// <summary>
         /// The difficulty to be saved in the profile.
-        /// 
+        ///
         /// If a song does not contain this difficulty, so long as the player
         /// does not *explicitly* and *manually* change the difficulty, this value
         /// should remain unchanged.
@@ -93,6 +95,7 @@ namespace YARG.Core.Game
             NoteSpeed = 6;
             HighwayLength = 1;
             LeftyFlip = false;
+            RangeEnabled = true;
 
             // Set preset IDs to default
             ColorProfile = Game.ColorProfile.Default.Id;
@@ -133,6 +136,11 @@ namespace YARG.Core.Game
             LeftyFlip = stream.ReadBoolean();
 
             GameMode = CurrentInstrument.ToGameMode();
+
+            if (version >= 3)
+            {
+                RangeEnabled = stream.ReadBoolean();
+            }
         }
 
         public void AddSingleModifier(Modifier modifier)
@@ -188,6 +196,10 @@ namespace YARG.Core.Game
                     else if (IsModifierActive(Modifier.TapsToHopos))
                     {
                         guitarTrack.ConvertFromTypeToType(GuitarNoteType.Tap, GuitarNoteType.Hopo);
+                    }
+                    else if (IsModifierActive(Modifier.RangeCompress))
+                    {
+                        guitarTrack.CompressGuitarRange();
                     }
 
                     break;
@@ -259,6 +271,8 @@ namespace YARG.Core.Game
             writer.Write(NoteSpeed);
             writer.Write(HighwayLength);
             writer.Write(LeftyFlip);
+
+            writer.Write(RangeEnabled);
         }
     }
 }


### PR DESCRIPTION
This PR adds a new modifier to compress all ranges into the song's starting range. (assuming that the song supports range shifts)

For example, if a song starts with the GRY range and later shifts to YBO, the YBO notes will be transposed to GRY notes.

For more background on what range shifts even are, see the [relevant proposal](https://discord.com/channels/1086048856678084609/1344362559347621960) on Discord.

Currently a draft because we don't yet have a modifier icon. 