### PR TITLE
Fix crunchy audio when using whammy

### DIFF
--- a/YARG.Core/Audio/GlobalAudioHandler.cs
+++ b/YARG.Core/Audio/GlobalAudioHandler.cs
@@ -13,7 +13,7 @@ namespace YARG.Core.Audio
 
     public static class GlobalAudioHandler
     {
-        public const int WHAMMY_FFT_DEFAULT = 512;
+        public const int WHAMMY_FFT_DEFAULT = 2048;
         public const int WHAMMY_OVERSAMPLE_DEFAULT = 8;
         public static readonly int MAX_THREADS = Environment.ProcessorCount switch
         {


### PR DESCRIPTION
FFT must be at least 2048 or audio gets crunchy

Crunchy:
https://github.com/user-attachments/assets/47852b74-7c68-4e93-9ce9-bf02f6fdb91f

Fixed:
https://github.com/user-attachments/assets/39f8c618-6571-41d8-b77d-1c8649cad38d