### PR TITLE
Implement sorting by stars in song library

### DIFF
--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -38,6 +38,8 @@ namespace YARG.Core.Song.Cache
 
         public static ScanProgressTracker Progress => _progress;
         private static ScanProgressTracker _progress;
+        public static IPlayerContext? PlayerContext { get; set; }
+        public static IStarProvider? StarProvider { get; set; }
 
         public static SongCache RunScan(bool tryQuickScan, string cacheLocation, string badSongsLocation, bool fullDirectoryPlaylists, List<string> baseDirectories)
         {

--- a/YARG.Core/Song/Cache/CacheNodes.cs
+++ b/YARG.Core/Song/Cache/CacheNodes.cs
@@ -14,11 +14,12 @@ namespace YARG.Core.Song
         public int Charter;
         public int Playlist;
         public int Source;
+        public int star;
     }
 
     internal class CacheReadStrings
     {
-        public const int NUM_CATEGORIES = 8;
+        public const int NUM_CATEGORIES = 9;
 
         private string[][] _categories = new string[NUM_CATEGORIES][];
 
@@ -30,6 +31,7 @@ namespace YARG.Core.Song
         public string[] Charters  => _categories[5];
         public string[] Playlists => _categories[6];
         public string[] Sources   => _categories[7];
+        public string[] Stars     => _categories[8];
 
         public unsafe CacheReadStrings(FixedArrayStream* stream)
         {

--- a/YARG.Core/Song/Cache/IPlayerContext.cs
+++ b/YARG.Core/Song/Cache/IPlayerContext.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace YARG.Core.Song.Cache
+{
+    public interface IPlayerContext
+    {
+        Guid GetCurrentPlayerId();
+    }
+}

--- a/YARG.Core/Song/Cache/IPlayerContext.cs
+++ b/YARG.Core/Song/Cache/IPlayerContext.cs
@@ -5,5 +5,9 @@ namespace YARG.Core.Song.Cache
     public interface IPlayerContext
     {
         Guid GetCurrentPlayerId();
+
+        Instrument GetCurrentInstrument();
+
+        Difficulty GetCurrentDifficulty();
     }
 }

--- a/YARG.Core/Song/Cache/IStarProvider.cs
+++ b/YARG.Core/Song/Cache/IStarProvider.cs
@@ -1,0 +1,10 @@
+using System;
+using YARG.Core.Game;
+
+namespace YARG.Core.Song.Cache
+{
+    public interface IStarProvider
+    {
+        StarAmount GetBestStarsForSong(HashWrapper songHash, Guid playerId);
+    }
+}

--- a/YARG.Core/Song/Cache/IStarProvider.cs
+++ b/YARG.Core/Song/Cache/IStarProvider.cs
@@ -5,6 +5,6 @@ namespace YARG.Core.Song.Cache
 {
     public interface IStarProvider
     {
-        StarAmount GetBestStarsForSong(HashWrapper songHash, Guid playerId);
+        public StarAmount GetBestStarsForSong(HashWrapper songHash, Guid playerId, Instrument instrument, Difficulty difficulty);
     }
 }

--- a/YARG.Core/Song/Cache/SongCache.cs
+++ b/YARG.Core/Song/Cache/SongCache.cs
@@ -26,6 +26,7 @@ namespace YARG.Core.Song
         public readonly SortedDictionary<SortString, List<SongEntry>> Charters     = new();
         public readonly SortedDictionary<SortString, List<SongEntry>> Playlists    = new();
         public readonly SortedDictionary<SortString, List<SongEntry>> Sources      = new();
+        public readonly SortedDictionary<string,     List<SongEntry>> Stars        = new();
 
         [NonSerialized]
         public readonly SortedDictionary<string,     List<SongEntry>> SongLengths  = new();

--- a/YARG.Core/Song/Entries/SongEntry.Sorting.cs
+++ b/YARG.Core/Song/Entries/SongEntry.Sorting.cs
@@ -22,6 +22,7 @@ namespace YARG.Core.Song
         Source,
         SongLength,
         DateAdded,
+        Star,
     };
 
     public static class SongEntrySorting
@@ -185,10 +186,28 @@ namespace YARG.Core.Song
             }
         }
 
+        private readonly struct StarComparer : IComparer<SongEntry>
+        {
+            public static readonly StarComparer Instance = default;
+
+            public readonly int Compare(SongEntry lhs, SongEntry rhs)
+            {
+                if (lhs.StarsAsNumber != rhs.StarsAsNumber)
+                {
+                    if (lhs.StarsAsNumber == int.MaxValue) return 1;
+                    if (rhs.StarsAsNumber == int.MaxValue) return -1;
+                    return rhs.StarsAsNumber.CompareTo(lhs.StarsAsNumber); // Descending
+                }
+
+                return MetadataComparer.Instance.Compare(lhs, rhs);
+            }
+        }
+
         private static readonly unsafe delegate*<SongCache, void>[] SORTERS =
         {
-            &SortByTitle,    &SortByArtist, &SortByAlbum,       &SortByGenre,  &SortByYear,      &SortByCharter,
-            &SortByPlaylist, &SortBySource, &SortByArtistAlbum, &SortByLength, &SortByDateAdded, &SortByInstruments
+            &SortByTitle, &SortByArtist, &SortByAlbum, &SortByGenre, &SortByYear,
+            &SortByArtistAlbum, &SortByCharter, &SortByPlaylist, &SortBySource,
+            &SortByLength, &SortByDateAdded, &SortByInstruments,  &SortByStars,
         };
 
         internal static unsafe void SortEntries(SongCache cache)
@@ -448,6 +467,24 @@ namespace YARG.Core.Song
                     }
                 }
             });
+        }
+
+        private static void SortByStars(SongCache cache)
+        {
+            foreach (var list in cache.Entries)
+            {
+                foreach (var entry in list.Value)
+                {
+                    var stars = entry.ParsedStars;
+                    if (!cache.Stars.TryGetValue(stars, out var category))
+                    {
+                        cache.Stars.Add(stars, category = new List<SongEntry>());
+                    }
+
+                    int index = category.BinarySearch(entry, StarComparer.Instance);
+                    category.Insert(~index, entry);
+                }
+            }
         }
 
         private static readonly unsafe delegate*<SongCache, Dictionary<SongEntry, CacheWriteIndices>, List<string>>[] COLLECTORS =

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -6,7 +6,6 @@ using YARG.Core.Game;
 using YARG.Core.IO;
 using YARG.Core.Song.Cache;
 using YARG.Core.Utility;
-using System.Diagnostics;
 
 namespace YARG.Core.Song
 {
@@ -100,13 +99,17 @@ namespace YARG.Core.Song
         public void PopulateStars(IStarProvider starProvider, IPlayerContext playerContext)
         {
             var playerId = playerContext.GetCurrentPlayerId();
-            var starAmount = starProvider.GetBestStarsForSong(Hash, playerId);
+            var instrument = playerContext.GetCurrentInstrument();
+            var difficulty = playerContext.GetCurrentDifficulty();
+            var starAmount = starProvider.GetBestStarsForSong(Hash, playerId, instrument, difficulty);
 
             _starsAsNumber = (int) starAmount;
             _parsedStars = starAmount switch
             {
                 StarAmount.StarGold => "Gold Stars",
-                _ => $"{(int) starAmount} Stars"
+                StarAmount.Star1 => "1 Star",
+                StarAmount.None => "Not Played",
+                _ => $"{(int) starAmount} Stars" // 5, 4, 3, 2 Stars
             };
         }
 

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -2,9 +2,11 @@
 using System.IO;
 using YARG.Core.Chart;
 using YARG.Core.Extensions;
+using YARG.Core.Game;
 using YARG.Core.IO;
 using YARG.Core.Song.Cache;
 using YARG.Core.Utility;
+using System.Diagnostics;
 
 namespace YARG.Core.Song
 {
@@ -92,6 +94,21 @@ namespace YARG.Core.Song
         protected LoaderSettings _settings = LoaderSettings.Default;
         protected string _parsedYear = string.Empty;
         protected int _yearAsNumber = int.MaxValue;
+        protected string _parsedStars = string.Empty;
+        protected int _starsAsNumber = int.MaxValue;
+
+        public void PopulateStars(IStarProvider starProvider, IPlayerContext playerContext)
+        {
+            var playerId = playerContext.GetCurrentPlayerId();
+            var starAmount = starProvider.GetBestStarsForSong(Hash, playerId);
+
+            _starsAsNumber = (int) starAmount;
+            _parsedStars = starAmount switch
+            {
+                StarAmount.StarGold => "Gold Stars",
+                _ => $"{(int) starAmount} Stars"
+            };
+        }
 
         public abstract EntryType SubType { get; }
         public abstract string SortBasedLocation { get; }
@@ -109,6 +126,9 @@ namespace YARG.Core.Song
         public string UnmodifiedYear => _metadata.Year;
         public string ParsedYear => _parsedYear;
         public int YearAsNumber => _yearAsNumber;
+
+        public string ParsedStars => _parsedStars;
+        public int StarsAsNumber => _starsAsNumber;
 
         public bool IsMaster => _metadata.IsMaster;
         public bool VideoLoop => _metadata.VideoLoop;
@@ -360,6 +380,8 @@ namespace YARG.Core.Song
             stream.Write(_settings.HopoThreshold, Endianness.Little);
             stream.Write(_settings.SustainCutoffThreshold, Endianness.Little);
             stream.Write(_settings.OverdiveMidiNote, Endianness.Little);
+
+            stream.Write(_starsAsNumber, Endianness.Little);
         }
 
         protected SongEntry() { }
@@ -440,6 +462,9 @@ namespace YARG.Core.Song
             _settings.HopoThreshold = stream.Read<long>(Endianness.Little);
             _settings.SustainCutoffThreshold = stream.Read<long>(Endianness.Little);
             _settings.OverdiveMidiNote = stream.Read<int>(Endianness.Little);
+
+            _starsAsNumber = stream.Read<int>(Endianness.Little);
+            _parsedStars = ((StarAmount)_starsAsNumber).ToString();
 
             SetSortStrings();
         }

--- a/YARG.Core/Song/Entries/Types/SongMetadata.cs
+++ b/YARG.Core/Song/Entries/Types/SongMetadata.cs
@@ -21,6 +21,7 @@ namespace YARG.Core.Song
         public const string DEFAULT_CHARTER = "Unknown Charter";
         public const string DEFAULT_SOURCE = "Unknown Source";
         public const string DEFAULT_YEAR = "####";
+        public const string DEFAULT_STARS = "Not Played";
 
         public static readonly SongMetadata Default = new()
         {
@@ -31,6 +32,7 @@ namespace YARG.Core.Song
             Charter = DEFAULT_CHARTER,
             Source = DEFAULT_SOURCE,
             Year = DEFAULT_YEAR,
+            Stars = DEFAULT_STARS,
             Playlist = string.Empty,
             IsMaster = true,
             VideoLoop = false,
@@ -83,6 +85,7 @@ namespace YARG.Core.Song
         public string Source;
         public string Playlist;
         public string Year;
+        public string Stars;
 
         public long SongLength;
         public long SongOffset;


### PR DESCRIPTION
Backend:
- Updated `SongEntry` and sorting logic in **YARG.Core**
- Integrated new sort mode into the `SongCache` system
- Refactored `SongEntry` and `SongCache` integration for cleaner star sorting
- Ensured star query logic resides in **ScoreDatabase.cs**
- Triggered music library refresh automatically when star ratings change

Frontend:
- Added new menu UI for selecting star sorting option
- Updated assets and `en-US.json` localization file
- Adjusted UI assets for consistent visual alignment
- Grouped songs contextually by instrument and difficulty
- Added secondary sort by intensity, tertiary sort by name

Other:
- Ensured compatibility with existing sorting workflows

Notes:
- I wasn’t sure where to best place the interfaces that connect `QueryPlayerSongBestStars()` results from **ScoreDatabase** to **YARG.Core/SongEntry**. Would appreciate any feedback or suggestions on this workflow.
- Songs are primarily grouped and sorted by number of stars descending, then secondarily by difficulty of the instrument you're playing ascending, and tertiarily by song name ascending.  If memory serves, that's how Rock Band 4 did it.  If my memory is wrong or we'd prefer another way, I'm open to suggestions.
- **Performance:** The music library currently refreshes whenever instrument, difficulty, or number of stars on any **one song** changes (typically after every song).  On my system, this adds ~1 second per 3000 songs.  Let me know if anyone thinks this needs further optimization.