### PR TITLE
Handle charts with missing initial range shift

### DIFF
--- a/YARG.Core/Chart/Tracks/InstrumentDifficultyExtensions.cs
+++ b/YARG.Core/Chart/Tracks/InstrumentDifficultyExtensions.cs
@@ -50,6 +50,13 @@ namespace YARG.Core.Chart
                 return;
             }
 
+            // Bail if the first shift event is after the first note. We could try to guess, but we may well end up
+            // with a really bad chart if we do.
+            if (difficulty.RangeShiftEvents[0].Time > difficulty.Notes[0].Time)
+            {
+                return;
+            }
+
             var shifts = difficulty.RangeShiftEvents;
 
             int firstRange = shifts[0].Range;


### PR DESCRIPTION
It turns out that some of the YARG DLC charts have range shifts in the middle of the chart, but do not include one at the beginning.

This PR adds a check to CompressGuitarRange that avoids doing range compression on such charts.