### PR TITLE
Allow generation of extra beatlines

### DIFF
--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -148,11 +148,10 @@ namespace YARG.Core.Chart
             // Dj = loader.LoadDjTrack(Instrument.Dj);
 
             // Ensure beatlines are present
-            // if (SyncTrack.Beatlines is null or { Count: < 1 })
-            // {
-            //     SyncTrack.GenerateBeatlines(GetLastTick());
-            // }
-            SyncTrack.GenerateBeatlines(GetEndTime() + 5.0);
+            if (SyncTrack.Beatlines is null or { Count: < 1 })
+            {
+                SyncTrack.GenerateBeatlines(GetLastTick());
+            }
 
             // Use beatlines to place auto-generated drum activation phrases for charts without manually authored phrases
             CreateDrumActivationPhrases();

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -148,10 +148,11 @@ namespace YARG.Core.Chart
             // Dj = loader.LoadDjTrack(Instrument.Dj);
 
             // Ensure beatlines are present
-            if (SyncTrack.Beatlines is null or { Count: < 1 })
-            {
-                SyncTrack.GenerateBeatlines(GetLastTick());
-            }
+            // if (SyncTrack.Beatlines is null or { Count: < 1 })
+            // {
+            //     SyncTrack.GenerateBeatlines(GetLastTick());
+            // }
+            SyncTrack.GenerateBeatlines(GetEndTime() + 5.0);
 
             // Use beatlines to place auto-generated drum activation phrases for charts without manually authored phrases
             CreateDrumActivationPhrases();


### PR DESCRIPTION
This PR updates beatline generation to allow generating beatlines without wiping the existing set of beatlines.

The ultimate point of this is to have beatlines generated for the entirety of the song and song end delay so that beat events continue to fire until the score screen is shown. This keeps the 5GS pulse going even after the end of the chart itself so that users can see how close they were to getting 5GS.

The motivation for not just wiping the existing set of beatlines is that we don't ever generate weak beatlines, only measure and strong, but some .mid charts have weak charted in the BEAT track, so wiping the existing set could be lossy.