### PR TITLE
Fix bug causing 3 parameter range shift to be treated as 2 parameter form

### DIFF
--- a/YARG.Core/Chart/SongChart.AutoGeneration.cs
+++ b/YARG.Core/Chart/SongChart.AutoGeneration.cs
@@ -537,6 +537,9 @@ namespace YARG.Core.Chart
 
             foreach (var textEvent in instrumentDifficulty.TextEvents)
             {
+                // This ensures that if size is not parseable we will use the default for the difficulty
+                size = -1;
+
                 if (!textEvent.Text.StartsWith("ld_range_shift"))
                 {
                     continue;
@@ -569,8 +572,9 @@ namespace YARG.Core.Chart
                     YargLogger.LogDebug("Invalid range shift event. (Unable to parse size)");
                     continue;
                 }
-                else
-                {
+
+                if (size < 0 || size > 5) {
+                    YargLogger.LogDebug("Range shift event size invalid, using default instead");
                     size = eventDifficulty switch
                     {
                         (int) Difficulty.Easy    => 3,
@@ -583,12 +587,14 @@ namespace YARG.Core.Chart
                 // 1) Is the range index valid
                 if (range < 1 || range > 5)
                 {
+                    YargLogger.LogDebug("Invalid range shift event. (Range is out of bounds)");
                     continue;
                 }
 
                 // 2) Is the size valid for the range index
                 if (range + size > 6)
                 {
+                    YargLogger.LogDebug("Invalid range shift event. (Size is too large for range)");
                     continue;
                 }
 


### PR DESCRIPTION
As noted in #254 the size field in the 3 parameter form of the range shift text event is being treated as if it were the 2 parameter form, always using the default size. This PR fixes that issue.