### PR TITLE
Make whammy star power gain frame independent

### DIFF
--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -65,6 +65,7 @@ namespace YARG.Core.Engine
 
         public uint CurrentTick { get; protected set; }
         public uint LastTick { get; protected set; }
+        public uint FirstWhammyTick { get; protected set; }
 
         public int CurrentSoloIndex { get; protected set; }
         public int CurrentStarIndex { get; protected set; }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretEngine.cs
@@ -74,7 +74,7 @@ namespace YARG.Core.Engine.Guitar.Engines
             }
             else if (action is GuitarAction.Whammy)
             {
-                StarPowerWhammyTimer.Start(gameInput.Time);
+                StartWhammyTimer(gameInput.Time);
             }
             else if (action is GuitarAction.StrumDown or GuitarAction.StrumUp && gameInput.Button)
             {

--- a/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/ProKeys/Engines/YargProKeysEngine.cs
@@ -34,7 +34,7 @@ namespace YARG.Core.Engine.ProKeys.Engines
             }
             else if (action is ProKeysAction.TouchEffects)
             {
-                StarPowerWhammyTimer.Start(gameInput.Time);
+                StartWhammyTimer(gameInput.Time);
             }
             else
             {


### PR DESCRIPTION
This addresses 2 issues the current whammy tick gain calculations has:

1. CalculateStarPowerGain is dependent on how number of ticks are broken down 
    When working with the expression (quarterTick - lastQuarterTick) * (32.0 / 30.0) followed by Math.Round() to convert to a uint, there could be rounding inconsistencies depending on how the ticks are broken down.
    For example:
    If you have a difference of 30 ticks, you get 30 * (32.0/30.0) = 32.0, which rounds to 32
    If you break this into two segments of 15 ticks each, you get:
    15 * (32.0/30.0) = 16.0, which rounds to 16
    15 * (32.0/30.0) = 16.0, which rounds to 16
    Total: 32 (consistent)
    However, if you break it into segments of 10 ticks each:
    10 * (32.0/30.0) = 10.6666..., which rounds to 11
    10 * (32.0/30.0) = 10.6666..., which rounds to 11
    10 * (32.0/30.0) = 10.6666..., which rounds to 11
    Total: 33 (inconsistent with the single calculation)
    
2. When whammy is just started the first tick amount is calculated using a previous tick that was calculated at the previous frame's update. However that could mean that if more than 1 tick passed since then and whammy was activated somewhere in between it will/may overcount the amount of ticks.
     
number one is solved by carrying a remainder between frames. 
number two is solved using an explicit whammy start tick storage

With these changes I am no longer able to reproduce any SP gain differences with various frame timings