### PR TITLE
Update replay serialization

### DIFF
--- a/ReplayCli/Cli.cs
+++ b/ReplayCli/Cli.cs
@@ -255,7 +255,8 @@ public partial class Cli
     public bool Run()
     {
         // I'm assuming that when running analyzer from the CLI we always want frame times if available
-        (var result, _replayInfo, _replayData) = ReplayIO.TryDeserialize(_replayPath, true);
+        var replayOptions = new ReplayReadOptions { KeepFrameTimes = true };
+        (var result, _replayInfo, _replayData) = ReplayIO.TryDeserialize(_replayPath, replayOptions);
         if (result != ReplayReadResult.Valid)
         {
             Console.WriteLine($"ERROR: Failed to load replay. Read Result: {result}.");

--- a/YARG.Core/Replays/ReplayData.cs
+++ b/YARG.Core/Replays/ReplayData.cs
@@ -28,7 +28,7 @@ namespace YARG.Core.Replays
             FrameTimes = frameTimes;
         }
 
-        public ReplayData(FixedArrayStream stream, int version, bool keepFrameTimes)
+        public ReplayData(FixedArrayStream stream, int version, ReplayReadOptions readOptions)
         {
             int _ = stream.Read<int>(Endianness.Little);
             _colorProfiles = DeserializeDict<ColorProfile>(ref stream);
@@ -49,7 +49,7 @@ namespace YARG.Core.Replays
                 frameTimes[i] = stream.Read<double>(Endianness.Little);
             }
 
-            if (keepFrameTimes)
+            if (readOptions.KeepFrameTimes)
             {
                 FrameTimes = frameTimes;
             }

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -19,6 +19,11 @@ namespace YARG.Core.Replays
         FileNotFound,
     }
 
+    public struct ReplayReadOptions
+    {
+        public bool KeepFrameTimes;
+    }
+
     public static class ReplayIO
     {
         private static readonly EightCC REPLAY_MAGIC_HEADER_OLD = new('Y', 'A', 'R', 'G', 'P', 'L', 'A', 'Y');
@@ -27,7 +32,7 @@ namespace YARG.Core.Replays
         private static readonly (int OLD_MIN, int METADATA_MIN, int DATA_MIN, int CURRENT) REPLAY_VERSIONS = (4, 6, 8, 8);
         private const int ENGINE_VERSION = 3;
 
-        public static (ReplayReadResult Result, ReplayInfo Info, ReplayData Data) TryDeserialize(string path, bool keepFrameTimes)
+        public static (ReplayReadResult Result, ReplayInfo Info, ReplayData Data) TryDeserialize(string path, ReplayReadOptions replayOptions)
         {
             try
             {
@@ -73,7 +78,7 @@ namespace YARG.Core.Replays
                     return (ReplayReadResult.Corrupted, null!, null!);
                 }
 
-                var replayData = new ReplayData(data.ToValueStream(), info.ReplayVersion, keepFrameTimes);
+                var replayData = new ReplayData(data.ToValueStream(), info.ReplayVersion, replayOptions);
                 return (ReplayReadResult.Valid, info, replayData);
             }
             catch (Exception ex)
@@ -141,7 +146,7 @@ namespace YARG.Core.Replays
             }
         }
 
-        public static (ReplayReadResult Result, ReplayData Data) TryLoadData(ReplayInfo info, bool keepFrameTimes)
+        public static (ReplayReadResult Result, ReplayData Data) TryLoadData(ReplayInfo info, ReplayReadOptions readOptions)
         {
             try
             {
@@ -200,7 +205,7 @@ namespace YARG.Core.Replays
                     return (ReplayReadResult.Corrupted, null!);
                 }
 
-                var replayData = new ReplayData(data.ToValueStream(), info.ReplayVersion, keepFrameTimes);
+                var replayData = new ReplayData(data.ToValueStream(), info.ReplayVersion, readOptions);
                 return (ReplayReadResult.Valid, replayData);
             }
             catch (Exception ex)


### PR DESCRIPTION
* Replay and minimum replay version bumped to version 8
* Engine version bumped to version 3
* ~~Updated various stats classes to gate deserialization of new parameters to version 8 or higher~~
* ~~Don't attempt to deserialize replay FrameTime data for replays older than version 8~~

~~Questions to which I don't have an answer:~~
* ~~Do we need to bump the engine version as well?~~
* ~~It looks like everything that uses the new FrameTimes array is fine with it being zero length, but I'm not absolutely certain of that yet.~~

~~If you'd rather not have replay compatibility, lmk and I'll strip out the deserialization conditionals, set DATA_MIN to 8, and we'll be on our way.~~