### PR TITLE
Make cymbal colors easier to tell apart, like in CH and RB

### DIFF
--- a/YARG.Core/Game/Presets/ColorProfile.Defaults.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.Defaults.cs
@@ -14,6 +14,12 @@ namespace YARG.Core.Game
         private static readonly Color DefaultBlue   = Color.FromArgb(0xFF, 0x00, 0xBF, 0xFF); // #00BFFF
         private static readonly Color DefaultOrange = Color.FromArgb(0xFF, 0xFF, 0x84, 0x00); // #FF8400
 
+        // By default, use these colors for notes only, not fret coloring or particles
+        private static readonly Color DefaultRedCymbal    = Color.FromArgb(0xFF, 0xF0, 0x20, 0x40); // #F02040
+        private static readonly Color DefaultYellowCymbal = Color.FromArgb(0xFF, 0xFF, 0xD0, 0x10); // #FFD010
+        private static readonly Color DefaultBlueCymbal   = Color.FromArgb(0xFF, 0x20, 0x90, 0xFF); // #2090FF
+        private static readonly Color DefaultGreenCymbal  = Color.FromArgb(0xFF, 0xA0, 0xD0, 0x10); // #A0D010
+
         private static readonly Color DefaultStarpower = Color.White; // #FFFFFF
 
         #endregion

--- a/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
@@ -130,10 +130,10 @@ namespace YARG.Core.Game
             public Color BlueDrum   = DefaultBlue;
             public Color GreenDrum  = DefaultGreen;
 
-            public Color RedCymbal    = DefaultRed;
-            public Color YellowCymbal = DefaultYellow;
-            public Color BlueCymbal   = DefaultBlue;
-            public Color GreenCymbal  = DefaultGreen;
+            public Color RedCymbal    = DefaultRedCymbal;
+            public Color YellowCymbal = DefaultYellowCymbal;
+            public Color BlueCymbal   = DefaultBlueCymbal;
+            public Color GreenCymbal  = DefaultGreenCymbal;
 
             /// <summary>
             /// Gets the note color for a specific note index.


### PR DESCRIPTION
Very small change to make pro drums easier to read, as is done in Clone Hero and Rock Band.

| Pad | Color code | Change |
| --- | --- | --- |
| R tom | `FF1D23` | None |
| Y tom | `FFE900` | None |
| B tom | `00BFFF` | None |
| G tom | `79D304` | None |
| R cym | `F02040` | Slightly more pink |
| Y cym | `FFD010` | Slightly more gold |
| B cym | `2090FF` | Slightly more indigo |
| G cym | `A0D010` | Slightly more yellow |

<img width="3456" height="2160" alt="image" src="https://github.com/user-attachments/assets/1e70b5ed-5ddc-40b6-8a6d-e621891e49ba" />

<img width="3456" height="2160" alt="image" src="https://github.com/user-attachments/assets/50f6742a-0b87-493a-8f3a-cb6d7651513a" />
