### PR TITLE
don't auto-activate SP for drums

### DIFF
--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -145,8 +145,6 @@ namespace YARG.Core.Engine.Drums.Engines
                 return;
             }
 
-            IsStarPowerInputActive = CanStarPowerActivate && !IsStarPowerInputActive;
-
             var note = Notes[NoteIndex];
 
             if (time < note.Time)


### PR DESCRIPTION
Drum bot should not do impossible SP activations as soon as they get enough to activate since SP will get activated naturally at an activation gem whenever there is enough SP to activate, so this PR reverts drums to their previous behavior.