### PR TITLE
Fix chart loading bugs

### DIFF
--- a/YARG.Core/Chart/Sync/SyncTrack.cs
+++ b/YARG.Core/Chart/Sync/SyncTrack.cs
@@ -191,7 +191,7 @@ namespace YARG.Core.Chart
                 }
 
                 // If startTick is prior to the current last beatline, we need to move it to the last beatline
-                startTick = Math.Min(startTick, lastBeatlineTick);
+                startTick = Math.Max(startTick, lastBeatlineTick);
 
                 // Generate beatlines for this time signature
                 GenerateBeatsForTimeSignature(currentTimeSig, startTick, endTick);
@@ -199,7 +199,7 @@ namespace YARG.Core.Chart
             }
 
 
-            uint finalStartTick = Math.Min(currentTimeSig.Tick, lastBeatlineTick);
+            uint finalStartTick = Math.Max(currentTimeSig.Tick, lastBeatlineTick);
             // Final time signature
             GenerateBeatsForTimeSignature(currentTimeSig, finalStartTick, lastTick);
 


### PR DESCRIPTION
Avoids passing an invalid tick value for the current time signature to TickToTime. Fixes half of YARG [issue #1072](https://github.com/YARC-Official/YARG/issues/1072) and similar reports on Discord about failures to load .chart files.