### PR TITLE
use insert instead of add in midreader, too

### DIFF
--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -569,7 +569,7 @@ namespace MoonscraperChartEditor.Song.IO
             // Copy text event to all difficulties
             foreach (var difficulty in EnumExtensions<MoonSong.Difficulty>.Values)
             {
-                processParams.song.GetChart(processParams.instrument, difficulty).Add(new MoonText(eventText, tick));
+                processParams.song.GetChart(processParams.instrument, difficulty).Insert(new MoonText(eventText, tick));
             }
         }
 


### PR DESCRIPTION
A few midi charts were bit by the same issue as was afflicting .chart, most notably Cowboy Tanaka