### PR TITLE
Make TimeInStarPower rounded to ticks

### DIFF
--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -445,7 +445,9 @@ namespace YARG.Core.Engine
 
             BaseStats.IsStarPowerActive = false;
 
-            double spTimeDelta = CurrentTime - StarPowerActivationTime;
+            double roundedTime = SyncTrack.TickToTime(SyncTrack.TimeToTick(CurrentTime));
+            double roundedActivationTime = SyncTrack.TickToTime(SyncTrack.TimeToTick(StarPowerActivationTime));
+            double spTimeDelta = roundedTime - roundedActivationTime;
             BaseStats.TimeInStarPower = spTimeDelta + BaseTimeInStarPower;
 
             BaseTimeInStarPower = BaseStats.TimeInStarPower;


### PR DESCRIPTION
The absolute value does not matter as it is calculated per tick anyway. Not doing this could lead to TimeInStarPower not being always consistent. We could land on a frame within same tick with microsecond difference, it will be processed identically, same score, same tick in SP amount but `TimeInStarPower` would be different as it's stored as fully time dependent value anyway