### PR TITLE
Change POINTS_PER_NOTE to GetPointsPerNote()

### DIFF
--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -326,7 +326,7 @@ namespace YARG.Core.Engine.Drums
                 combo += 1 + note.ChildNotes.Count;
             }
 
-            YargLogger.LogDebug($"[Vocals] Base score: {score}, Max Combo: {combo}");
+            YargLogger.LogDebug($"[Drums] Base score: {score}, Max Combo: {combo}");
             return (int) Math.Round(score);
         }
 

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -322,7 +322,7 @@ namespace YARG.Core.Engine.Drums
                 // invert it to calculate leniency
                 weight = 1.0 * multiplier / BaseParameters.MaxMultiplier;
 
-                score += weight * (POINTS_PER_NOTE * (1 + note.ChildNotes.Count));
+                score += weight * (GetPointsPerNote() * (1 + note.ChildNotes.Count));
                 combo += 1 + note.ChildNotes.Count;
             }
 

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -365,7 +365,7 @@ namespace YARG.Core.Engine.Guitar
                 }
             }
 
-            YargLogger.LogDebug($"[Vocals] Base score: {score}, Max Combo: {combo}");
+            YargLogger.LogDebug($"[Guitar] Base score: {score}, Max Combo: {combo}");
             return (int) Math.Round(score);
         }
 


### PR DESCRIPTION
This PR changes the use of POINTS_PER_NOTE to GetPointsPerNote() to account for Pro Drums awarding 60 points per note instead of 50.

As discovered by roman72896 on this thread: https://discord.com/channels/1086048856678084609/1404587259956695152 the GS cutoff for Pro Drums is way lower than it should be, even despite the recently added Unison Phrases: 

<img width="1674" height="549" alt="image" src="https://github.com/user-attachments/assets/0a7a947f-0aa6-45d6-bdce-e6f6d6cc70c0" />

The 5GS cutoff for Pro Drums seemed like it was around 3.49, where in reality it should be at 4.29. roman72896 also noticed that if we use 50 points as the base note point value, then the avg multiplier required is much closer to the intended value (as seen in the screenshoot above), which resulted in me finding this bug and fixing it.


...i haven't tested/built the game  so if it crashes for some reason then thats on me