### PR TITLE
Add star power metal colors

### DIFF
--- a/YARG.Core/Game/Presets/ColorProfile.Defaults.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.Defaults.cs
@@ -14,6 +14,12 @@ namespace YARG.Core.Game
         private static readonly Color DefaultBlue   = Color.FromArgb(0xFF, 0x00, 0xBF, 0xFF); // #00BFFF
         private static readonly Color DefaultOrange = Color.FromArgb(0xFF, 0xFF, 0x84, 0x00); // #FF8400
 
+        // By default, use these colors for notes only, not fret coloring or particles
+        private static readonly Color DefaultRedCymbal    = Color.FromArgb(0xFF, 0xF0, 0x20, 0x40); // #F02040
+        private static readonly Color DefaultYellowCymbal = Color.FromArgb(0xFF, 0xFF, 0xD0, 0x10); // #FFD010
+        private static readonly Color DefaultBlueCymbal   = Color.FromArgb(0xFF, 0x20, 0x90, 0xFF); // #2090FF
+        private static readonly Color DefaultGreenCymbal  = Color.FromArgb(0xFF, 0xA0, 0xD0, 0x10); // #A0D010
+
         private static readonly Color DefaultStarpower = Color.White; // #FFFFFF
 
         #endregion

--- a/YARG.Core/Game/Presets/ColorProfile.Defaults.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.Defaults.cs
@@ -22,6 +22,11 @@ namespace YARG.Core.Game
 
         private static readonly Color DefaultStarpower = Color.White; // #FFFFFF
 
+        private static readonly Color DefaultMetal          = Color.FromArgb(0xFF, 0xFF, 0xFF, 0xFF); // #FFFFFF
+        private static readonly Color DefaultMetalStarPower = Color.FromArgb(0xFF, 0xFF, 0xD7, 0x00); // #FFD700
+
+        private static readonly Color DefaultMiss = Color.FromArgb(0xFF, 0x90, 0x90, 0x90); // #909090
+
         #endregion
 
         #region Circular Colors

--- a/YARG.Core/Game/Presets/ColorProfile.FiveFretGuitar.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FiveFretGuitar.cs
@@ -143,6 +143,24 @@ namespace YARG.Core.Game
 
             #endregion
 
+            #region Metal
+
+            public Color Metal          = DefaultMetal;
+            public Color MetalStarPower = DefaultMetalStarPower;
+
+            public Color GetMetalColor(bool isForStarPower)
+            {
+                return isForStarPower ? MetalStarPower : Metal;
+            }
+
+            #endregion
+
+            #region Miss Effect
+
+            public Color Miss = DefaultMiss;
+
+            #endregion
+
             #region Serialization
 
             public FiveFretGuitarColors Copy()

--- a/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
@@ -150,6 +150,24 @@ namespace YARG.Core.Game
 
             #endregion
 
+            #region Metal
+
+            public Color Metal          = DefaultMetal;
+            public Color MetalStarPower = DefaultMetalStarPower;
+
+            public Color GetMetalColor(bool isForStarPower)
+            {
+                return isForStarPower ? MetalStarPower : Metal;
+            }
+
+            #endregion
+
+            #region Miss Effect
+
+            public Color Miss = DefaultMiss;
+
+            #endregion
+
             #region Serialization
 
             public FiveLaneDrumsColors Copy()

--- a/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
@@ -199,6 +199,24 @@ namespace YARG.Core.Game
 
             public Color ActivationNote = DefaultPurple;
 
+            #region Metal
+
+            public Color Metal          = DefaultMetal;
+            public Color MetalStarPower = DefaultMetalStarPower;
+
+            public Color GetMetalColor(bool isForStarPower)
+            {
+                return isForStarPower ? MetalStarPower : Metal;
+            }
+
+            #endregion
+
+            #region Miss Effect
+
+            public Color Miss = DefaultMiss;
+
+            #endregion
+
             #endregion
 
             #region Serialization

--- a/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
@@ -130,10 +130,10 @@ namespace YARG.Core.Game
             public Color BlueDrum   = DefaultBlue;
             public Color GreenDrum  = DefaultGreen;
 
-            public Color RedCymbal    = DefaultRed;
-            public Color YellowCymbal = DefaultYellow;
-            public Color BlueCymbal   = DefaultBlue;
-            public Color GreenCymbal  = DefaultGreen;
+            public Color RedCymbal    = DefaultRedCymbal;
+            public Color YellowCymbal = DefaultYellowCymbal;
+            public Color BlueCymbal   = DefaultBlueCymbal;
+            public Color GreenCymbal  = DefaultGreenCymbal;
 
             /// <summary>
             /// Gets the note color for a specific note index.

--- a/YARG.Core/Game/Presets/ColorProfile.ProKeys.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.ProKeys.cs
@@ -70,8 +70,26 @@ namespace YARG.Core.Game
             public Color WhiteNote = Color.White;
             public Color BlackNote = Color.Black;
 
-            public Color WhiteNoteStarPower = CircularStarpower;
-            public Color BlackNoteStarPower = CircularStarpower;
+            public Color WhiteNoteStarPower = Color.FromArgb(0xFF, 0xFF, 0xF2, 0xAA); // #FFF2AA
+            public Color BlackNoteStarPower = Color.FromArgb(0xFF, 0xAA, 0x8F, 0x00); // #AA8F00
+
+            #endregion
+
+            #region Metal
+
+            public Color Metal          = DefaultMetal;
+            public Color MetalStarPower = DefaultMetalStarPower;
+
+            public Color GetMetalColor(bool isForStarPower)
+            {
+                return isForStarPower ? MetalStarPower : Metal;
+            }
+
+            #endregion
+
+            #region Miss Effect
+
+            public Color Miss = DefaultMiss;
 
             #endregion
 


### PR DESCRIPTION
Adds star power metal colors (gold by default) and miss colors (gray by default, subject to change). To be used in a subsequent non-core change.