### PR TITLE
Song metadata refactor

### DIFF
--- a/YARG.Core/Song/Entries/Types/SongMetadata.cs
+++ b/YARG.Core/Song/Entries/Types/SongMetadata.cs
@@ -135,6 +135,7 @@ namespace YARG.Core.Song
         public string CharterProGuitar;
         public string CharterVocals;
 
+        [MethodImpl(MethodImplOption.AggressiveInlining)]
         private static void ReadIniStringIfNotEmpty(IniModifierCollection modifiers, string modifierName, out string output) {
             if (modifiers.Extract(modifierName, out string readValue) && value.Length > 0)
             {
@@ -142,6 +143,7 @@ namespace YARG.Core.Song
             }
         }
 
+        [MethodImpl(MethodImplOption.AggressiveInlining)]
         private static void ReadIniString(IniModifierCollection modifiers, string modifierName, out string output) {
             if (modifiers.Extract(modifierName, out string readValue))
             {
@@ -149,6 +151,7 @@ namespace YARG.Core.Song
             }
         }
 
+        [MethodImpl(MethodImplOption.AggressiveInlining)]
         private static void ReadIniIntOr(IniModifierCollection modifiers, string modifierName, out int output, int fallbackValue) {
             if (modifiers.Extract(modifierName, out int readValue))
             {
@@ -160,6 +163,7 @@ namespace YARG.Core.Song
             }
         }
 
+        [MethodImpl(MethodImplOption.AggressiveInlining)]
         private static void ReadIniLong(IniModifierCollection modifiers, string modifierName, out long output) {
             if (modifiers.Extract(modifierName, out long readValue))
             {

--- a/YARG.Core/Song/Entries/Types/SongMetadata.cs
+++ b/YARG.Core/Song/Entries/Types/SongMetadata.cs
@@ -1,4 +1,5 @@
 ﻿using YARG.Core.IO.Ini;
+using System.Runtime.CompilerServices;
 
 namespace YARG.Core.Song
 {
@@ -135,23 +136,23 @@ namespace YARG.Core.Song
         public string CharterProGuitar;
         public string CharterVocals;
 
-        [MethodImpl(MethodImplOption.AggressiveInlining)]
-        private static void ReadIniStringIfNotEmpty(IniModifierCollection modifiers, string modifierName, out string output) {
-            if (modifiers.Extract(modifierName, out string readValue) && value.Length > 0)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ReadIniStringIfNotEmpty(IniModifierCollection modifiers, string modifierName, ref string output) {
+            if (modifiers.Extract(modifierName, out string readValue) && readValue.Length > 0)
             {
                 output = readValue;
             }
         }
 
-        [MethodImpl(MethodImplOption.AggressiveInlining)]
-        private static void ReadIniString(IniModifierCollection modifiers, string modifierName, out string output) {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ReadIniString(IniModifierCollection modifiers, string modifierName, ref string output) {
             if (modifiers.Extract(modifierName, out string readValue))
             {
                 output = readValue;
             }
         }
 
-        [MethodImpl(MethodImplOption.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void ReadIniIntOr(IniModifierCollection modifiers, string modifierName, out int output, int fallbackValue) {
             if (modifiers.Extract(modifierName, out int readValue))
             {
@@ -163,8 +164,8 @@ namespace YARG.Core.Song
             }
         }
 
-        [MethodImpl(MethodImplOption.AggressiveInlining)]
-        private static void ReadIniLong(IniModifierCollection modifiers, string modifierName, out long output) {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ReadIniLong(IniModifierCollection modifiers, string modifierName, ref long output) {
             if (modifiers.Extract(modifierName, out long readValue))
             {
                 output = readValue;
@@ -180,10 +181,10 @@ namespace YARG.Core.Song
 
         public static void FillFromIni(ref SongMetadata metadata, IniModifierCollection modifiers)
         {
-            ReadIniStringIfNotEmpty(modifiers, "name", out metadata.Name);
-            ReadIniStringIfNotEmpty(modifiers, "artist", out metadata.Artist);
-            ReadIniStringIfNotEmpty(modifiers, "album", out metadata.Album);
-            ReadIniStringIfNotEmpty(modifiers, "genre", out metadata.Genre);
+            ReadIniStringIfNotEmpty(modifiers, "name", ref metadata.Name);
+            ReadIniStringIfNotEmpty(modifiers, "artist", ref metadata.Artist);
+            ReadIniStringIfNotEmpty(modifiers, "album", ref metadata.Album);
+            ReadIniStringIfNotEmpty(modifiers, "genre", ref metadata.Genre);
 
             if (modifiers.Extract("year", out string year) && year.Length > 0)
             {
@@ -213,46 +214,46 @@ namespace YARG.Core.Song
                 }
             }
 
-            ReadIniStringIfNotEmpty(modifiers, "icon", out metadata.Source);
-            ReadIniStringIfNotEmpty(modifiers, "playlist", out metadata.Playlist);
-            ReadIniString(modifiers, "loading_phrase", out metadata.LoadingPhrase);
+            ReadIniStringIfNotEmpty(modifiers, "icon", ref metadata.Source);
+            ReadIniStringIfNotEmpty(modifiers, "playlist", ref metadata.Playlist);
+            ReadIniString(modifiers, "loading_phrase", ref metadata.LoadingPhrase);
 
-            ReadIniString(modifiers, "link_bandcamp", out metadata.LinkBandcamp);
-            ReadIniString(modifiers, "link_bluesky", out metadata.LinkBluesky);
-            ReadIniString(modifiers, "link_facebook", out metadata.LinkFacebook);
-            ReadIniString(modifiers, "link_instagram", out metadata.LinkInstagram);
-            ReadIniString(modifiers, "link_spotify", out metadata.LinkSpotify);
-            ReadIniString(modifiers, "link_twitter", out metadata.LinkTwitter);
-            ReadIniString(modifiers, "link_bluesky", out metadata.LinkBluesky);
-            ReadIniString(modifiers, "link_other", out metadata.LinkOther);
-            ReadIniString(modifiers, "link_youtube", out metadata.LinkYoutube);
+            ReadIniString(modifiers, "link_bandcamp", ref metadata.LinkBandcamp);
+            ReadIniString(modifiers, "link_bluesky", ref metadata.LinkBluesky);
+            ReadIniString(modifiers, "link_facebook", ref metadata.LinkFacebook);
+            ReadIniString(modifiers, "link_instagram", ref metadata.LinkInstagram);
+            ReadIniString(modifiers, "link_spotify", ref metadata.LinkSpotify);
+            ReadIniString(modifiers, "link_twitter", ref metadata.LinkTwitter);
+            ReadIniString(modifiers, "link_bluesky", ref metadata.LinkBluesky);
+            ReadIniString(modifiers, "link_other", ref metadata.LinkOther);
+            ReadIniString(modifiers, "link_youtube", ref metadata.LinkYoutube);
 
-            ReadIniString(modifiers, "location", out metadata.Location);
+            ReadIniString(modifiers, "location", ref metadata.Location);
 
-            ReadIniString(modifiers, "credit_album_art_designed_by", out metadata.CreditAlbumArtDesignedBy);
-            ReadIniString(modifiers, "credit_arranged_by", out metadata.CreditArrangedBy);
-            ReadIniString(modifiers, "credit_composed_by", out metadata.CreditComposedBy);
-            ReadIniString(modifiers, "credit_courtesy_of", out metadata.CreditCourtesyOf);
-            ReadIniString(modifiers, "credit_engineered_by", out metadata.CreditEngineeredBy);
-            ReadIniString(modifiers, "credit_license", out metadata.CreditLicense);
-            ReadIniString(modifiers, "credit_mastered_by", out metadata.CreditMasteredBy);
-            ReadIniString(modifiers, "credit_mixed_by", out metadata.CreditMixedBy);
-            ReadIniString(modifiers, "credit_other", out metadata.CreditOther);
-            ReadIniString(modifiers, "credit_performed_by", out metadata.CreditPerformedBy);
-            ReadIniString(modifiers, "credit_produced_by", out metadata.CreditProducedBy);
-            ReadIniString(modifiers, "credit_published_by", out metadata.CreditPublishedBy);
-            ReadIniString(modifiers, "credit_written_by", out metadata.CreditWrittenBy);
+            ReadIniString(modifiers, "credit_album_art_designed_by", ref metadata.CreditAlbumArtDesignedBy);
+            ReadIniString(modifiers, "credit_arranged_by", ref metadata.CreditArrangedBy);
+            ReadIniString(modifiers, "credit_composed_by", ref metadata.CreditComposedBy);
+            ReadIniString(modifiers, "credit_courtesy_of", ref metadata.CreditCourtesyOf);
+            ReadIniString(modifiers, "credit_engineered_by", ref metadata.CreditEngineeredBy);
+            ReadIniString(modifiers, "credit_license", ref metadata.CreditLicense);
+            ReadIniString(modifiers, "credit_mastered_by", ref metadata.CreditMasteredBy);
+            ReadIniString(modifiers, "credit_mixed_by", ref metadata.CreditMixedBy);
+            ReadIniString(modifiers, "credit_other", ref metadata.CreditOther);
+            ReadIniString(modifiers, "credit_performed_by", ref metadata.CreditPerformedBy);
+            ReadIniString(modifiers, "credit_produced_by", ref metadata.CreditProducedBy);
+            ReadIniString(modifiers, "credit_published_by", ref metadata.CreditPublishedBy);
+            ReadIniString(modifiers, "credit_written_by", ref metadata.CreditWrittenBy);
 
-            ReadIniString(modifiers, "charter_bass", out metadata.CharterBass);
-            ReadIniString(modifiers, "charter_drums", out metadata.CharterDrums);
-            ReadIniString(modifiers, "charter_elite_drums", out metadata.CharterEliteDrums);
-            ReadIniString(modifiers, "charter_guitar", out metadata.CharterGuitar);
-            ReadIniString(modifiers, "charter_keys", out metadata.CharterKeys);
-            ReadIniString(modifiers, "charter_lower_diff", out metadata.CharterLowerDiff);
-            ReadIniString(modifiers, "charter_pro_bass", out metadata.CharterProBass);
-            ReadIniString(modifiers, "charter_pro_keys", out metadata.CharterProKeys);
-            ReadIniString(modifiers, "charter_pro_guitar", out metadata.CharterProGuitar);
-            ReadIniString(modifiers, "charter_vocals", out metadata.CharterVocals);
+            ReadIniString(modifiers, "charter_bass", ref metadata.CharterBass);
+            ReadIniString(modifiers, "charter_drums", ref metadata.CharterDrums);
+            ReadIniString(modifiers, "charter_elite_drums", ref metadata.CharterEliteDrums);
+            ReadIniString(modifiers, "charter_guitar", ref metadata.CharterGuitar);
+            ReadIniString(modifiers, "charter_keys", ref metadata.CharterKeys);
+            ReadIniString(modifiers, "charter_lower_diff", ref metadata.CharterLowerDiff);
+            ReadIniString(modifiers, "charter_pro_bass", ref metadata.CharterProBass);
+            ReadIniString(modifiers, "charter_pro_keys", ref metadata.CharterProKeys);
+            ReadIniString(modifiers, "charter_pro_guitar", ref metadata.CharterProGuitar);
+            ReadIniString(modifiers, "charter_vocals", ref metadata.CharterVocals);
 
             ReadIniIntOr(modifiers, "playlist_track", out metadata.PlaylistTrack, int.MaxValue);
             ReadIniIntOr(modifiers, "album_track", out metadata.AlbumTrack, int.MaxValue);
@@ -262,9 +263,9 @@ namespace YARG.Core.Song
                 metadata.SongRating = (SongRating)songRating;
             }
 
-            ReadIniLong(modifiers, "song_length", out long metadata.SongLength);
-            ReadIniLong(modifiers, "video_start_time", out long metadata.Video.Start);
-            ReadIniLong(modifiers, "video_end_time", out long metadata.Video.End);
+            ReadIniLong(modifiers, "song_length", ref metadata.SongLength);
+            ReadIniLong(modifiers, "video_start_time", ref metadata.Video.Start);
+            ReadIniLong(modifiers, "video_end_time", ref metadata.Video.End);
 
             if (modifiers.Extract("preview", out (long Start, long End) preview))
             {

--- a/YARG.Core/Song/Entries/Types/SongMetadata.cs
+++ b/YARG.Core/Song/Entries/Types/SongMetadata.cs
@@ -135,6 +135,38 @@ namespace YARG.Core.Song
         public string CharterProGuitar;
         public string CharterVocals;
 
+        private static void ReadIniStringIfNotEmpty(IniModifierCollection modifiers, string modifierName, out string output) {
+            if (modifiers.Extract(modifierName, out string readValue) && value.Length > 0)
+            {
+                output = readValue;
+            }
+        }
+
+        private static void ReadIniString(IniModifierCollection modifiers, string modifierName, out string output) {
+            if (modifiers.Extract(modifierName, out string readValue))
+            {
+                output = readValue;
+            }
+        }
+
+        private static void ReadIniIntOr(IniModifierCollection modifiers, string modifierName, out int output, int fallbackValue) {
+            if (modifiers.Extract(modifierName, out int readValue))
+            {
+                output = readValue;
+            }
+            else
+            {
+                output = fallbackValue;
+            }
+        }
+
+        private static void ReadIniLong(IniModifierCollection modifiers, string modifierName, out long output) {
+            if (modifiers.Extract(modifierName, out long readValue))
+            {
+                output = readValue;
+            }
+        }
+
         public static SongMetadata CreateFromIni(IniModifierCollection modifiers)
         {
             var metadata = Default;
@@ -144,25 +176,10 @@ namespace YARG.Core.Song
 
         public static void FillFromIni(ref SongMetadata metadata, IniModifierCollection modifiers)
         {
-            if (modifiers.Extract("name", out string name) && name.Length > 0)
-            {
-                metadata.Name = name;
-            }
-
-            if (modifiers.Extract("artist", out string artist) && artist.Length > 0)
-            {
-                metadata.Artist = artist;
-            }
-
-            if (modifiers.Extract("album", out string album) && album.Length > 0)
-            {
-                metadata.Album = album;
-            }
-
-            if (modifiers.Extract("genre", out string genre) && genre.Length > 0)
-            {
-                metadata.Genre = genre;
-            }
+            ReadIniStringIfNotEmpty(modifiers, "name", out metadata.Name);
+            ReadIniStringIfNotEmpty(modifiers, "artist", out metadata.Artist);
+            ReadIniStringIfNotEmpty(modifiers, "album", out metadata.Album);
+            ReadIniStringIfNotEmpty(modifiers, "genre", out metadata.Genre);
 
             if (modifiers.Extract("year", out string year) && year.Length > 0)
             {
@@ -192,213 +209,58 @@ namespace YARG.Core.Song
                 }
             }
 
-            if (modifiers.Extract("icon", out string source) && source.Length > 0)
-            {
-                metadata.Source = source;
-            }
+            ReadIniStringIfNotEmpty(modifiers, "icon", out metadata.Source);
+            ReadIniStringIfNotEmpty(modifiers, "playlist", out metadata.Playlist);
+            ReadIniString(modifiers, "loading_phrase", out metadata.LoadingPhrase);
 
-            if (modifiers.Extract("playlist", out string playlist) && playlist.Length > 0)
-            {
-                metadata.Playlist = playlist;
-            }
+            ReadIniString(modifiers, "link_bandcamp", out metadata.LinkBandcamp);
+            ReadIniString(modifiers, "link_bluesky", out metadata.LinkBluesky);
+            ReadIniString(modifiers, "link_facebook", out metadata.LinkFacebook);
+            ReadIniString(modifiers, "link_instagram", out metadata.LinkInstagram);
+            ReadIniString(modifiers, "link_spotify", out metadata.LinkSpotify);
+            ReadIniString(modifiers, "link_twitter", out metadata.LinkTwitter);
+            ReadIniString(modifiers, "link_bluesky", out metadata.LinkBluesky);
+            ReadIniString(modifiers, "link_other", out metadata.LinkOther);
+            ReadIniString(modifiers, "link_youtube", out metadata.LinkYoutube);
 
-            if (modifiers.Extract("loading_phrase", out string loadingPhrase))
-            {
-                metadata.LoadingPhrase = loadingPhrase;
-            }
+            ReadIniString(modifiers, "location", out metadata.Location);
 
-            if (modifiers.Extract("link_bluesky", out string linkBluesky))
-            {
-                metadata.LinkBluesky = linkBluesky;
-            }
+            ReadIniString(modifiers, "credit_album_art_designed_by", out metadata.CreditAlbumArtDesignedBy);
+            ReadIniString(modifiers, "credit_arranged_by", out metadata.CreditArrangedBy);
+            ReadIniString(modifiers, "credit_composed_by", out metadata.CreditComposedBy);
+            ReadIniString(modifiers, "credit_courtesy_of", out metadata.CreditCourtesyOf);
+            ReadIniString(modifiers, "credit_engineered_by", out metadata.CreditEngineeredBy);
+            ReadIniString(modifiers, "credit_license", out metadata.CreditLicense);
+            ReadIniString(modifiers, "credit_mastered_by", out metadata.CreditMasteredBy);
+            ReadIniString(modifiers, "credit_mixed_by", out metadata.CreditMixedBy);
+            ReadIniString(modifiers, "credit_other", out metadata.CreditOther);
+            ReadIniString(modifiers, "credit_performed_by", out metadata.CreditPerformedBy);
+            ReadIniString(modifiers, "credit_produced_by", out metadata.CreditProducedBy);
+            ReadIniString(modifiers, "credit_published_by", out metadata.CreditPublishedBy);
+            ReadIniString(modifiers, "credit_written_by", out metadata.CreditWrittenBy);
 
-            if (modifiers.Extract("link_facebook", out string linkFacebook))
-            {
-                metadata.LinkFacebook = linkFacebook;
-            }
+            ReadIniString(modifiers, "charter_bass", out metadata.CharterBass);
+            ReadIniString(modifiers, "charter_drums", out metadata.CharterDrums);
+            ReadIniString(modifiers, "charter_elite_drums", out metadata.CharterEliteDrums);
+            ReadIniString(modifiers, "charter_guitar", out metadata.CharterGuitar);
+            ReadIniString(modifiers, "charter_keys", out metadata.CharterKeys);
+            ReadIniString(modifiers, "charter_lower_diff", out metadata.CharterLowerDiff);
+            ReadIniString(modifiers, "charter_pro_bass", out metadata.CharterProBass);
+            ReadIniString(modifiers, "charter_pro_keys", out metadata.CharterProKeys);
+            ReadIniString(modifiers, "charter_pro_guitar", out metadata.CharterProGuitar);
+            ReadIniString(modifiers, "charter_vocals", out metadata.CharterVocals);
 
-            if (modifiers.Extract("link_instagram", out string linkInstagram))
-            {
-                metadata.LinkInstagram = linkInstagram;
-            }
-
-            if (modifiers.Extract("link_spotify", out string linkSpotify))
-            {
-                metadata.LinkSpotify = linkSpotify;
-            }
-
-            if (modifiers.Extract("link_twitter", out string linkTwitter))
-            {
-                metadata.LinkTwitter = linkTwitter;
-            }
-
-            if (modifiers.Extract("link_other", out string linkOther))
-            {
-                metadata.LinkOther = linkOther;
-            }
-
-            if (modifiers.Extract("link_youtube", out string linkYoutube))
-            {
-                metadata.LinkYoutube = linkYoutube;
-            }
-
-            if (modifiers.Extract("location", out string location))
-            {
-                metadata.Location = location;
-            }
-
-            if (modifiers.Extract("credit_album_art_designed_by", out string creditAlbumArt))
-            {
-                metadata.CreditAlbumArtDesignedBy = creditAlbumArt;
-            }
-
-            if (modifiers.Extract("credit_arranged_by", out string creditArrangedBy))
-            {
-                metadata.CreditArrangedBy = creditArrangedBy;
-            }
-
-            if (modifiers.Extract("credit_composed_by", out string creditComposedBy))
-            {
-                metadata.CreditComposedBy = creditComposedBy;
-            }
-
-            if (modifiers.Extract("credit_courtesy_of", out string creditCourtesyOf))
-            {
-                metadata.CreditCourtesyOf = creditCourtesyOf;
-            }
-
-            if (modifiers.Extract("credit_engineered_by", out string creditEngineeredBy))
-            {
-                metadata.CreditEngineeredBy = creditEngineeredBy;
-            }
-
-            if (modifiers.Extract("credit_license", out string creditLicense))
-            {
-                metadata.CreditLicense = creditLicense;
-            }
-
-            if (modifiers.Extract("credit_mastered_by", out string creditMasteredBy))
-            {
-                metadata.CreditMasteredBy = creditMasteredBy;
-            }
-
-            if (modifiers.Extract("credit_mixed_by", out string creditMixedBy))
-            {
-                metadata.CreditMixedBy = creditMixedBy;
-            }
-
-            if (modifiers.Extract("credit_other", out string creditOther))
-            {
-                metadata.CreditOther = creditOther;
-            }
-
-            if (modifiers.Extract("credit_performed_by", out string creditPerformedBy))
-            {
-                metadata.CreditPerformedBy = creditPerformedBy;
-            }
-
-            if (modifiers.Extract("credit_produced_by", out string creditProducedBy))
-            {
-                metadata.CreditProducedBy = creditProducedBy;
-            }
-
-            if (modifiers.Extract("credit_published_by", out string creditPublishedBy))
-            {
-                metadata.CreditPublishedBy = creditPublishedBy;
-            }
-
-            if (modifiers.Extract("credit_written_by", out string creditWrittenBy))
-            {
-                metadata.CreditWrittenBy = creditWrittenBy;
-            }
-
-            if (modifiers.Extract("charter_bass", out string charterBass))
-            {
-                metadata.CharterBass = charterBass;
-            }
-
-            if (modifiers.Extract("charter_drums", out string charterDrums))
-            {
-                metadata.CharterDrums = charterDrums;
-            }
-
-            if (modifiers.Extract("charter_elite_drums", out string charterEliteDrums))
-            {
-                metadata.CharterEliteDrums = charterEliteDrums;
-            }
-
-            if (modifiers.Extract("charter_guitar", out string charterGuitar))
-            {
-                metadata.CharterGuitar = charterGuitar;
-            }
-
-            if (modifiers.Extract("charter_keys", out string charterKeys))
-            {
-                metadata.CharterKeys = charterKeys;
-            }
-
-            if (modifiers.Extract("charter_lower_diff", out string charterLowerDiff))
-            {
-                metadata.CharterLowerDiff = charterLowerDiff;
-            }
-
-            if (modifiers.Extract("charter_pro_bass", out string charterProBass))
-            {
-                metadata.CharterProBass = charterProBass;
-            }
-
-            if (modifiers.Extract("charter_pro_keys", out string charterProKeys))
-            {
-                metadata.CharterProKeys = charterProKeys;
-            }
-
-            if (modifiers.Extract("charter_pro_guitar", out string charterProGuitar))
-            {
-                metadata.CharterProGuitar = charterProGuitar;
-            }
-
-            if (modifiers.Extract("charter_vocals", out string charterVocals))
-            {
-                metadata.CharterVocals = charterVocals;
-            }
-
-            if (modifiers.Extract("playlist_track", out int playlistTrack))
-            {
-                metadata.PlaylistTrack = playlistTrack;
-            }
-            else
-            {
-                metadata.PlaylistTrack = int.MaxValue;
-            }
-
-            if (modifiers.Extract("album_track", out int albumTrack))
-            {
-                metadata.AlbumTrack = albumTrack;
-            }
-            else
-            {
-                metadata.AlbumTrack = int.MaxValue;
-            }
+            ReadIniIntOr(modifiers, "playlist_track", out metadata.PlaylistTrack, int.MaxValue);
+            ReadIniIntOr(modifiers, "album_track", out metadata.AlbumTrack, int.MaxValue);
 
             if (modifiers.Extract("rating", out uint songRating))
             {
                 metadata.SongRating = (SongRating)songRating;
             }
 
-            if (modifiers.Extract("song_length", out long songLength))
-            {
-                metadata.SongLength = songLength;
-            }
-
-            if (modifiers.Extract("video_start_time", out long videoStartTime))
-            {
-                metadata.Video.Start = videoStartTime;
-            }
-
-            if (modifiers.Extract("video_end_time", out long videoEndTime))
-            {
-                metadata.Video.End = videoEndTime;
-            }
+            ReadIniLong(modifiers, "song_length", out long metadata.SongLength);
+            ReadIniLong(modifiers, "video_start_time", out long metadata.Video.Start);
+            ReadIniLong(modifiers, "video_end_time", out long metadata.Video.End);
 
             if (modifiers.Extract("preview", out (long Start, long End) preview))
             {
@@ -442,11 +304,6 @@ namespace YARG.Core.Song
             if (modifiers.Extract("video_loop", out bool videoLoop))
             {
                 metadata.VideoLoop = videoLoop;
-            }
-
-            if (modifiers.Extract("link_bandcamp", out string linkBandcamp))
-            {
-                metadata.LinkBandcamp = linkBandcamp;
             }
         }
     }


### PR DESCRIPTION
This is a refactor of the SongMetadata FillFromIni function, it replaces the repeated function calls with one generic function. This improves the readability and maintainability of the FillFromIni function.

@TheNathannator has noted that this change may affect performance negatively, so this PR needs to be tested in terms of performance before being accepted into the main repo. These functions use the `[MethodImpl(MethodImplOptions.AggressiveInlining)]` attribute which should theoretically make the methods inlined, but still it needs to be tested.