### PR TITLE
End wait countdowns at the start of the next note

### DIFF
--- a/YARG.Core/Chart/Events/WaitCountdown.cs
+++ b/YARG.Core/Chart/Events/WaitCountdown.cs
@@ -6,10 +6,6 @@ namespace YARG.Core.Chart
     public class WaitCountdown : ChartEvent
     {
         public const double MIN_SECONDS = 9;
-        public const double END_COUNTDOWN_SECOND = 1;
-
-        //The time where the countdown should start fading out and overstrums will break combo again
-        public double DeactivateTime => TimeEnd - END_COUNTDOWN_SECOND;
 
         public WaitCountdown(double time, double timeLength, uint tick, uint tickLength) : base(time, timeLength, tick, tickLength)
         {

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -269,13 +269,13 @@ namespace YARG.Core.Engine
                 if (IsWaitCountdownActive)
                 {
                     var currentCountdown = WaitCountdowns[CurrentWaitCountdownIndex];
-                    double deactivateTime = currentCountdown.DeactivateTime;
+                    double endTime = currentCountdown.TimeEnd;
 
-                    if (IsTimeBetween(deactivateTime, previousTime, nextTime))
+                    if (IsTimeBetween(endTime, previousTime, nextTime))
                     {
                         YargLogger.LogFormatTrace("Queuing countdown {0} deactivation at {1}",
-                            CurrentWaitCountdownIndex, deactivateTime);
-                        QueueUpdateTime(deactivateTime, "Deactivate Countdown");
+                            CurrentWaitCountdownIndex, endTime);
+                        QueueUpdateTime(endTime, "Deactivate Countdown");
                     }
                 }
                 else
@@ -342,7 +342,7 @@ namespace YARG.Core.Engine
 
                 if (time >= currentCountdown.Time)
                 {
-                    if (time < currentCountdown.DeactivateTime)
+                    if (time < currentCountdown.TimeEnd)
                     {
                         // This countdown should be displayed onscreen
                         if (!IsWaitCountdownActive)
@@ -359,7 +359,7 @@ namespace YARG.Core.Engine
                         if (IsWaitCountdownActive)
                         {
                             IsWaitCountdownActive = false;
-                            YargLogger.LogFormatTrace("Countdown {0} deactivated at time {1}. Expected time: {2}", CurrentWaitCountdownIndex, time, currentCountdown.DeactivateTime);
+                            YargLogger.LogFormatTrace("Countdown {0} deactivated at time {1}. Expected time: {2}", CurrentWaitCountdownIndex, time, currentCountdown.TimeEnd);
                         }
 
                         CurrentWaitCountdownIndex++;

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -29,8 +29,8 @@ namespace YARG.Core.Replays
         private static readonly EightCC REPLAY_MAGIC_HEADER_OLD = new('Y', 'A', 'R', 'G', 'P', 'L', 'A', 'Y');
         private static readonly EightCC REPLAY_MAGIC_HEADER = new('Y', 'A', 'R', 'E', 'P', 'L', 'A', 'Y');
 
-        private static readonly (int OLD_MIN, int METADATA_MIN, int DATA_MIN, int CURRENT) REPLAY_VERSIONS = (4, 6, 8, 8);
-        private const int ENGINE_VERSION = 3;
+        private static readonly (int OLD_MIN, int METADATA_MIN, int DATA_MIN, int CURRENT) REPLAY_VERSIONS = (4, 6, 9, 9);
+        private const int ENGINE_VERSION = 4;
 
         public static (ReplayReadResult Result, ReplayInfo Info, ReplayData Data) TryDeserialize(string path, ReplayReadOptions replayOptions)
         {


### PR DESCRIPTION
This allows overstrums and drum freestyling to be done until the next note after the break finishes. This is done by removing `DeactivateTime` and replacing everywhere it is used with the `TimeEnd` of the break instead.

I wasn't sure if I should have kept DeactivateTime, but in my opinion, it doesn't really make sense anyway, since IMO it would just be better to offset the actual end time of the break instead, instead of having two end times.

`END_COUNTDOWN_SECOND` has also been removed from Core, and moved into CountdownDisplay in the main repo, since nothing in Core referenced it anymore, and it seemed more relevant to the actual display vs. everything that Core handles.

Engine version also got bumped to 4, and replay versions to 9.

Depends on YARC-Official/YARG#1101