### PR TITLE
Don't use extra_authoring for charter metadata

### DIFF
--- a/YARG.Core/IO/DTA/DTAEntry.cs
+++ b/YARG.Core/IO/DTA/DTAEntry.cs
@@ -250,34 +250,13 @@ namespace YARG.Core.IO
                     case "video_venues": VideoVenues = YARGDTAReader.ExtractStringArray(ref container); break;
                     case "extra_authoring":
                     {
-                        StringBuilder authors = new();
                         foreach (string str in YARGDTAReader.ExtractStringArray(ref container))
                         {
                             if (str == "disc_update")
                             {
                                 DiscUpdate = true;
                             }
-                            else
-                            {
-                                if (authors.Length == 0 && Charter == SongMetadata.DEFAULT_CHARTER)
-                                {
-                                    authors.Append(str);
-                                }
-                                else
-                                {
-                                    if (authors.Length == 0)
-                                        authors.Append(Charter);
-                                    authors.Append(", " + str);
-                                }
-                            }
                         }
-
-                        if (authors.Length == 0)
-                        {
-                            authors.Append(Charter);
-                        }
-
-                        Charter = authors.ToString();
                     }
                     break;
                 }


### PR DESCRIPTION
This fixes a bug where a song would have null charter metadata if `(extra_authoring disc_update)` was in `songs_updates.dta` but `author` was only in `songs.dta`. I don't believe any content uses `extra_authoring` for charter names so this shouldn't be a loss in functionality.