### PR TITLE
Add DrumsEngineParameter for ignoring overhits

### DIFF
--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -64,6 +64,12 @@ namespace YARG.Core.Engine.Drums
                 return;
             }
 
+            // Cancel overhit if we've been told to ignore overhits.
+            if (EngineParameters.IgnoreOverhits)
+            {
+                return;
+            }
+
             // Cancel overhit if past last note
             if (NoteIndex >= Chart.Notes.Count - 1)
             {

--- a/YARG.Core/Engine/Drums/DrumsEngineParameters.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngineParameters.cs
@@ -24,13 +24,17 @@ namespace YARG.Core.Engine.Drums
         // The maximum allowed time (seconds) between notes to use context-sensitive velocity scoring
         public readonly float SituationalVelocityWindow;
 
+        // Whether to ignore overhits for scoring/streak purposes.
+        public readonly bool IgnoreOverhits;
+
         public DrumsEngineParameters(HitWindowSettings hitWindow, int maxMultiplier, float[] starMultiplierThresholds,
-            DrumMode mode)
+            DrumMode mode, bool ignoreOverhits = false)
             : base(hitWindow, maxMultiplier, 0, 0, starMultiplierThresholds)
         {
             Mode = mode;
             VelocityThreshold = 0.35f;
             SituationalVelocityWindow = 1.5f;
+            IgnoreOverhits = ignoreOverhits;
         }
 
         public DrumsEngineParameters(ref FixedArrayStream stream, int version)
@@ -39,6 +43,7 @@ namespace YARG.Core.Engine.Drums
             Mode = (DrumMode) stream.ReadByte();
             VelocityThreshold = stream.Read<float>(Endianness.Little);
             SituationalVelocityWindow = stream.Read<float>(Endianness.Little);
+            IgnoreOverhits = stream.ReadBoolean();
         }
 
         public override void Serialize(BinaryWriter writer)
@@ -48,6 +53,7 @@ namespace YARG.Core.Engine.Drums
             writer.Write((byte) Mode);
             writer.Write(VelocityThreshold);
             writer.Write(SituationalVelocityWindow);
+            writer.Write(IgnoreOverhits);
         }
 
         public override string ToString()
@@ -55,7 +61,8 @@ namespace YARG.Core.Engine.Drums
             return
                 $"{base.ToString()}\n" +
                 $"Velocity threshold: {VelocityThreshold}\n" +
-                $"Situational velocity window: {SituationalVelocityWindow}";
+                $"Situational velocity window: {SituationalVelocityWindow}\n" +
+                $"Ignore overhits: {IgnoreOverhits}";
         }
     }
 }

--- a/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
+++ b/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
@@ -154,6 +154,9 @@ namespace YARG.Core.Game
                 FrontToBackRatio = 1.0
             };
 
+            [SettingType(SettingType.Toggle)]
+            public bool IgnoreOverhits = false;
+
             public DrumsPreset Copy()
             {
                 return new DrumsPreset
@@ -169,7 +172,8 @@ namespace YARG.Core.Game
                     hitWindow,
                     DEFAULT_MAX_MULTIPLIER,
                     starMultiplierThresholds,
-                    mode);
+                    mode,
+                    IgnoreOverhits);
             }
         }
 


### PR DESCRIPTION
Pretty basic, just adds an engine param for ignoring overhits on drums.