### PR TITLE
Band Score Multipliers

### DIFF
--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -491,7 +491,8 @@ namespace YARG.Core.Engine
                 // Amount of points just from Star Power is half of the current multiplier (8x total -> 4x SP points)
                 var spScore = scoreMultiplier / 2;
 
-                EngineStats.StarPowerScore += spScore;
+                EngineStats.StarPowerScore += spScore;            
+                EngineStats.BandBonusScore += EngineStats.BandBonusMultiplier * spScore;
 
                 // Subtract score from the note that was just hit to get the multiplier points
                 EngineStats.MultiplierScore += spScore - score;
@@ -499,7 +500,9 @@ namespace YARG.Core.Engine
             else
             {
                 EngineStats.MultiplierScore += scoreMultiplier - score;
+                EngineStats.BandBonusScore += EngineStats.BandBonusMultiplier * scoreMultiplier;
             }
+
             UpdateStars();
         }
 

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -409,6 +409,12 @@ namespace YARG.Core.Engine
             RebaseSustains(CurrentTick);
         }
 
+        
+        public void UpdateBandMultiplier(int multiplier)
+        {
+            BaseStats.BandMultiplier = multiplier;
+        }
+
         public double GetStarPowerBarAmount()
         {
             return BaseStats.StarPowerTickAmount / (double) TicksPerFullSpBar;

--- a/YARG.Core/Engine/BaseStats.cs
+++ b/YARG.Core/Engine/BaseStats.cs
@@ -29,7 +29,7 @@ namespace YARG.Core.Engine
         /// <remarks>
         /// Calculated from <see cref="CommittedScore"/>, <see cref="PendingScore"/>, and <see cref="SoloBonuses"/>.
         /// </remarks>
-        public int TotalScore => CommittedScore + PendingScore + SoloBonuses;
+        public int TotalScore => CommittedScore + PendingScore + SoloBonuses + BandBonusScore;
 
         /// <summary>
         /// Total score earned from hitting notes.
@@ -45,6 +45,11 @@ namespace YARG.Core.Engine
         /// Total score earned from score multipliers.
         /// </summary>
         public int MultiplierScore;
+
+        /// <summary>
+        /// Total score earned from band bonuses, typically from Star Power/Overdrive activations from other players.
+        /// </summary>
+        public int BandBonusScore;
 
         /// <summary>
         /// The score used to calculate star progress.
@@ -79,6 +84,17 @@ namespace YARG.Core.Engine
         /// The player's current score multiplier (e.g 2x, 3x)
         /// </summary>
         public int ScoreMultiplier;
+
+        /// <summary>
+        /// The score multiplier currently applied to the entire band.
+        /// </summary>
+        public int BandMultiplier;
+
+        /// <summary>
+        /// The bonus multiplier awared to this player as a result of other players having Star Power/Overdrive active.
+        /// See also <see cref="BandBonusScore"/>.
+        /// </summary>
+        public int BandBonusMultiplier => IsStarPowerActive ? BandMultiplier - 2 : BandMultiplier - 1;
 
         /// <summary>
         /// Number of notes which have been hit.
@@ -183,9 +199,12 @@ namespace YARG.Core.Engine
             NoteScore = stats.NoteScore;
             SustainScore = stats.SustainScore;
             MultiplierScore = stats.MultiplierScore;
+            BandBonusScore = stats.BandBonusScore;
             Combo = stats.Combo;
             MaxCombo = stats.MaxCombo;
             ScoreMultiplier = stats.ScoreMultiplier;
+            BandMultiplier = stats.BandMultiplier;
+
             NotesHit = stats.NotesHit;
             TotalNotes = stats.TotalNotes;
 
@@ -213,10 +232,12 @@ namespace YARG.Core.Engine
             NoteScore = stream.Read<int>(Endianness.Little);
             SustainScore = stream.Read<int>(Endianness.Little);
             MultiplierScore = stream.Read<int>(Endianness.Little);
+            BandBonusScore = stream.Read<int>(Endianness.Little);
 
             Combo = stream.Read<int>(Endianness.Little);
             MaxCombo = stream.Read<int>(Endianness.Little);
             ScoreMultiplier = stream.Read<int>(Endianness.Little);
+            BandMultiplier = stream.Read<int>(Endianness.Little);
 
             NotesHit = stream.Read<int>(Endianness.Little);
             TotalNotes = stream.Read<int>(Endianness.Little);
@@ -245,9 +266,11 @@ namespace YARG.Core.Engine
             NoteScore = 0;
             SustainScore = 0;
             MultiplierScore = 0;
+            BandBonusScore = 0;
             Combo = 0;
             MaxCombo = 0;
             ScoreMultiplier = 1;
+            BandMultiplier = 1;
             NotesHit = 0;
             // Don't reset TotalNotes
             // TotalNotes = 0;

--- a/YARG.Core/Engine/EngineManager.Band.cs
+++ b/YARG.Core/Engine/EngineManager.Band.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace YARG.Core.Engine
+{
+    public partial class EngineManager
+    {
+        public int BandMultiplier => Math.Max(_starpowerCount * 2, 1);
+
+        private void UpdateBandMultiplier()
+        {
+            foreach (var engine in Engines)
+            {
+                engine.Engine.UpdateBandMultiplier(BandMultiplier);
+            }
+        }
+    }
+}

--- a/YARG.Core/Engine/EngineManager.FailMeter.cs
+++ b/YARG.Core/Engine/EngineManager.FailMeter.cs
@@ -191,7 +191,12 @@ namespace YARG.Core.Engine
 
             private void OnKeysOverhit(int key) => OnOverstrum();
 
-            private void OnStarpowerStatus(bool isActive) => _engineManager._starpowerCount += isActive ? 1 : -1;
+            private void OnStarPowerStatus(bool active)
+            {
+                var count = _engineManager._starpowerCount;
+                count += active ? 1 : -1;
+                _engineManager.UpdateStarPowerCount(count);
+            }
 
             private void AddHappiness(float delta)
             {
@@ -208,7 +213,7 @@ namespace YARG.Core.Engine
                     var engine = (GuitarEngine) guitarEngine;
                     engine.OnNoteHit += OnNoteHit;
                     engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarpowerStatus;
+                    engine.OnStarPowerStatus += OnStarPowerStatus;
                     engine.OnOverstrum += OnOverstrum;
                 }
 
@@ -217,7 +222,7 @@ namespace YARG.Core.Engine
                     var engine = (DrumsEngine) drumEngine;
                     engine.OnNoteHit += OnNoteHit;
                     engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarpowerStatus;
+                    engine.OnStarPowerStatus += OnStarPowerStatus;
                     engine.OnOverhit += OnOverstrum;
                 }
 
@@ -227,7 +232,7 @@ namespace YARG.Core.Engine
                     var engine = (ProKeysEngine) proKeysEngine;
                     engine.OnNoteHit += OnNoteHit;
                     engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarpowerStatus;
+                    engine.OnStarPowerStatus += OnStarPowerStatus;
                     engine.OnOverhit += OnKeysOverhit;
                 }
 
@@ -236,16 +241,22 @@ namespace YARG.Core.Engine
                     var engine = (FiveLaneKeysEngine) keysEngine;
                     engine.OnNoteHit += OnNoteHit;
                     engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarpowerStatus;
+                    engine.OnStarPowerStatus += OnStarPowerStatus;
                     engine.OnOverhit += OnKeysOverhit;
                 }
 
                 if (Engine is VocalsEngine vocalsEngine)
                 {
                     vocalsEngine.OnPhraseHit += OnVocalPhraseHit;
-                    vocalsEngine.OnStarPowerStatus += OnStarpowerStatus;
+                    vocalsEngine.OnStarPowerStatus += OnStarPowerStatus;
                 }
             }
+        }
+
+        private void UpdateStarPowerCount(int count)
+        {
+            _starpowerCount = Math.Clamp(count, 0, int.MaxValue);
+            UpdateBandMultiplier();
         }
     }
 }

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -409,21 +409,5 @@ namespace YARG.Core.Engine
             }
             unison.Awarded = true;
         }
-
-        private void IncreaseBandMultiplier()
-        {
-            foreach (var container in _allEngines)
-            {
-
-            }
-        }
-
-        private void DecreaseBandMultiplier()
-        {
-            foreach (var container in _allEngines)
-            {
-
-            }
-        }
     }
 }


### PR DESCRIPTION
This PR adds support for Band Multipliers to Yarg.Core. For details, see the associated YARG repo PR.