### PR TITLE
Add "Advanced Statistics" section to Scorecard

### DIFF
--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -159,7 +159,11 @@ namespace YARG.Core.Engine.Drums
 
             IncrementCombo();
 
-            EngineStats.IncrementNotesHit(note, CurrentTime);
+            EngineStats.RecordNoteHitTiming(note, CurrentTime, EngineParameters.HitWindow.MaxWindow,
+                EngineParameters.HitWindow.PerfectThresholdPercent,
+                EngineParameters.HitWindow.GreatThresholdPercent,
+                EngineParameters.HitWindow.GoodThresholdPercent,
+                EngineParameters.HitWindow.PoorThresholdPercent);
 
             UpdateMultiplier();
 

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -255,7 +255,11 @@ namespace YARG.Core.Engine.Guitar
 
             IncrementCombo();
 
-            EngineStats.IncrementNotesHit(note, CurrentTime);
+            EngineStats.RecordNoteHitTiming(note, CurrentTime, EngineParameters.HitWindow.MaxWindow,
+                EngineParameters.HitWindow.PerfectThresholdPercent,
+                EngineParameters.HitWindow.GreatThresholdPercent,
+                EngineParameters.HitWindow.GoodThresholdPercent,
+                EngineParameters.HitWindow.PoorThresholdPercent);
 
             UpdateMultiplier();
 

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -127,7 +127,11 @@ namespace YARG.Core.Engine.Keys
                 IncrementCombo();
             }
 
-            EngineStats.IncrementNotesHit(note, CurrentTime);
+            EngineStats.RecordNoteHitTiming(note, CurrentTime, EngineParameters.HitWindow.MaxWindow,
+                EngineParameters.HitWindow.PerfectThresholdPercent,
+                EngineParameters.HitWindow.GreatThresholdPercent,
+                EngineParameters.HitWindow.GoodThresholdPercent,
+                EngineParameters.HitWindow.PoorThresholdPercent);
 
             UpdateMultiplier();
 

--- a/YARG.Core/Game/Presets/BasePreset.cs
+++ b/YARG.Core/Game/Presets/BasePreset.cs
@@ -47,6 +47,14 @@ namespace YARG.Core.Game
 
         public abstract BasePreset CopyWithNewName(string name);
 
+        /// <summary>
+        /// Validates the preset's settings. Returns null if valid, or an error message if invalid.
+        /// </summary>
+        public virtual string? Validate()
+        {
+            return null;
+        }
+
         private static Guid GetGuidForBasePreset(string name)
         {
             // Make sure default presets are consistent based on names.

--- a/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
+++ b/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
@@ -45,6 +45,23 @@ namespace YARG.Core.Game
             [SettingRange(0f, 2f)]
             public double FrontToBackRatio = 1.0;
 
+            // Timing judgement thresholds (as percentages of half-window)
+            [SettingType(SettingType.Slider)]
+            [SettingRange(0f, 100f)]
+            public double PerfectThresholdPercent = 15.0;
+
+            [SettingType(SettingType.Slider)]
+            [SettingRange(0f, 100f)]
+            public double GreatThresholdPercent = 30.0;
+
+            [SettingType(SettingType.Slider)]
+            [SettingRange(0f, 100f)]
+            public double GoodThresholdPercent = 60.0;
+
+            [SettingType(SettingType.Slider)]
+            [SettingRange(0f, 100f)]
+            public double PoorThresholdPercent = 100.0;
+
             [SettingType(SettingType.Slider)]
             [SettingRange(0f, 3f)]
             public double TremoloFrontEndPercent = 1.5;
@@ -52,7 +69,9 @@ namespace YARG.Core.Game
             public HitWindowSettings Create()
             {
                 return new HitWindowSettings(MaxWindow, MinWindow, FrontToBackRatio, IsDynamic,
-                    DynamicSlope, DynamicScale, DynamicGamma, TremoloFrontEndPercent);
+                    DynamicSlope, DynamicScale, DynamicGamma,
+                    PerfectThresholdPercent, GreatThresholdPercent, GoodThresholdPercent, PoorThresholdPercent,
+                    TremoloFrontEndPercent);
             }
 
             public HitWindowPreset Copy()
@@ -68,6 +87,11 @@ namespace YARG.Core.Game
                     DynamicGamma = DynamicGamma,
 
                     FrontToBackRatio = FrontToBackRatio,
+
+                    PerfectThresholdPercent = PerfectThresholdPercent,
+                    GreatThresholdPercent = GreatThresholdPercent,
+                    GoodThresholdPercent = GoodThresholdPercent,
+                    PoorThresholdPercent = PoorThresholdPercent,
 
                     TremoloFrontEndPercent = TremoloFrontEndPercent
                 };
@@ -288,7 +312,7 @@ namespace YARG.Core.Game
                 };
 
                 var hitWindow = new HitWindowSettings(
-                    PercussionHitWindow, PercussionHitWindow, 1, false, 0, 0, 0, 0);
+                    PercussionHitWindow, PercussionHitWindow, 1, false, 0, 0, 0, 15, 30, 60, 100, 0);
 
                 return new VocalsEngineParameters(
                     hitWindow,

--- a/YARG.Core/Game/Presets/EnginePreset.cs
+++ b/YARG.Core/Game/Presets/EnginePreset.cs
@@ -31,5 +31,42 @@ namespace YARG.Core.Game
                 ProKeys = ProKeys.Copy(),
             };
         }
+
+        public override string? Validate()
+        {
+            // Validate timing thresholds for all instruments (except Vocals which doesn't have a hit window)
+            string? error;
+
+            error = ValidateHitWindowThresholds("Five Fret Guitar", FiveFretGuitar.HitWindow);
+            if (error != null) return error;
+
+            error = ValidateHitWindowThresholds("Drums", Drums.HitWindow);
+            if (error != null) return error;
+
+            error = ValidateHitWindowThresholds("Pro Keys", ProKeys.HitWindow);
+            if (error != null) return error;
+
+            return null;
+        }
+
+        private static string? ValidateHitWindowThresholds(string instrumentName, HitWindowPreset hitWindow)
+        {
+            if (hitWindow.PerfectThresholdPercent >= hitWindow.GreatThresholdPercent)
+            {
+                return $"{instrumentName}: Perfect threshold ({hitWindow.PerfectThresholdPercent:F2}%) must be less than Great threshold ({hitWindow.GreatThresholdPercent:F2}%).";
+            }
+
+            if (hitWindow.GreatThresholdPercent >= hitWindow.GoodThresholdPercent)
+            {
+                return $"{instrumentName}: Great threshold ({hitWindow.GreatThresholdPercent:F2}%) must be less than Good threshold ({hitWindow.GoodThresholdPercent:F2}%).";
+            }
+
+            if (hitWindow.GoodThresholdPercent >= hitWindow.PoorThresholdPercent)
+            {
+                return $"{instrumentName}: Good threshold ({hitWindow.GoodThresholdPercent:F2}%) must be less than Poor threshold ({hitWindow.PoorThresholdPercent:F2}%).";
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
Corresponding YARG PR: https://github.com/YARC-Official/YARG/pull/1222

Props to https://github.com/YARC-Official/YARG.Core/pull/302 for some inspiration.

This PR implements a new section on the scorecard that details:
 - Accuracy (mean average of notes hit)
 - Precision (standard deviation of notes hit)
 - Score Judgement (Perfect, Great, Good, Poor)  
 
<img width="313" height="558" alt="20251117_223704_YARG" src="https://github.com/user-attachments/assets/80f6bebc-fcfb-4fb0-8c47-a8656bfbdce9" />


This new Advanced Statistics section and the calculations handled for OnNoteHit are disabled by default and can be enabled with the "Enable Advanced Statistics on Scorecard" option under Experimental. Feel free to move this to whatever section you'd like.

Score judgement can also be customized as part of the Engine presets.
<img width="4520" height="1920" alt="20251117_230217" src="https://github.com/user-attachments/assets/a71bff03-16ee-4e72-80d6-3f81545d137e" />


Limitations/caveats:
- When testing, I was receiving invalid game replay results.
- Vocal is not supported, did no testing for this instrument.
- Didn't test for dynamic windows
- I tried to implement some validation that the score judgement values were reasonable (Perfect < Great < Good < Poor), but there was no settings validation mechanism. In fact, the Confirm button the settings page doesn't do anything and all settings are saved immediately. The current behavior for validation in this PR is that an error dialog will appear if an engine preset is invalid.

<img width="3440" height="1440" alt="image" src="https://github.com/user-attachments/assets/17bcf57a-b5d9-447d-a870-bea29cdb6b49" />
