### PR TITLE
Fixed Star Power phrase ending with Expert+ Kick not awarding Star Power

### DIFF
--- a/YARG.Core/Chart/SongChart.AutoGeneration.cs
+++ b/YARG.Core/Chart/SongChart.AutoGeneration.cs
@@ -106,6 +106,10 @@ namespace YARG.Core.Chart
                 if (!isPhraseEnd(phraseEndExpert))
                 {
                     phraseEndExpert.ActivateFlag(phraseEndFlag);
+                    foreach (var child in phraseEndExpert.ChildNotes)
+                    {
+                        child.ActivateFlag(phraseEndFlag);
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Bug:** If a Star Power phrase ended with an Expert+ (Note 95) kick, YARG would not award count it as fully hit. It does not break combo, but the energy is not awarded.

**Root cause:** `FixDrumPhraseEnds` accounts for this, but only calls `ActivateFlag(phraseEndFlag)` on the parent of the reassigned chord, not the children. In `YargDrumsEngine`, `HitNote` is called per note, and the award check is `note.IsStarPowerEnd && note.ParentOrSelf.WasFullyHit()`. Since only the parent has the flag, it will not award Star Power unless the parent is the last note hit, which makes it inconsistent to reproduce in normal playback because sometimes it _may_ award Star Power.

**Fix:** call `ActivateFlag(phraseEndFlag)` on all child notes after calling it on the parent. 

**Note:** This also fixes a similar, hidden issue in `SoloEnd`