### PR TITLE
Implement exPKG (PS3 format exCON) scanning and loading

### DIFF
--- a/YARG.Core/IO/Images/YARGImage.cs
+++ b/YARG.Core/IO/Images/YARGImage.cs
@@ -52,6 +52,15 @@ namespace YARG.Core.IO
             using var data = FixedArray.LoadFile(path);
             return TransferDXT(data);
         }
+        public static YARGImage LoadPS3DXT(string path)
+        {
+            using var data = FixedArray.LoadFile(path);
+            // .png_ps3 files are identical to the .png_xbox ones, just with every pair of bytes swapped in the raw image data.
+            for (var i = 32; i < data.Length; i += 2) {
+                (data[i], data[i + 1]) = (data[i + 1], data[i]);
+            }
+            return TransferDXT(data);
+        }
 
         public static unsafe YARGImage TransferDXT(FixedArray<byte> file)
         {

--- a/YARG.Core/Song/Cache/CacheGroups/CONEntryGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/CONEntryGroup.cs
@@ -11,13 +11,22 @@ namespace YARG.Core.Song.Cache
     {
         public const string SONGS_DTA = "songs.dta";
 
-        private readonly Dictionary<string, List<(int Index, RBCONEntry Entry)>> _entries;
-        private readonly string _defaultPlaylist;
-        protected readonly AbridgedFileInfo _root;
-        protected readonly Dictionary<string, List<YARGTextContainer<byte>>> _nodes;
-        protected FixedArray<byte> _data;
+        private readonly            Dictionary<string, List<(int Index, RBCONEntry Entry)>> _entries;
+        private readonly            string                                                  _defaultPlaylist;
+        protected readonly          AbridgedFileInfo                                        _root;
+        protected internal readonly Dictionary<string, List<YARGTextContainer<byte>>>       _nodes;
+        protected internal          FixedArray<byte>                                        _data;
 
-        protected abstract bool Tag { get; }
+        public enum CONEntryType : int
+        {
+            PackedCONEntry = 0,
+            UnpackedCONEntry = 1,
+            UnpackedPKGEntry = 2,
+        }
+        /// <summary>
+        /// Determines the type of a CON entry group.
+        /// </summary>
+        protected abstract CONEntryType Tag { get; }
 
         public AbridgedFileInfo Root => _root;
         public string DefaultPlaylist => _defaultPlaylist;
@@ -77,7 +86,7 @@ namespace YARG.Core.Song.Cache
         public void Serialize(MemoryStream groupStream, Dictionary<SongEntry, CacheWriteIndices> indices)
         {
             _root.Serialize(groupStream);
-            groupStream.Write(Tag);
+            groupStream.Write(Tag.Convert(), Endianness.Little);
 
             int count = 0;
             foreach (var list in _entries)

--- a/YARG.Core/Song/Cache/CacheGroups/PackedCONEntryGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/PackedCONEntryGroup.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.MemoryMappedFiles;
 using System.Text;
+using YARG.Core.Extensions;
 using YARG.Core.IO;
 using YARG.Core.Logging;
 
@@ -14,7 +15,7 @@ namespace YARG.Core.Song.Cache
         private readonly List<CONFileListing> _listings;
         private FileStream _stream = null!;
 
-        protected override bool Tag => true;
+        protected override CONEntryType Tag => CONEntryType.PackedCONEntry;
 
         private PackedCONEntryGroup(List<CONFileListing> listings, in AbridgedFileInfo root, string defaultPlaylist)
             : base(root, defaultPlaylist)

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedConsolePackageEntryGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedConsolePackageEntryGroup.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.IO;
+using YARG.Core.IO;
+using YARG.Core.Logging;
+
+namespace YARG.Core.Song.Cache
+{
+    internal abstract class UnpackedConsolePackageEntryGroup : CONEntryGroup
+    {
+        private UnpackedConsolePackageEntryGroup(in AbridgedFileInfo root, string defaultPlaylist)
+            : base(root, defaultPlaylist) { }
+
+        public static bool Create(string directory, FileInfo dtaInfo, string defaultPlaylist, out CONEntryGroup group)
+        {
+            try
+            {
+                // Peek at the DTA just to detect platform, don't hold onto the data
+                using var data = FixedArray.LoadFile(dtaInfo.FullName);
+                var container = YARGDTAReader.Create(data);
+                while (YARGDTAReader.StartNode(ref container))
+                {
+                    string name = YARGDTAReader.GetNameOfNode(ref container, true);
+
+                    if (File.Exists(Path.Combine(directory, name, name + ".mid.edat")))
+                    {
+                        return UnpackedPKGEntryGroup.Create(directory, dtaInfo, defaultPlaylist, out group);
+                    }
+                    if (File.Exists(Path.Combine(directory, name, name + ".mid")))
+                    {
+                        return UnpackedCONEntryGroup.Create(directory, dtaInfo, defaultPlaylist, out group);
+                    }
+                    YargLogger.LogWarning("Node contained neither .mid nor .mid.edat, cannot determine entry group, checking next node if available");
+                    YARGDTAReader.EndNode(ref container);
+                }
+
+                group = null!;
+                return false;
+            }
+            catch (Exception e)
+            {
+                YargLogger.LogException(e);
+            }
+            group = null!;
+            return false;
+        }
+    }
+}

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedConsolePackageEntryGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedConsolePackageEntryGroup.cs
@@ -14,19 +14,25 @@ namespace YARG.Core.Song.Cache
         {
             try
             {
-                // Peek at the DTA just to detect platform, don't hold onto the data
                 using var data = FixedArray.LoadFile(dtaInfo.FullName);
                 var container = YARGDTAReader.Create(data);
                 while (YARGDTAReader.StartNode(ref container))
                 {
                     string name = YARGDTAReader.GetNameOfNode(ref container, true);
-
-
-                    if (File.Exists(Path.Combine(directory, name, name + ".mid.edat")))
+                    // This is an expensive operation, but happens only once per CON entry group, and is required to parse location
+                    var entry = DTAEntry.Create(name, container);
+                    if (entry.Location is null)
+                    {
+                        YargLogger.LogFormatWarning("Node {0} could not be parsed as a DTA entry, cannot determine entry group, checking next node if available", name);
+                        YARGDTAReader.EndNode(ref container);
+                        continue;
+                    }
+                    string subname = entry.Location[6..entry.Location.IndexOf('/', 6)];
+                    if (File.Exists(Path.Combine(directory, subname, subname + ".mid.edat")))
                     {
                         return UnpackedPKGEntryGroup.Create(directory, dtaInfo, defaultPlaylist, out group);
                     }
-                    if (File.Exists(Path.Combine(directory, name, name + ".mid")))
+                    if (File.Exists(Path.Combine(directory, subname, subname + ".mid")))
                     {
                         return UnpackedCONEntryGroup.Create(directory, dtaInfo, defaultPlaylist, out group);
                     }

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedConsolePackageEntryGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedConsolePackageEntryGroup.cs
@@ -21,6 +21,7 @@ namespace YARG.Core.Song.Cache
                 {
                     string name = YARGDTAReader.GetNameOfNode(ref container, true);
 
+
                     if (File.Exists(Path.Combine(directory, name, name + ".mid.edat")))
                     {
                         return UnpackedPKGEntryGroup.Create(directory, dtaInfo, defaultPlaylist, out group);
@@ -29,7 +30,7 @@ namespace YARG.Core.Song.Cache
                     {
                         return UnpackedCONEntryGroup.Create(directory, dtaInfo, defaultPlaylist, out group);
                     }
-                    YargLogger.LogWarning("Node contained neither .mid nor .mid.edat, cannot determine entry group, checking next node if available");
+                    YargLogger.LogFormatWarning("Node {0} contained neither .mid nor .mid.edat, cannot determine entry group, checking next node if available", name);
                     YARGDTAReader.EndNode(ref container);
                 }
 

--- a/YARG.Core/Song/Cache/CacheGroups/UnpackedPKGEntryGroup.cs
+++ b/YARG.Core/Song/Cache/CacheGroups/UnpackedPKGEntryGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using YARG.Core.IO;
@@ -6,21 +6,21 @@ using YARG.Core.Logging;
 
 namespace YARG.Core.Song.Cache
 {
-    internal class UnpackedCONEntryGroup : CONEntryGroup
+    internal class UnpackedPKGEntryGroup : CONEntryGroup
     {
-        protected override CONEntryType Tag => CONEntryType.UnpackedCONEntry;
+        protected override CONEntryType Tag => CONEntryType.UnpackedPKGEntry;
 
-        private UnpackedCONEntryGroup(in AbridgedFileInfo root, string defaultPlaylist)
+        private UnpackedPKGEntryGroup(in AbridgedFileInfo root, string defaultPlaylist)
             : base(root, defaultPlaylist) { }
 
         public override ScanExpected<RBCONEntry> CreateEntry(in RBScanParameters paramaters)
         {
-            return UnpackedRBCONEntry.Create(in paramaters);
+            return UnpackedRBPKGEntry.Create(in paramaters);
         }
 
         public override void DeserializeEntry(ref FixedArrayStream stream, string name, int index, CacheReadStrings strings)
         {
-            var entry = UnpackedRBCONEntry.TryDeserialize(in _root, name, ref stream, strings);
+            var entry = UnpackedRBPKGEntry.TryDeserialize(in _root, name, ref stream, strings);
             if (entry != null)
             {
                 AddEntry(name, index, entry);
@@ -31,11 +31,10 @@ namespace YARG.Core.Song.Cache
         {
             var dtaLastWrite = AbridgedFileInfo.NormalizedLastWrite(dtaInfo);
             var root = new AbridgedFileInfo(directory, dtaLastWrite);
-            group = new UnpackedCONEntryGroup(in root, defaultPlaylist);
+            group = new UnpackedPKGEntryGroup(in root, defaultPlaylist);
             try
             {
                 using var data = FixedArray.LoadFile(dtaInfo.FullName);
-
                 var container = YARGDTAReader.Create(data);
                 while (YARGDTAReader.StartNode(ref container))
                 {

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -552,6 +552,9 @@ namespace YARG.Core.Song.Cache
                     case ScanResult.MissingCONMidi:
                         writer.WriteLine("Midi file queried for found missing");
                         break;
+                    case ScanResult.EdatMidiEncrypted:
+                        writer.WriteLine(".mid.edat file found to be encrypted");
+                        break;
                     case ScanResult.PossibleCorruption:
                         writer.WriteLine("Possible corruption of a queried midi file");
                         break;

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -34,7 +34,7 @@ namespace YARG.Core.Song.Cache
         /// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
         /// if multiple cache version changes happen in a single day).
         /// </summary>
-        private const int CACHE_VERSION = 26_02_11_00;
+        private const int CACHE_VERSION = 26_03_25_00;
 
         public static ScanProgressTracker Progress => _progress;
         private static ScanProgressTracker _progress;
@@ -661,7 +661,7 @@ namespace YARG.Core.Song.Cache
                         var dta = new FileInfo(Path.Combine(directory.FullName, CONEntryGroup.SONGS_DTA));
                         if (dta.Exists)
                         {
-                            if (UnpackedCONEntryGroup.Create(directory.FullName, dta, tracker.Playlist, out var entryGroup))
+                            if (UnpackedConsolePackageEntryGroup.Create(directory.FullName, dta, tracker.Playlist, out var entryGroup))
                             {
                                 lock (conEntryGroups)
                                 {
@@ -917,7 +917,7 @@ namespace YARG.Core.Song.Cache
         /// </summary>
         /// <param name="cacheLocation">File location for the cache</param>
         /// <param name="fullDirectoryPlaylists">Toggle for the display style of directory-based playlists</param>
-        /// <returns>A FixedArray instance pointing to a buffer of the cache file's data, or <see cref="FixedArray&lt;&rt;"/>.Null if invalid</returns>
+        /// <returns>A FixedArray instance pointing to a buffer of the cache file's data, or <see cref="FixedArray&lt;&gt;"/>.Null if invalid</returns>
         private static FixedArray<byte>? LoadCacheToMemory(string cacheLocation, bool fullDirectoryPlaylists)
         {
             FileInfo info = new(cacheLocation);
@@ -1420,7 +1420,7 @@ namespace YARG.Core.Song.Cache
                 if (dtaInfo.Exists)
                 {
                     FindOrMarkDirectory(location);
-                    if (UnpackedCONEntryGroup.Create(location, dtaInfo, defaultPlaylist, out var unpacked))
+                    if (UnpackedConsolePackageEntryGroup.Create(location, dtaInfo, defaultPlaylist, out var unpacked))
                     {
                         lock (conEntryGroups)
                         {
@@ -1463,8 +1463,8 @@ namespace YARG.Core.Song.Cache
         {
             var root = new AbridgedFileInfo(ref stream);
             List<CONFileListing>? listings = null;
-            bool packed = stream.ReadBoolean();
-            if (packed)
+            var type = (CONEntryGroup.CONEntryType) stream.Read<int>(Endianness.Little);
+            if (type == CONEntryGroup.CONEntryType.PackedCONEntry)
             {
                 listings = GetCacheCONListings(root.FullName);
             }
@@ -1475,9 +1475,13 @@ namespace YARG.Core.Song.Cache
                 {
                     string name = node.Slice.ReadString();
                     int index = node.Slice.ReadByte();
-                    RBCONEntry entry = packed
-                            ? PackedRBCONEntry.ForceDeserialize(listings, in root, name, ref node.Slice, strings)
-                            : UnpackedRBCONEntry.ForceDeserialize(in root, name, ref node.Slice, strings);
+                    RBCONEntry entry = type switch
+                    {
+                        CONEntryGroup.CONEntryType.PackedCONEntry   => PackedRBCONEntry.ForceDeserialize(listings, in root, name, ref node.Slice, strings),
+                        CONEntryGroup.CONEntryType.UnpackedCONEntry => UnpackedRBCONEntry.ForceDeserialize(in root, name, ref node.Slice, strings),
+                        CONEntryGroup.CONEntryType.UnpackedPKGEntry => UnpackedRBPKGEntry.ForceDeserialize(in root, name, ref node.Slice, strings),
+                        _ => throw new InvalidOperationException($"Invalid CON entry type {type} in cache!")
+                    };
 
                     if (cacheCONModifications.TryGetValue(name, out var mods))
                     {

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedConsolePackage.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedConsolePackage.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.IO;
+using YARG.Core.Extensions;
+using YARG.Core.IO;
+using YARG.Core.Venue;
+
+namespace YARG.Core.Song
+{
+    internal abstract class UnpackedConsolePackageEntry : RBCONEntry
+    {
+        protected abstract YARGImage DXTImageLoader(string path);
+
+
+        protected DateTime _midiLastWrite;
+
+        public override EntryType SubType => EntryType.ExCON;
+        public override string SortBasedLocation => Path.Combine(_root.FullName, _subName);
+        public override string ActualLocation => Path.Combine(_root.FullName, _subName);
+        protected override DateTime MidiLastWriteTime => _midiLastWrite;
+
+        internal override void Serialize(MemoryStream stream, CacheWriteIndices node)
+        {
+            stream.Write(_subName);
+            stream.Write(_midiLastWrite.ToBinary(), Endianness.Little);
+            base.Serialize(stream, node);
+        }
+
+        protected YARGImage? LoadAlbumData(string fileExtension)
+        {
+            var image = LoadUpdateAlbumData();
+            if (image == null)
+            {
+                string path = Path.Combine(_root.FullName, _subName, "gen", _subName + "_keep" + fileExtension);
+                if (File.Exists(path))
+                {
+                    image = DXTImageLoader(path);
+                }
+            }
+            return image;
+        }
+
+        public override BackgroundResult? LoadBackground()
+        {
+            string yarground = Path.Combine(_root.FullName, _subName, YARGROUND_FULLNAME);
+            if (File.Exists(yarground))
+            {
+                var stream = File.OpenRead(yarground);
+                return new BackgroundResult(BackgroundType.Yarground, stream);
+            }
+
+            foreach (var name in BACKGROUND_FILENAMES)
+            {
+                var fileBase = Path.Combine(_root.FullName, _subName, name);
+                foreach (var ext in VIDEO_EXTENSIONS)
+                {
+                    string videoFile = fileBase + ext;
+                    if (File.Exists(videoFile))
+                    {
+                        var stream = File.OpenRead(videoFile);
+                        return new BackgroundResult(BackgroundType.Video, stream);
+                    }
+                }
+            }
+
+            //                                     No "video"
+            foreach (var name in BACKGROUND_FILENAMES[..2])
+            {
+                var fileBase = Path.Combine(_root.FullName, _subName, name);
+                foreach (var ext in IMAGE_EXTENSIONS)
+                {
+                    string imageFile = fileBase + ext;
+                    if (File.Exists(imageFile))
+                    {
+                        var image = YARGImage.Load(imageFile);
+                        if (image != null)
+                        {
+                            return new BackgroundResult(image);
+                        }
+                    }
+                }
+            }
+            return null;
+        }
+
+        protected FixedArray<byte>? LoadMiloData(string fileExtension)
+        {
+            var data = LoadUpdateMiloData();
+            if (data == null)
+            {
+                string path = Path.Combine(_root.FullName, _subName, "gen", _subName + fileExtension);
+                if (File.Exists(path))
+                {
+                    data = FixedArray.LoadFile(path);
+                }
+            }
+            return data;
+        }
+
+        protected FixedArray<byte>? GetMainMidiData(string fileExtension)
+        {
+            string path = Path.Combine(_root.FullName, _subName, _subName + fileExtension);
+            return File.Exists(path) ? FixedArray.LoadFile(path) : null;
+        }
+
+        protected override Stream? GetMoggStream()
+        {
+            var stream = LoadUpdateMoggStream();
+            if (stream == null)
+            {
+                string path = Path.Combine(_root.FullName, _subName, _subName + ".mogg");
+                if (File.Exists(path))
+                {
+                    stream = File.OpenRead(path);
+                }
+            }
+            return stream;
+        }
+
+        protected UnpackedConsolePackageEntry(in AbridgedFileInfo root, string nodeName)
+            : base(in root, nodeName) {}
+
+    }
+}

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using YARG.Core.Extensions;
-using YARG.Core.Song.Cache;
 using YARG.Core.IO;
 using YARG.Core.Venue;
 using YARG.Core.Logging;
@@ -10,6 +9,8 @@ namespace YARG.Core.Song
 {
     internal sealed class UnpackedRBCONEntry : RBCONEntry
     {
+        private const int    ENCRYPTED_EDAT_MAGIC       = 0x4E504400;
+
         private DateTime _midiLastWrite;
 
         public override EntryType SubType => EntryType.ExCON;
@@ -33,6 +34,14 @@ namespace YARG.Core.Song
                 if (File.Exists(path))
                 {
                     image = YARGImage.LoadDXT(path);
+                }
+                else
+                {
+                    path  = Path.Combine(_root.FullName, _subName, "gen", _subName + "_keep.png_ps3");
+                    if (File.Exists(path))
+                    {
+                        image = YARGImage.LoadPS3DXT(path);
+                    }
                 }
             }
             return image;
@@ -86,10 +95,20 @@ namespace YARG.Core.Song
             var data = LoadUpdateMiloData();
             if (data == null)
             {
-                string path = Path.Combine(_root.FullName, _subName, "gen", _subName + ".mogg");
+                string path = Path.Combine(_root.FullName, _subName, "gen", _subName + ".milo_xbox");
                 if (File.Exists(path))
                 {
                     data = FixedArray.LoadFile(path);
+                }
+                else
+                {
+                    // milo files are identical on PS3 and Xbox, unless they have textures embedded,
+                    // which apparently only applies to TBRB, and I don't think YARG reads them anyway
+                    path = Path.Combine(_root.FullName, _subName, "gen", _subName + ".milo_ps3");
+                    if (File.Exists(path))
+                    {
+                        data = FixedArray.LoadFile(path);
+                    }
                 }
             }
             return data;
@@ -98,6 +117,10 @@ namespace YARG.Core.Song
         protected override FixedArray<byte>? GetMainMidiData()
         {
             string path = Path.Combine(_root.FullName, _subName, _subName + ".mid");
+            if (!File.Exists(path))
+            {
+                path = Path.Combine(_root.FullName, _subName, _subName + ".mid.edat");
+            }
             return File.Exists(path) ? FixedArray.LoadFile(path) : null;
         }
 
@@ -142,7 +165,18 @@ namespace YARG.Core.Song
                 var midiInfo = new FileInfo(Path.Combine(songDirectory, entry._subName + ".mid"));
                 if (!midiInfo.Exists)
                 {
-                    return new ScanUnexpected(ScanResult.MissingCONMidi);
+                    // Try the PS3 .mid.edat file
+                    midiInfo = new FileInfo(Path.Combine(songDirectory, entry._subName + ".mid.edat"));
+                    if (!midiInfo.Exists)
+                    {
+                        return new ScanUnexpected(ScanResult.MissingCONMidi);
+                    }
+                    // First three bytes should be 4E 50 44 if encrypted
+                    using var midiStream = new FileStream(midiInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
+                    if ((midiStream.Read<int>(Endianness.Big) & 0xFFFFFF00) == ENCRYPTED_EDAT_MAGIC)
+                    {
+                        return new ScanUnexpected(ScanResult.EdatMidiEncrypted);
+                    }
                 }
 
                 string moggPath = Path.Combine(songDirectory, entry._subName + ".mogg");
@@ -184,7 +218,14 @@ namespace YARG.Core.Song
             var midiInfo = new FileInfo(midiPath);
             if (!midiInfo.Exists)
             {
-                return null;
+                // Try the PS3 .mid.edat file
+                midiPath = Path.Combine(root.FullName, subname, subname + ".mid.edat");
+                midiInfo = new FileInfo(midiPath);
+                // I don't think we need to check encryption here, since if the .mid.edat is encrypted, it should have been caught during the initial scan.
+                if (!midiInfo.Exists)
+                {
+                    return null;
+                }
             }
 
             var midiLastWrite = DateTime.FromBinary(stream.Read<long>(Endianness.Little));

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBPKG.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBPKG.cs
@@ -6,18 +6,19 @@ using YARG.Core.Logging;
 
 namespace YARG.Core.Song
 {
-    internal sealed class UnpackedRBCONEntry : UnpackedConsolePackageEntry
+    internal sealed class UnpackedRBPKGEntry : UnpackedConsolePackageEntry
     {
-        protected override YARGImage DXTImageLoader(string path) => YARGImage.LoadDXT(path);
+        private const int    ENCRYPTED_EDAT_MAGIC       = 0x4E504400;
+        protected override YARGImage DXTImageLoader(string path) => YARGImage.LoadPS3DXT(path);
 
-        private UnpackedRBCONEntry(in AbridgedFileInfo root, string nodeName)
+        private UnpackedRBPKGEntry(in AbridgedFileInfo root, string nodeName)
             : base(in root, nodeName) {}
 
         public static ScanExpected<RBCONEntry> Create(in RBScanParameters parameters)
         {
             try
             {
-                var entry = new UnpackedRBCONEntry(in parameters.Root, parameters.NodeName)
+                var entry = new UnpackedRBPKGEntry(in parameters.Root, parameters.NodeName)
                 {
                     _updateDirectoryAndDtaLastWrite = parameters.UpdateDirectory,
                     _updateMidiLastWrite = parameters.UpdateMidi,
@@ -34,10 +35,17 @@ namespace YARG.Core.Song
                 entry._subName = location.Value[6..location.Value.IndexOf('/', 6)];
 
                 string songDirectory = Path.Combine(parameters.Root.FullName, entry._subName);
-                var midiInfo = new FileInfo(Path.Combine(songDirectory, entry._subName + ".mid"));
+
+                var midiInfo = new FileInfo(Path.Combine(songDirectory, entry._subName + ".mid.edat"));
                 if (!midiInfo.Exists)
                 {
                     return new ScanUnexpected(ScanResult.MissingCONMidi);
+                }
+                // First three bytes should be 4E 50 44 if encrypted
+                using var midiStream = new FileStream(midiInfo.FullName, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
+                if ((midiStream.Read<int>(Endianness.Big) & 0xFFFFFF00) == ENCRYPTED_EDAT_MAGIC)
+                {
+                    return new ScanUnexpected(ScanResult.EdatMidiEncrypted);
                 }
 
                 string moggPath = Path.Combine(songDirectory, entry._subName + ".mogg");
@@ -72,10 +80,10 @@ namespace YARG.Core.Song
             }
         }
 
-        public static UnpackedRBCONEntry? TryDeserialize(in AbridgedFileInfo root, string nodeName, ref FixedArrayStream stream, CacheReadStrings strings)
+        public static UnpackedRBPKGEntry? TryDeserialize(in AbridgedFileInfo root, string nodeName, ref FixedArrayStream stream, CacheReadStrings strings)
         {
             string subname = stream.ReadString();
-            string midiPath = Path.Combine(root.FullName, subname, subname + ".mid");
+            string midiPath = Path.Combine(root.FullName, subname, subname + ".mid.edat");
             var midiInfo = new FileInfo(midiPath);
             if (!midiInfo.Exists)
             {
@@ -88,7 +96,7 @@ namespace YARG.Core.Song
                 return null;
             }
 
-            var entry = new UnpackedRBCONEntry(in root, nodeName)
+            var entry = new UnpackedRBPKGEntry(in root, nodeName)
             {
                 _subName = subname,
                 _midiLastWrite = midiLastWrite,
@@ -97,9 +105,9 @@ namespace YARG.Core.Song
             return entry;
         }
 
-        public static UnpackedRBCONEntry ForceDeserialize(in AbridgedFileInfo root, string nodeName, ref FixedArrayStream stream, CacheReadStrings strings)
+        public static UnpackedRBPKGEntry ForceDeserialize(in AbridgedFileInfo root, string nodeName, ref FixedArrayStream stream, CacheReadStrings strings)
         {
-            var entry = new UnpackedRBCONEntry(in root, nodeName)
+            var entry = new UnpackedRBPKGEntry(in root, nodeName)
             {
                 _subName = stream.ReadString(),
                 _midiLastWrite = DateTime.FromBinary(stream.Read<long>(Endianness.Little)),
@@ -108,10 +116,10 @@ namespace YARG.Core.Song
             return entry;
         }
 
-        public override YARGImage? LoadAlbumData() => LoadAlbumData(".png_xbox");
+        public override YARGImage? LoadAlbumData() => LoadAlbumData(".png_ps3");
 
-        public override FixedArray<byte>? LoadMiloData() => LoadMiloData(".milo_xbox");
+        public override FixedArray<byte>? LoadMiloData() => LoadMiloData(".milo_ps3");
 
-        protected override FixedArray<byte>? GetMainMidiData() => GetMainMidiData(".mid");
+        protected override FixedArray<byte>? GetMainMidiData() => GetMainMidiData(".mid.edat");
     }
 }

--- a/YARG.Core/Song/Entries/Types/ScanExpected.cs
+++ b/YARG.Core/Song/Entries/Types/ScanExpected.cs
@@ -15,6 +15,7 @@ namespace YARG.Core.Song
         MoggError_Update,
         UnsupportedEncryption,
         MissingCONMidi,
+        EdatMidiEncrypted,
         PossibleCorruption,
         FailedSngLoad,
 


### PR DESCRIPTION
I'm not sure this is exactly the best way to do this, since it first checks for the Xbox-style ex-cons and then only if those files don't exist, checks for the PS3-style ex-cons, which might affect performance when scanning the PS3 files.

The main differences between the Xbox and PS3 styles is the file names (.png_xbox -> .png_ps3, .milo_xbox -> .milo_ps3, .mid -> .mid.edat), the pngs have every byte swapped with its neighbour after the header, and that the midi files can be encrypted as .edats.

Since we don't want to support decrypting edats for obvious reasons, this just throws an error if the midi is detected as encrypted (First three bytes are NPD -> `4E 50 44`). Also, same as other CONs, moggs need to be unencrypted. RB3DX does support both unencrypted moggs and edats, so libraries should be compatible if set up correctly.

Also fixed a bug where .milo files were not being loaded at all for ex-cons.