### PR TITLE
Parse covered_by

### DIFF
--- a/YARG.Core/IO/DTA/DTAEntry.cs
+++ b/YARG.Core/IO/DTA/DTAEntry.cs
@@ -14,6 +14,7 @@ namespace YARG.Core.IO
 
         public TextSpan? Name;
         public TextSpan? Artist;
+        public TextSpan? CoveredBy;
         public TextSpan? Album;
         public string? Genre;
         public string? Subgenre;
@@ -75,6 +76,7 @@ namespace YARG.Core.IO
                 {
                     case "name": Name = YARGDTAReader.ExtractTextBytes(ref container); break;
                     case "artist": Artist = YARGDTAReader.ExtractTextBytes(ref container); break;
+                    case "covered_by": CoveredBy = YARGDTAReader.ExtractTextBytes(ref container); break;
                     case "master": IsMaster = YARGDTAReader.ExtractBoolean_FlippedDefault(ref container); break;
                     case "context":
                         unsafe

--- a/YARG.Core/IO/Ini/SongIniHandler.cs
+++ b/YARG.Core/IO/Ini/SongIniHandler.cs
@@ -46,6 +46,7 @@ namespace YARG.Core.IO.Ini
                 { "charter_vocals",                       new("charter_vocals", ModifierType.String) },
                 { "count",                                new("count", ModifierType.UInt32) },
                 { "cover",                                new("cover", ModifierType.String) },
+                { "covered_by",                           new("covered_by", ModifierType.String) },
                 { "credit_album_art_by",                  new("credit_album_art_designed_by", ModifierType.String) },
                 { "credit_album_art_designed_by",         new("credit_album_art_designed_by", ModifierType.String) },
                 { "credit_album_cover",                   new("credit_album_art_designed_by", ModifierType.String) },

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -741,6 +741,7 @@ namespace YARG.Core.Song
         {
             if (dta.Name != null)                 { entry._metadata.Name          = YARGDTAReader.DecodeString(dta.Name.Value, dta.MetadataEncoding); }
             if (dta.Artist != null)               { entry._metadata.Artist        = YARGDTAReader.DecodeString(dta.Artist.Value, dta.MetadataEncoding); }
+            if (dta.CoveredBy != null)            { entry._metadata.CoveredBy     = YARGDTAReader.DecodeString(dta.CoveredBy.Value, dta.MetadataEncoding); }
             if (dta.Album != null)                { entry._metadata.Album         = YARGDTAReader.DecodeString(dta.Album.Value, dta.MetadataEncoding); }
             if (dta.Charter != null)              { entry._metadata.Charter       = YARGDTAReader.DecodeString(dta.Charter.Value, dta.MetadataEncoding); }
             if (dta.LoadingPhrase != null)        { entry._metadata.LoadingPhrase = YARGDTAReader.DecodeString(dta.LoadingPhrase.Value, dta.MetadataEncoding); }

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -98,6 +98,8 @@ namespace YARG.Core.Song
         public SortString Source => _source;
         public SortString Playlist => _playlist;
 
+        public string CoveredBy => _metadata.CoveredBy;
+
         public string UnmodifiedYear => _metadata.Year;
         public string ParsedYear => _parsedYear;
         public int YearAsNumber => _yearAsNumber;
@@ -378,6 +380,7 @@ namespace YARG.Core.Song
             stream.Write(_metadata.Video.Start, Endianness.Little);
             stream.Write(_metadata.Video.End, Endianness.Little);
 
+            stream.Write(_metadata.CoveredBy);
             stream.Write(_metadata.LoadingPhrase);
             stream.Write(_metadata.YearSecondary);
 
@@ -464,6 +467,7 @@ namespace YARG.Core.Song
             _metadata.Video.Start = stream.Read<long>(Endianness.Little);
             _metadata.Video.End = stream.Read<long>(Endianness.Little);
 
+            _metadata.CoveredBy = stream.ReadString();
             _metadata.LoadingPhrase = stream.ReadString();
             _metadata.YearSecondary = stream.ReadString();
 

--- a/YARG.Core/Song/Entries/Types/SongMetadata.cs
+++ b/YARG.Core/Song/Entries/Types/SongMetadata.cs
@@ -27,6 +27,7 @@ namespace YARG.Core.Song
         {
             Name = DEFAULT_NAME,
             Artist = DEFAULT_ARTIST,
+            CoveredBy = string.Empty,
             Album = DEFAULT_ALBUM,
             Genre = string.Empty,
             Subgenre = string.Empty,
@@ -86,6 +87,7 @@ namespace YARG.Core.Song
 
         public string Name;
         public string Artist;
+        public string CoveredBy;
         public string Album;
         public string Genre;
         public string Subgenre;
@@ -170,6 +172,11 @@ namespace YARG.Core.Song
             if (modifiers.Extract("artist", out string artist) && artist.Length > 0)
             {
                 metadata.Artist = artist;
+            }
+
+            if (modifiers.Extract("covered_by", out string coveredBy))
+            {
+                metadata.CoveredBy = coveredBy;
             }
 
             if (modifiers.Extract("album", out string album) && album.Length > 0)


### PR DESCRIPTION
Adds support for `covered_by` metadata used for "As Made Famous By" covers in RB3DX. 