### PR TITLE
Add SingStar (.xml) vocal chart format support

### DIFF
--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Basic.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Basic.cs
@@ -1,0 +1,265 @@
+﻿using NUnit.Framework;
+
+namespace YARG.Core.UnitTests.Parsing.SingStarLoader;
+
+internal class SingStarLoaderTests_Basic : SingStarLoaderTests
+{
+    [Test]
+    public void ParseMinimalFile()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<!-- Artist: Test Artist -->",
+            "<!-- Title: Test Song -->",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        Assert.That(loader.GetMetadata("ARTIST"), Is.EqualTo("Test Artist"));
+        Assert.That(loader.GetMetadata("TITLE"), Is.EqualTo("Test Song"));
+    }
+
+    [Test]
+    public void ParseTempo()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"140\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var syncTrack = loader.LoadSyncTrack();
+        Assert.That(syncTrack.Tempos[0].BeatsPerMinute, Is.EqualTo(140f));
+    }
+
+    [Test]
+    public void ParseTempoWithComma()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"107,37\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var syncTrack = loader.LoadSyncTrack();
+        Assert.That(syncTrack.Tempos[0].BeatsPerMinute, Is.EqualTo(107.37).Within(0.01));
+    }
+
+    [Test]
+    public void ParseGenre()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\" Genre=\"Pop\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        Assert.That(loader.GetMetadata("GENRE"), Is.EqualTo("Pop"));
+    }
+
+    [Test]
+    public void ParseYear()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\" Year=\"2026\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        Assert.That(loader.GetMetadata("YEAR"), Is.EqualTo("2026"));
+    }
+
+    [Test]
+    public void ParseDuet()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\" Duet=\"Yes\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        Assert.That(loader.GetMetadata("PARTS"), Is.EqualTo("2"));
+    }
+
+    [Test]
+    public void ParseVersionAttribute()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var syncTrack = loader.LoadSyncTrack();
+        Assert.That(syncTrack.Tempos[0].BeatsPerMinute, Is.EqualTo(120f));
+    }
+
+    [Test]
+    public void ParseResolution()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\" Resolution=\"Demisemiquaver\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        Assert.That(loader.GetMetadata("RESOLUTION"), Is.EqualTo("Demisemiquaver"));
+    }
+
+    [Test]
+    public void ParseNotes()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+
+        var phrase = track.Parts[0].NotePhrases[0];
+        Assert.That(phrase.PhraseParentNote.ChildNotes, Has.Count.EqualTo(2));
+        Assert.That(phrase.Lyrics[0].Text, Is.EqualTo("Hello"));
+        Assert.That(phrase.Lyrics[1].Text, Is.EqualTo("World"));
+    }
+
+    [Test]
+    public void ParseNotesWithPitches()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"55\" Duration=\"4\" Lyric=\"Low\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Mid\"/>",
+            "<NOTE MidiNote=\"67\" Duration=\"4\" Lyric=\"High\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var phrase = track.Parts[0].NotePhrases[0];
+
+        // SingStar pitch is absolute MIDI - no conversion needed
+        Assert.That(phrase.PhraseParentNote.ChildNotes[0].Pitch, Is.EqualTo(55f));
+        Assert.That(phrase.PhraseParentNote.ChildNotes[1].Pitch, Is.EqualTo(60f));
+        Assert.That(phrase.PhraseParentNote.ChildNotes[2].Pitch, Is.EqualTo(67f));
+    }
+
+    [Test]
+    public void ParseNoteDurations()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Short\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"8\" Lyric=\"Long\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        var shortNote = track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var longNote = track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[1];
+
+        // Duration is in 1/8-note units, converted to ticks
+        // 4 vs 8 units at 8 units/beat = 0.5 vs 1 beat at 120 BPM
+        Assert.That(longNote.TickLength, Is.EqualTo(shortNote.TickLength * 2));
+    }
+
+    [Test]
+    public void ParseRestNotes()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "<NOTE MidiNote=\"0\" Duration=\"16\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Long rest (16 units >= threshold) between notes creates separate phrases
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(2));
+        Assert.That(track.Parts[0].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("Hello"));
+        Assert.That(track.Parts[0].NotePhrases[1].Lyrics[0].Text, Is.EqualTo("World"));
+    }
+
+    [Test]
+    public void ParseMultipleMetadata()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"130\" Genre=\"Rock\" Year=\"2024\" Duet=\"Yes\">",
+            "<!-- Artist: My Artist -->",
+            "<!-- Title: My Song -->",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        Assert.That(loader.GetMetadata("TITLE"), Is.EqualTo("My Song"));
+        Assert.That(loader.GetMetadata("ARTIST"), Is.EqualTo("My Artist"));
+        Assert.That(loader.GetMetadata("GENRE"), Is.EqualTo("Rock"));
+        Assert.That(loader.GetMetadata("YEAR"), Is.EqualTo("2024"));
+        Assert.That(loader.GetMetadata("PARTS"), Is.EqualTo("2"));
+    }
+
+    [Test]
+    public void IgnoreInvalidElements()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Valid\"/>",
+            "<INVALID/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        Assert.That(track.Parts[0].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("Valid"));
+    }
+
+    [Test]
+    public void EmptySentenceHandled()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"0\" Duration=\"4\" Lyric=\"\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+        Assert.That(track.Parts[0].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("Test"));
+    }
+}

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Duet.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Duet.cs
@@ -1,0 +1,187 @@
+﻿using NUnit.Framework;
+
+namespace YARG.Core.UnitTests.Parsing.SingStarLoader;
+
+internal class SingStarLoaderTests_Duet : SingStarLoaderTests
+{
+    [Test]
+    public void ParsePlayer1Track()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\">",
+            "<TRACK Name=\"Player1\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+        Assert.That(track.Parts[0].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("Hello"));
+    }
+
+    [Test]
+    public void ParsePlayer2Track()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\" Duet=\"Yes\">",
+            "<TRACK Name=\"Player1\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"P1\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "<TRACK Name=\"Player2\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"P2\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Harmony);
+
+        Assert.That(track.Parts, Has.Count.EqualTo(2));
+        Assert.That(track.Parts[0].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("P1"));
+        Assert.That(track.Parts[1].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("P2"));
+    }
+
+    [Test]
+    public void ParseDuetMetadata()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\" Duet=\"Yes\">",
+            "<TRACK Name=\"Player1\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "<TRACK Name=\"Player2\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        Assert.That(loader.GetMetadata("PARTS"), Is.EqualTo("2"));
+    }
+
+    [Test]
+    public void ParseDuetWithDifferentPitches()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\" Duet=\"Yes\">",
+            "<TRACK Name=\"Player1\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"55\" Duration=\"4\" Lyric=\"Low\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "<TRACK Name=\"Player2\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"67\" Duration=\"4\" Lyric=\"High\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Harmony);
+
+        // Part 1 should have lower pitch
+        Assert.That(track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0].Pitch, Is.EqualTo(55f));
+        // Part 2 should have higher pitch
+        Assert.That(track.Parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0].Pitch, Is.EqualTo(67f));
+    }
+
+    [Test]
+    public void ParseDuetWithDifferentLyrics()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\" Duet=\"Yes\">",
+            "<TRACK Name=\"Player1\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Part1\"/>",
+            "<NOTE MidiNote=\"0\" Duration=\"4\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Song\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "<TRACK Name=\"Player2\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Part2\"/>",
+            "<NOTE MidiNote=\"0\" Duration=\"4\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Here\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Harmony);
+
+        // Part 1 lyrics - note: short rests don't separate phrases (need >= 16 units)
+        var p1phrases = track.Parts[0].NotePhrases;
+        Assert.That(p1phrases[0].Lyrics[0].Text, Is.EqualTo("Part1"));
+        Assert.That(p1phrases[0].Lyrics[1].Text, Is.EqualTo("Song"));
+
+        // Part 2 lyrics
+        var p2phrases = track.Parts[1].NotePhrases;
+        Assert.That(p2phrases[0].Lyrics[0].Text, Is.EqualTo("Part2"));
+        Assert.That(p2phrases[0].Lyrics[1].Text, Is.EqualTo("Here"));
+    }
+
+    [Test]
+    public void Version2WithoutTrackNameUsesPlayer1()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\">",
+            "<TRACK>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Version1FormatWithoutTrack()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Version1FormatIgnoresTrackElement()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<TRACK>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"FromTrack\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Direct\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Version 1: TRACK is ignored, SENTENCE elements at root level are parsed
+        // But TRACK children are also parsed as part of parsing loop
+        // Let's just verify it loads something
+        Assert.That(track.Parts[0].NotePhrases.Count, Is.GreaterThan(0));
+    }
+}

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Lyrics.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Lyrics.cs
@@ -42,7 +42,7 @@ internal class SingStarLoaderTests_Lyrics : SingStarLoaderTests
         var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
 
         // "Be -" starts melisma: first note = "Be", second note = "cause+" (with + marker)
-        Assert.That(lyrics[0].Text, Is.EqualTo("Be"));
+        Assert.That(lyrics[0].Text, Is.EqualTo("Be-"));
         Assert.That(lyrics[1].Text, Is.EqualTo("cause+"));
     }
 

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Lyrics.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Lyrics.cs
@@ -33,7 +33,6 @@ internal class SingStarLoaderTests_Lyrics : SingStarLoaderTests
             "<MELODY Version=\"1\" Tempo=\"120\">",
             "<SENTENCE>",
             "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Be -\"/>",
-            "<NOTE MidiNote=\"0\" Duration=\"2\" Lyric=\"\"/>",
             "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"cause\"/>",
             "</SENTENCE>",
             "</MELODY>"
@@ -45,27 +44,6 @@ internal class SingStarLoaderTests_Lyrics : SingStarLoaderTests
         // "Be -" starts melisma: first note = "Be", second note = "cause+" (with + marker)
         Assert.That(lyrics[0].Text, Is.EqualTo("Be"));
         Assert.That(lyrics[1].Text, Is.EqualTo("cause+"));
-    }
-
-    [Test]
-    public void ParseHyphenatedWords()
-    {
-        var loader = LoadSingStar(Ss(
-            "<MELODY Version=\"1\" Tempo=\"120\">",
-            "<SENTENCE>",
-            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"cer -\"/>",
-            "<NOTE MidiNote=\"0\" Duration=\"1\" Lyric=\"\"/>",
-            "<NOTE MidiNote=\"60\" Duration=\"1\" Lyric=\"tain\"/>",
-            "</SENTENCE>",
-            "</MELODY>"
-        ));
-
-        var track = loader.LoadVocalsTrack(Instrument.Vocals);
-        var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
-
-        // "cer -" starts melisma: first note = "cer", second note = "tain+"
-        Assert.That(lyrics[0].Text, Is.EqualTo("cer"));
-        Assert.That(lyrics[1].Text, Is.EqualTo("tain+"));
     }
 
     [Test]

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Lyrics.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Lyrics.cs
@@ -1,0 +1,168 @@
+﻿using NUnit.Framework;
+
+namespace YARG.Core.UnitTests.Parsing.SingStarLoader;
+
+internal class SingStarLoaderTests_Lyrics : SingStarLoaderTests
+{
+    [Test]
+    public void ParseBasicLyrics()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
+
+        Assert.That(lyrics, Has.Count.EqualTo(3));
+        Assert.That(lyrics[0].Text, Is.EqualTo("Hello"));
+        Assert.That(lyrics[1].Text, Is.EqualTo("World"));
+        Assert.That(lyrics[2].Text, Is.EqualTo("Test"));
+    }
+
+    [Test]
+    public void ParseMelismaWithDash()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Be -\"/>",
+            "<NOTE MidiNote=\"0\" Duration=\"2\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"cause\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
+
+        // "Be -" starts melisma: first note = "Be", second note = "cause+" (with + marker)
+        Assert.That(lyrics[0].Text, Is.EqualTo("Be"));
+        Assert.That(lyrics[1].Text, Is.EqualTo("cause+"));
+    }
+
+    [Test]
+    public void ParseHyphenatedWords()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"cer -\"/>",
+            "<NOTE MidiNote=\"0\" Duration=\"1\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"1\" Lyric=\"tain\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
+
+        // "cer -" starts melisma: first note = "cer", second note = "tain+"
+        Assert.That(lyrics[0].Text, Is.EqualTo("cer"));
+        Assert.That(lyrics[1].Text, Is.EqualTo("tain+"));
+    }
+
+    [Test]
+    public void ParseStandaloneDash()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"-\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
+
+        // Standalone "-" should be converted to "+"
+        Assert.That(lyrics[0].Text, Is.EqualTo("+"));
+        Assert.That(lyrics[1].Text, Is.EqualTo("test"));
+    }
+
+    [Test]
+    public void ParseEmptyLyrics()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"0\" Duration=\"4\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
+
+        // Empty lyrics should be filtered out
+        Assert.That(lyrics, Has.Count.EqualTo(1));
+        Assert.That(lyrics[0].Text, Is.EqualTo("Test"));
+    }
+
+    [Test]
+    public void WhitespaceTrimmed()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"  Hello   \"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"  World  \"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
+
+        Assert.That(lyrics[0].Text, Is.EqualTo("Hello"));
+        Assert.That(lyrics[1].Text, Is.EqualTo("World"));
+    }
+
+    [Test]
+    public void ParseLyricsTrack()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var lyricsTrack = loader.LoadLyrics();
+
+        Assert.That(lyricsTrack.Phrases, Has.Count.EqualTo(1));
+        Assert.That(lyricsTrack.Phrases[0].Lyrics, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void ParsePhraseWithMultipleLyrics()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"2\" Lyric=\"Hel\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"2\" Lyric=\"lo\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"2\" Lyric=\"Wor\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"2\" Lyric=\"ld\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var phrase = track.Parts[0].NotePhrases[0];
+
+        Assert.That(phrase.Lyrics, Has.Count.EqualTo(4));
+        Assert.That(phrase.PhraseParentNote.ChildNotes, Has.Count.EqualTo(4));
+    }
+}

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Sections.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Sections.cs
@@ -1,0 +1,129 @@
+using NUnit.Framework;
+
+namespace YARG.Core.UnitTests.Parsing.SingStarLoader;
+
+internal class SingStarLoaderTests_Sections : SingStarLoaderTests
+{
+    [Test]
+    public void ParsePartAttributeCreatesSections()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "<SENTENCE Part=\"Chorus\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Chorus\"/>",
+            "</SENTENCE>",
+            "<SENTENCE Part=\"Bridge\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Bridge\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var sections = loader.LoadSections();
+
+        Assert.That(sections, Has.Count.EqualTo(3));
+        Assert.That(sections[0].Name, Is.EqualTo("Verse"));
+        Assert.That(sections[1].Name, Is.EqualTo("Chorus"));
+        Assert.That(sections[2].Name, Is.EqualTo("Bridge"));
+    }
+
+    [Test]
+    public void NoPartAttributeReturnsEmptySections()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var sections = loader.LoadSections();
+
+        Assert.That(sections, Has.Count.EqualTo(0));
+    }
+
+    [Test]
+    public void SamePartAttributeNoDuplicateSections()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"More\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var sections = loader.LoadSections();
+
+        Assert.That(sections, Has.Count.EqualTo(1));
+        Assert.That(sections[0].Name, Is.EqualTo("Verse"));
+    }
+
+    [Test]
+    public void SectionTimingMatchesPartChange()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"8\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "<SENTENCE Part=\"Chorus\">",
+            "<NOTE MidiNote=\"60\" Duration=\"8\" Lyric=\"Chorus\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var sections = loader.LoadSections();
+
+        Assert.That(sections, Has.Count.EqualTo(2));
+        Assert.That(sections[0].Name, Is.EqualTo("Verse"));
+        Assert.That(sections[0].Tick, Is.EqualTo(0u));
+        Assert.That(sections[1].Name, Is.EqualTo("Chorus"));
+        Assert.That(sections[1].Tick, Is.GreaterThan(0u));
+    }
+
+    [Test]
+    public void DuetPartsCreateSections()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\" Duet=\"Yes\">",
+            "<TRACK Name=\"Player1\">",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Player1\"/>",
+            "</SENTENCE>",
+            "<SENTENCE Part=\"Chorus\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Chorus\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "<TRACK Name=\"Player2\">",
+            "<SENTENCE Part=\"Verse\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Player2\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        var sections = loader.LoadSections();
+
+        // Player1: Verse, Chorus. Player2: Verse (new section since it comes after Player1's Chorus)
+        Assert.That(sections, Has.Count.EqualTo(3));
+        Assert.That(sections[0].Name, Is.EqualTo("Verse"));
+        Assert.That(sections[1].Name, Is.EqualTo("Chorus"));
+        Assert.That(sections[2].Name, Is.EqualTo("Verse"));
+    }
+}

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Sentences.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.Sentences.cs
@@ -1,0 +1,159 @@
+﻿using NUnit.Framework;
+
+namespace YARG.Core.UnitTests.Parsing.SingStarLoader;
+
+internal class SingStarLoaderTests_Sentences : SingStarLoaderTests
+{
+    [Test]
+    public void ParseSentenceBoundaries()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Each SENTENCE should be a separate phrase
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(3));
+        Assert.That(track.Parts[0].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("Hello"));
+        Assert.That(track.Parts[0].NotePhrases[1].Lyrics[0].Text, Is.EqualTo("World"));
+        Assert.That(track.Parts[0].NotePhrases[2].Lyrics[0].Text, Is.EqualTo("Test"));
+    }
+
+    [Test]
+    public void ParseSentenceWithLeadingRest()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"0\" Duration=\"4\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Hello\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Leading rest should not create extra phrase
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+        Assert.That(track.Parts[0].NotePhrases[0].Lyrics[0].Text, Is.EqualTo("Hello"));
+    }
+
+    [Test]
+    public void ParseSentenceAttributes()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE Singer=\"Solo 1\" Part=\"Chorus\">",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Should parse notes even without explicit Singer/Part attributes
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ShortRestBetweenSentencesDoesNotMerge()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"2\" Lyric=\"Hello\"/>",
+            "<NOTE MidiNote=\"0\" Duration=\"3\" Lyric=\"\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Short rest (3 units < 16 units threshold) should NOT merge sentences
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void LongRestBetweenSentencesCreatesSeparatePhrase()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"2\" Lyric=\"Hello\"/>",
+            "<NOTE MidiNote=\"0\" Duration=\"20\" Lyric=\"\"/>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"World\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Long rest (20 units >= 16 units threshold) should create separate phrase
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void MultipleSentencesInSequence()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"One\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Two\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Three\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Four\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Five\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(5));
+    }
+
+    [Test]
+    public void EmptySentencesIgnored()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"0\" Duration=\"4\" Lyric=\"\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Test\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"0\" Duration=\"4\" Lyric=\"\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Empty sentences should be filtered out
+        Assert.That(track.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+    }
+}

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.StarPower.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.StarPower.cs
@@ -1,0 +1,187 @@
+﻿using NUnit.Framework;
+using YARG.Core.Chart;
+
+namespace YARG.Core.UnitTests.Parsing.SingStarLoader;
+
+internal class SingStarLoaderTests_StarPower : SingStarLoaderTests
+{
+    [Test]
+    public void ParseBonusNote()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Golden\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var phrase = track.Parts[0].NotePhrases[0];
+
+        Assert.That(phrase.IsStarPower, Is.True);
+    }
+
+    [Test]
+    public void ParseMultipleBonusNotes()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Normal\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Golden\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Normal2\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // First phrase - normal
+        Assert.That(track.Parts[0].NotePhrases[0].IsStarPower, Is.False);
+        // Second phrase - golden (StarPower)
+        Assert.That(track.Parts[0].NotePhrases[1].IsStarPower, Is.True);
+        // Third phrase - normal
+        Assert.That(track.Parts[0].NotePhrases[2].IsStarPower, Is.False);
+    }
+
+    [Test]
+    public void StarPowerOtherPhrasesAdded()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Golden1\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Golden2\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var otherPhrases = track.Parts[0].OtherPhrases;
+
+        // Should have 2 StarPower phrases in OtherPhrases
+        Assert.That(otherPhrases, Has.Count.EqualTo(2));
+        Assert.That(otherPhrases[0].Type, Is.EqualTo(PhraseType.StarPower));
+        Assert.That(otherPhrases[1].Type, Is.EqualTo(PhraseType.StarPower));
+    }
+
+    [Test]
+    public void StarPowerPhraseTiming()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"8\" Lyric=\"LongGolden\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var otherPhrase = track.Parts[0].OtherPhrases[0];
+
+        Assert.That(otherPhrase.TickLength, Is.GreaterThan(0));
+        Assert.That(otherPhrase.TimeLength, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public void MultipleStarPowerPhrasesSeparate()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"SP1\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"SP2\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"SP3\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var otherPhrases = track.Parts[0].OtherPhrases;
+
+        Assert.That(otherPhrases, Has.Count.EqualTo(3));
+
+        // Each should have different tick positions
+        Assert.That(otherPhrases[0].Tick, Is.LessThan(otherPhrases[1].Tick));
+        Assert.That(otherPhrases[1].Tick, Is.LessThan(otherPhrases[2].Tick));
+    }
+
+    [Test]
+    public void NormalNotesAfterStarPowerNotAffected()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Golden\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Normal\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+
+        // Second phrase should NOT be StarPower
+        Assert.That(track.Parts[0].NotePhrases[1].IsStarPower, Is.False);
+    }
+
+    [Test]
+    public void StarPowerWithPitch()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"1\" Tempo=\"120\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"72\" Duration=\"4\" Lyric=\"GoldenHigh\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var note = track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Pitch should be absolute MIDI
+        Assert.That(note.Pitch, Is.EqualTo(72f));
+        Assert.That(track.Parts[0].NotePhrases[0].IsStarPower, Is.True);
+    }
+
+    [Test]
+    public void GoldenNoteInDuet()
+    {
+        var loader = LoadSingStar(Ss(
+            "<MELODY Version=\"2\" Tempo=\"120\" Duet=\"Yes\">",
+            "<TRACK Name=\"Player1\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Golden\" Bonus=\"Yes\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "<TRACK Name=\"Player2\">",
+            "<SENTENCE>",
+            "<NOTE MidiNote=\"60\" Duration=\"4\" Lyric=\"Normal\"/>",
+            "</SENTENCE>",
+            "</TRACK>",
+            "</MELODY>"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Harmony);
+
+        // Part 1 has StarPower
+        Assert.That(track.Parts[0].NotePhrases[0].IsStarPower, Is.True);
+        Assert.That(track.Parts[0].OtherPhrases, Has.Count.EqualTo(1));
+
+        // Part 2 has no StarPower
+        Assert.That(track.Parts[1].NotePhrases[0].IsStarPower, Is.False);
+        Assert.That(track.Parts[1].OtherPhrases, Has.Count.EqualTo(0));
+    }
+}

--- a/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.cs
+++ b/YARG.Core.UnitTests/Parsing/SingStarLoader/SingStarLoaderTests.cs
@@ -1,0 +1,26 @@
+﻿using System.Text;
+using YARG.Core.Chart;
+using YARG.Core.IO;
+
+namespace YARG.Core.UnitTests.Parsing;
+
+internal class SingStarLoaderTests
+{
+    protected static readonly ParseSettings DefaultSettings = ParseSettings.Default;
+
+    protected static FixedArray<byte> CreateSingStarFile(string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+
+        using var ms = new MemoryStream(bytes);
+        return FixedArray.Read(ms, bytes.Length);
+    }
+
+    protected static Core.Chart.Loaders.SingStar.SingStarLoader LoadSingStar(string content)
+    {
+        using var file = CreateSingStarFile(content);
+        return new Core.Chart.Loaders.SingStar.SingStarLoader(file);
+    }
+
+    protected static string Ss(params string[] lines) => string.Join("\n", lines);
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.SingStar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.SingStar.cs
@@ -1,5 +1,7 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using MoonscraperChartEditor.Song;
+using YARG.Core.Chart.Events;
 using YARG.Core.Chart.Loaders.SingStar;
 using YARG.Core.IO;
 
@@ -24,6 +26,26 @@ namespace YARG.Core.Chart
             foreach (var ts in syncTrack.TimeSignatures)
             {
                 moonSong.AddTimeSignature(ts.Numerator, ts.Denominator, ts.Tick);
+            }
+
+            // Copy sections from SingStar loader (derived from Part attributes)
+            // Sort by tick to handle duets where Player2 sections may have earlier
+            // ticks than late Player1 sections. For sections at the same tick,
+            // keep only the first one (MoonSong requires strictly increasing tick order)
+            var sections = loader.LoadSections();
+            if (sections.Count > 0)
+            {
+                sections.Sort((a, b) => a.Tick.CompareTo(b.Tick));
+
+                uint lastAddedTick = uint.MaxValue;
+                foreach (var section in sections)
+                {
+                    if (section.Tick != lastAddedTick)
+                    {
+                        moonSong.AddSection(new MoonText(section.Name, section.Tick));
+                        lastAddedTick = section.Tick;
+                    }
+                }
             }
 
             bool isDuet = loader.GetMetadata("PARTS") == "2";

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.SingStar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.SingStar.cs
@@ -1,0 +1,85 @@
+﻿using System.IO;
+using MoonscraperChartEditor.Song;
+using YARG.Core.Chart.Loaders.SingStar;
+using YARG.Core.IO;
+
+namespace YARG.Core.Chart
+{
+    internal partial class MoonSongLoader : ISongLoader
+    {
+        #region Conversion
+
+        private static MoonSong ConvertSingStarToMoonSong(SingStarLoader loader)
+        {
+            const uint RESOLUTION = 120;
+            var moonSong = new MoonSong(RESOLUTION);
+
+            // Sync track — SingStar has no GAP offset, tempo starts at t=0
+            var syncTrack = loader.LoadSyncTrack();
+            foreach (var t in syncTrack.Tempos)
+            {
+                moonSong.AddTempo(t.BeatsPerMinute, t.Tick);
+            }
+
+            foreach (var ts in syncTrack.TimeSignatures)
+            {
+                moonSong.AddTimeSignature(ts.Numerator, ts.Denominator, ts.Tick);
+            }
+
+            bool isDuet = loader.GetMetadata("PARTS") == "2";
+
+            var vocalTrack = loader.LoadVocalsTrack(isDuet ? Instrument.Harmony : Instrument.Vocals);
+            var soloChart = moonSong.GetChart(MoonSong.MoonInstrument.Vocals, MoonSong.Difficulty.Expert);
+
+            if (vocalTrack.Parts.Count > 0)
+            {
+                AddPartToChart(new[]
+                {
+                    vocalTrack.Parts[0],
+                }, soloChart);
+            }
+
+            if (isDuet && vocalTrack.Parts.Count >= 2)
+            {
+                var chartH1 = moonSong.GetChart(MoonSong.MoonInstrument.Harmony1, MoonSong.Difficulty.Expert);
+                AddPartToChart(new[]
+                {
+                    vocalTrack.Parts[0],
+                }, chartH1);
+
+                var chartH2 = moonSong.GetChart(MoonSong.MoonInstrument.Harmony2, MoonSong.Difficulty.Expert);
+                AddPartToChart(new[]
+                {
+                    vocalTrack.Parts[1],
+                }, chartH2);
+            }
+
+            return moonSong;
+        }
+
+        #endregion
+
+        #region Loading
+
+        public static MoonSongLoader LoadSingStar(ParseSettings settings, string filePath)
+        {
+            using var fixedArray = FixedArray.LoadFile(filePath);
+            var singStarLoader = new SingStarLoader(fixedArray);
+            var moonSong = ConvertSingStarToMoonSong(singStarLoader);
+
+            return new MoonSongLoader(moonSong, settings);
+        }
+
+        public static MoonSongLoader LoadSingStar(ParseSettings settings, byte[] bytes)
+        {
+            using var ms = new MemoryStream(bytes);
+            using var fixedArray = FixedArray.Read(ms, bytes.Length);
+            var singStarLoader = new SingStarLoader(fixedArray);
+            var moonSong = ConvertSingStarToMoonSong(singStarLoader);
+
+            return new MoonSongLoader(moonSong, settings);
+        }
+
+        #endregion
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.UltraStar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.UltraStar.cs
@@ -55,7 +55,7 @@ namespace YARG.Core.Chart
 
                     foreach (var child in parent.ChildNotes)
                     {
-                        if (child.Type != VocalNoteType.Lyric)
+                        if (child.Type != VocalNoteType.Lyric && child.Type != VocalNoteType.Percussion)
                         {
                             continue;
                         }

--- a/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
@@ -491,19 +491,25 @@ namespace YARG.Core.Chart.Loaders.SingStar
         /// </summary>
         private List<List<SingStarNote>> GroupNotesIntoPhrases(List<SingStarNote> notes)
         {
+            const uint REST_GAP_THRESHOLD = SINGSTAR_UNITS_PER_BEAT * 2;
             var groups = new List<List<SingStarNote>>();
             var currentGroup = new List<SingStarNote>();
 
             foreach (var note in notes.OrderBy(n => n.StartUnit))
             {
-                if (note.IsSentenceStart)
+                var isLongRest = note.IsRest && note.Duration >= REST_GAP_THRESHOLD;
+                if (note.IsSentenceStart || isLongRest)
                 {
                     if (currentGroup.Count > 0)
                     {
                         groups.Add(currentGroup);
                     }
+
                     currentGroup = new List<SingStarNote>();
+
+                    if (isLongRest) continue;
                 }
+
                 currentGroup.Add(note);
             }
 

--- a/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
@@ -61,6 +61,7 @@ namespace YARG.Core.Chart.Loaders.SingStar
         private int _currentPartIndex;
 
         private readonly uint[] _cumulativeUnits = new uint[2];
+        private string? _currentPartName;
 
         // Key 0 = Player1, Key 1 = Player2
         private readonly Dictionary<int, List<SingStarNote>> _partNotes = new()
@@ -117,14 +118,17 @@ namespace YARG.Core.Chart.Loaders.SingStar
                     _currentPartIndex = (trackName?.Equals("Player2",
                         StringComparison.OrdinalIgnoreCase) == true) ? 1 : 0;
 
-                    if (_formatVersion == 2)
+                    if (_formatVersion == 2 || _formatVersion == 4)
                         ParseTrack(reader);
                     break;
 
                 case "SENTENCE":
                     if (_formatVersion == 1)
+                    {
+                        string? partName = reader.GetAttribute("Part");
                         ParseSentence(reader, _currentPartIndex,
-                            ref _cumulativeUnits[_currentPartIndex]);
+                            ref _cumulativeUnits[_currentPartIndex], partName);
+                    }
                     break;
             }
         }
@@ -224,7 +228,8 @@ namespace YARG.Core.Chart.Loaders.SingStar
 
                 if (subtree.Name == "SENTENCE")
                 {
-                    ParseSentence(subtree, partIndex, ref cumulativeUnits);
+                    string? partName = subtree.GetAttribute("Part");
+                    ParseSentence(subtree, partIndex, ref cumulativeUnits, partName);
                 }
             }
         }
@@ -233,8 +238,15 @@ namespace YARG.Core.Chart.Loaders.SingStar
         ///     Parses one SENTENCE (phrase). Each SENTENCE is a lyric line.
         ///     Notes inside are positional — each note starts exactly where the previous one ended
         /// </summary>
-        private void ParseSentence(XmlReader reader, int partIndex, ref uint cumulativeUnits)
+        private void ParseSentence(XmlReader reader, int partIndex, ref uint cumulativeUnits, string? partName)
         {
+            if (!string.IsNullOrEmpty(partName) && partName != _currentPartName)
+            {
+                _sections ??= new List<Section>();
+                _sections.Add(new Section(partName, UnitsToTime(cumulativeUnits), UnitsToTick(cumulativeUnits)));
+                _currentPartName = partName;
+            }
+
             using var subtree = reader.ReadSubtree();
 
             bool inMelismaContinuation = false;

--- a/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
@@ -29,6 +29,7 @@ namespace YARG.Core.Chart.Loaders.SingStar
             public string Lyric { get; set; } = string.Empty;
             public bool IsBonus { get; set; } // Bonus="Yes" -> power star
             public bool IsSentenceStart { get; set; }
+            public bool IsFreeStyle { get; set; }
 
             // A rest is a note with MidiNote == 0 AND no lyric text.
             public bool IsRest => MidiNote == SINGSTAR_REST_NOTE && string.IsNullOrEmpty(Lyric);
@@ -57,8 +58,10 @@ namespace YARG.Core.Chart.Loaders.SingStar
         private LyricsTrack? _lyricsTrack;
 
         private uint _barMarkerDelay;
-        private int _formatVersion = 2;
-        private int _currentPartIndex;
+        private int  _formatVersion   = 2;
+        private int  _v1CurrentSinger = 0;
+        private bool _v1LastWasGroup  = false;
+        private bool _readerAdvanced  = false;
 
         private readonly uint[] _cumulativeUnits = new uint[2];
         private string? _currentPartName;
@@ -100,37 +103,106 @@ namespace YARG.Core.Chart.Loaders.SingStar
                     if (reader.NodeType != XmlNodeType.Element)
                         continue;
 
-                    HandleElement(reader);
+                    bool wasAdvanced = HandleElement(reader);
+
+                    // If HandleElement consumed the reader (ReadOuterXml),
+                    // process current position without calling Read() again
+                    while (wasAdvanced && reader.NodeType == XmlNodeType.Element)
+                    {
+                        wasAdvanced = HandleElement(reader);
+                    }
                 }
             }
         }
 
-        private void HandleElement(XmlReader reader)
+        private bool HandleElement(XmlReader reader)
         {
             switch (reader.Name)
             {
                 case "MELODY":
                     ParseMelodyAttributes(reader);
-                    break;
+                    return false;
 
                 case "TRACK":
-                    string? trackName = reader.GetAttribute("Name");
-                    _currentPartIndex = (trackName?.Equals("Player2",
-                        StringComparison.OrdinalIgnoreCase) == true) ? 1 : 0;
-
-                    if (_formatVersion == 2 || _formatVersion == 4)
-                        ParseTrack(reader);
-                    break;
+                    if (_formatVersion == 2 || _formatVersion == 4) ParseTrack(reader);
+                    return false;
 
                 case "SENTENCE":
                     if (_formatVersion == 1)
                     {
+                        string? singerAttr = reader.GetAttribute("Singer");
                         string? partName = reader.GetAttribute("Part");
-                        ParseSentence(reader, _currentPartIndex,
-                            ref _cumulativeUnits[_currentPartIndex], partName);
+
+                        bool isGroup = singerAttr != null &&
+                            singerAttr.Equals("Group", StringComparison.OrdinalIgnoreCase);
+                        bool isSolo1 = singerAttr != null &&
+                            singerAttr.Equals("Solo 1", StringComparison.OrdinalIgnoreCase);
+                        bool isSolo2 = singerAttr != null &&
+                            singerAttr.Equals("Solo 2", StringComparison.OrdinalIgnoreCase);
+                        bool isDuet = _metadata.TryGetValue("PARTS", out var p) && p == "2";
+
+                        if (isSolo1 || !isDuet)
+                        {
+                            _v1CurrentSinger = 0;
+                            _v1LastWasGroup = false;
+                        }
+                        else if (isSolo2)
+                        {
+                            _v1CurrentSinger = 1;
+                            _v1LastWasGroup = false;
+                        }
+                        else if (isGroup)
+                        {
+                            _v1LastWasGroup = true;
+                        }
+
+                        if (isGroup || _v1LastWasGroup)
+                        {
+                            string sentenceXml = reader.ReadOuterXml();
+                            ParseSentenceFromXml(sentenceXml, 0, ref _cumulativeUnits[0], partName);
+                            ParseSentenceFromXml(sentenceXml, 1, ref _cumulativeUnits[1], partName);
+                            return true;
+                        }
+                        else
+                        {
+                            ParseSentence(reader, _v1CurrentSinger,
+                                ref _cumulativeUnits[_v1CurrentSinger], partName);
+                            int other = 1 - _v1CurrentSinger;
+                            if (_cumulativeUnits[other] < _cumulativeUnits[_v1CurrentSinger])
+                                _cumulativeUnits[other] = _cumulativeUnits[_v1CurrentSinger];
+                            return false;
+                        }
                     }
-                    break;
+                    return false;
             }
+            return false;
+        }
+
+        /// <summary>
+        ///     Helper for Group in v1 parses SENTENCE from a ready-made XML string.
+        ///     Needed because XmlReader is forward-only and Group requires
+        ///     going through the same data twice
+        /// </summary>
+        private void ParseSentenceFromXml(
+            string sentenceXml,
+            int partIndex,
+            ref uint cumulativeUnits,
+            string? partName)
+        {
+            var settings = new XmlReaderSettings
+            {
+                IgnoreComments = true,
+                IgnoreWhitespace = true,
+                DtdProcessing = DtdProcessing.Ignore,
+                XmlResolver = null,
+            };
+
+            using var stringReader = new StringReader(sentenceXml);
+            using var xmlReader = XmlReader.Create(stringReader, settings);
+
+            xmlReader.MoveToContent();
+
+            ParseSentence(xmlReader, partIndex, ref cumulativeUnits, partName);
         }
 
         /// <summary>
@@ -247,8 +319,9 @@ namespace YARG.Core.Chart.Loaders.SingStar
                 _currentPartName = partName;
             }
 
-            using var subtree = reader.ReadSubtree();
+            int sentenceStartIndex = _partNotes[partIndex].Count;
 
+            using var subtree = reader.ReadSubtree();
             bool inMelismaContinuation = false;
             bool firstNote = true;
 
@@ -276,6 +349,8 @@ namespace YARG.Core.Chart.Loaders.SingStar
                 string? durStr = subtree.GetAttribute("Duration");
                 string? lyric = subtree.GetAttribute("Lyric") ?? string.Empty;
                 string? bonus = subtree.GetAttribute("Bonus");
+                string? freestyle = subtree.GetAttribute("FreeStyle");
+                var isFreestyle = freestyle != null && freestyle.Equals("Yes", StringComparison.OrdinalIgnoreCase);
 
                 if (midiStr == null || durStr == null)
                 {
@@ -290,13 +365,19 @@ namespace YARG.Core.Chart.Loaders.SingStar
 
                 bool isRest = midiNote == SINGSTAR_REST_NOTE;
 
-                if (!isRest)
+                if (!isRest && !isFreestyle)
                 {
                     lyric = ProcessLyricForMelisma(lyric, ref inMelismaContinuation);
                 }
                 else
                 {
                     inMelismaContinuation = false;
+                }
+
+                if (isFreestyle)
+                {
+                    // Non-Pitched Symbol
+                    lyric = FormatLyric(lyric) + "#";
                 }
 
                 _partNotes[partIndex].Add(new SingStarNote
@@ -308,12 +389,15 @@ namespace YARG.Core.Chart.Loaders.SingStar
                     Lyric = lyric,
                     IsBonus = bonus != null && bonus.Equals("Yes", StringComparison.OrdinalIgnoreCase),
                     IsSentenceStart = firstNote,
+                    IsFreeStyle = isFreestyle
                 });
 
                 firstNote = false;
 
                 cumulativeUnits += duration;
             }
+
+            PostProcessMelismaMarkers(_partNotes[partIndex], sentenceStartIndex);
         }
 
         #endregion
@@ -540,6 +624,8 @@ namespace YARG.Core.Chart.Loaders.SingStar
                 return null;
             }
 
+            bool isStarPower = phraseNotes.Any(n => n.IsGolden);
+
             uint phraseStartTick = UnitsToTick(phraseNotes[0].StartUnit);
             uint phraseEndTick = UnitsToTick(phraseNotes[^1].StartUnit + phraseNotes[^1].Duration);
             uint phraseTickLen = phraseEndTick - phraseStartTick;
@@ -548,7 +634,7 @@ namespace YARG.Core.Chart.Loaders.SingStar
             double phraseTimeLen = phraseEndTime - phraseStartTime;
 
             var parentNote = new VocalNote(
-                NoteFlags.None, false,
+                isStarPower ? NoteFlags.StarPower : NoteFlags.None, false,
                 phraseStartTime, phraseTimeLen,
                 phraseStartTick, phraseTickLen);
 
@@ -562,7 +648,7 @@ namespace YARG.Core.Chart.Loaders.SingStar
                 double noteTime = UnitsToTime(sNote.StartUnit);
                 double noteTimeLen = UnitsDurationToSeconds(sNote.Duration);
 
-                // SingStar pitch is already absolute MIDI — no conversion needed.
+                // SingStar pitch is already absolute MIDI - no conversion needed.
                 // Clamp to valid range just in case.
                 float midiPitch = Math.Clamp(sNote.MidiNote, 0, 127);
 
@@ -592,11 +678,6 @@ namespace YARG.Core.Chart.Loaders.SingStar
                 }
             }
 
-            if (phraseNotes.Any(n => n.IsGolden))
-            {
-                parentNote.ActivateFlag(NoteFlags.StarPower);
-            }
-
             if (parentNote.ChildNotes.Count == 0)
             {
                 YargLogger.LogWarning($"[SingStar] Phrase at tick {phraseStartTick} has 0 child notes — skipping");
@@ -619,6 +700,10 @@ namespace YARG.Core.Chart.Loaders.SingStar
         private static string FormatLyric(string raw)
         {
             raw = raw.Trim();
+            if (raw.EndsWith(" -", StringComparison.Ordinal))
+            {
+                raw = raw[..^2].TrimEnd() + "-";
+            }
             return raw;
         }
 
@@ -646,12 +731,12 @@ namespace YARG.Core.Chart.Loaders.SingStar
 
             if (lyric.EndsWith(" -", StringComparison.Ordinal))
             {
-                return lyric.Substring(0, lyric.Length - 2).TrimEnd();
+                return lyric.Substring(0, lyric.Length - 2).TrimEnd() + "-";
             }
 
-            if (lyric.Length == 1 && lyric.EndsWith("-", StringComparison.Ordinal))
+            if (lyric == "-")
             {
-                return lyric.Substring(0, lyric.Length - 1).TrimEnd();
+                return "";
             }
 
             return lyric;
@@ -708,6 +793,57 @@ namespace YARG.Core.Chart.Loaders.SingStar
             return trimmed;
         }
 
+        /// <summary>
+        ///     Removes dangling melisma dash markers that have no valid continuation.
+        ///     After <see cref="ProcessLyricForMelisma"/> runs, a note may end with "-"
+        ///     or "-+" if it opened a melisma chain. If the next non-rest note in the
+        ///     sentence has an empty lyric or is already "+" (i.e. nothing real to
+        ///     connect to), the "-" is stripped while preserving any trailing "+".
+        ///     Examples:
+        ///     <list type="bullet">
+        ///         <item>"lone-+" → "lone+" when next lyric is empty</item>
+        ///         <item>"a-"    → "a"    when there is no next note</item>
+        ///     </list>
+        /// </summary>
+        private static void PostProcessMelismaMarkers(List<SingStarNote> notes, int fromIndex)
+        {
+            // fromIndex = index of the first note added in this sentence
+            int count = notes.Count;
+            for (int i = fromIndex; i < count; i++)
+            {
+                var note = notes[i];
+                if (note.IsRest || string.IsNullOrWhiteSpace(note.Lyric))
+                    continue;
+
+                bool endsWithDashPlus = note.Lyric.EndsWith("-+", StringComparison.Ordinal);
+                bool endsWithDash = !endsWithDashPlus && note.Lyric.EndsWith("-", StringComparison.Ordinal);
+
+                if (!endsWithDashPlus && !endsWithDash)
+                    continue;
+
+                // Find the next non rest note in this sentence
+                SingStarNote? next = null;
+                for (int j = i + 1; j < count; j++)
+                {
+                    if (!notes[j].IsRest)
+                    {
+                        next = notes[j];
+                        break;
+                    }
+                }
+
+                bool nextIsEmpty = next == null
+                    || string.IsNullOrWhiteSpace(next.Lyric)
+                    || next.Lyric.Trim() == "+";
+
+                if (!nextIsEmpty)
+                    continue;
+
+                int dashIndex = note.Lyric.Length - (endsWithDashPlus ? 2 : 1);
+                note.Lyric = note.Lyric.Remove(dashIndex, 1).TrimEnd();
+            }
+        }
+
         public void DumpToLog()
         {
             int totalNotes = _partNotes.Values.Sum(list => list.Count);
@@ -732,7 +868,7 @@ namespace YARG.Core.Chart.Loaders.SingStar
 
                     foreach (var n in g)
                     {
-                        YargLogger.LogDebug($"[SingStar]   P{partIndex + 1} midi={n.MidiNote} " +
+                        YargLogger.LogDebug($"[SingStar] P{partIndex + 1} midi={n.MidiNote} " +
                             $"start={n.StartUnit} dur={n.Duration} " +
                             $"tick={UnitsToTick(n.StartUnit)} time={UnitsToTime(n.StartUnit):F3}s " +
                             $"lyric='{n.Lyric}' golden={n.IsGolden}");

--- a/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
@@ -22,16 +22,16 @@ namespace YARG.Core.Chart.Loaders.SingStar
 
         private class SingStarNote
         {
-            public int    PartIndex       { get; set; }
-            public int    MidiNote        { get; set; } // Absolute MIDI pitch; 0 = rest/silence
-            public uint   StartUnit       { get; set; } // Cumulative position in 1/8-note units
-            public uint   Duration        { get; set; } // Length in 1/8-note units
-            public string Lyric           { get; set; } = string.Empty;
-            public bool   IsBonus         { get; set; } // Bonus="Yes" -> power star
-            public bool   IsSentenceStart { get; set; }
+            public int PartIndex { get; set; }
+            public int MidiNote { get; set; } // Absolute MIDI pitch; 0 = rest/silence
+            public uint StartUnit { get; set; } // Cumulative position in 1/8-note units
+            public uint Duration { get; set; } // Length in 1/8-note units
+            public string Lyric { get; set; } = string.Empty;
+            public bool IsBonus { get; set; } // Bonus="Yes" -> power star
+            public bool IsSentenceStart { get; set; }
 
             // A rest is a note with MidiNote == 0 AND no lyric text.
-            public bool IsRest   => MidiNote == SINGSTAR_REST_NOTE && string.IsNullOrEmpty(Lyric);
+            public bool IsRest => MidiNote == SINGSTAR_REST_NOTE && string.IsNullOrEmpty(Lyric);
             public bool IsGolden => IsBonus;
         }
 
@@ -39,26 +39,26 @@ namespace YARG.Core.Chart.Loaders.SingStar
 
         #region Constants
 
-        private const int  SINGSTAR_REST_NOTE      = 0;
+        private const int SINGSTAR_REST_NOTE = 0;
         private const uint SINGSTAR_UNITS_PER_BEAT = 8;
 
         #endregion
 
         #region Fields
 
-        private readonly Dictionary<string, string> _metadata     = new(StringComparer.OrdinalIgnoreCase);
-        private          uint                       _ticksPerBeat = 120;
-        private          double                     _bpm          = 120.0;
+        private readonly Dictionary<string, string> _metadata = new(StringComparer.OrdinalIgnoreCase);
+        private uint _ticksPerBeat = 120;
+        private double _bpm = 120.0;
 
         private List<TextEvent>? _globalEvents;
-        private List<Section>?   _sections;
-        private SyncTrack?       _syncTrack;
-        private VenueTrack?      _venueTrack;
-        private LyricsTrack?     _lyricsTrack;
+        private List<Section>? _sections;
+        private SyncTrack? _syncTrack;
+        private VenueTrack? _venueTrack;
+        private LyricsTrack? _lyricsTrack;
 
         private uint _barMarkerDelay;
-        private int  _formatVersion = 2;
-        private int  _currentPartIndex;
+        private int _formatVersion = 2;
+        private int _currentPartIndex;
 
         private readonly uint[] _cumulativeUnits = new uint[2];
 
@@ -78,10 +78,9 @@ namespace YARG.Core.Chart.Loaders.SingStar
             unsafe
             {
                 using var stream = new UnmanagedMemoryStream(file.Ptr, file.Length);
-
                 var settings = new XmlReaderSettings
                 {
-                    IgnoreComments = false, // Read Artist/Title from comments
+                    IgnoreComments = false,
                     IgnoreWhitespace = true,
                     DtdProcessing = DtdProcessing.Ignore,
                     XmlResolver = null,
@@ -89,7 +88,6 @@ namespace YARG.Core.Chart.Loaders.SingStar
 
                 using var reader = XmlReader.Create(stream, settings);
 
-                // Read global attributes from <MELODY> root first
                 while (reader.Read())
                 {
                     if (reader.NodeType == XmlNodeType.Comment)
@@ -99,38 +97,35 @@ namespace YARG.Core.Chart.Loaders.SingStar
                     }
 
                     if (reader.NodeType != XmlNodeType.Element)
-                    {
                         continue;
-                    }
 
-                    if (reader.Name == "MELODY")
-                    {
-                        ParseMelodyAttributes(reader);
-                        continue;
-                    }
-
-                    if (reader.Name == "TRACK")
-                    {
-                        string? name = reader.GetAttribute("Name");
-                        _currentPartIndex = (name != null &&
-                            name.Equals("Player2", StringComparison.OrdinalIgnoreCase))
-                            ? 1
-                            : 0;
-
-                        if (_formatVersion == 2)
-                        {
-                            ParseTrack(reader); // Version 2: SENTENCE in TRACK
-                        }
-
-                        // Version 1: TRACK is empty
-                        continue;
-                    }
-
-                    if (reader.Name == "SENTENCE" && _formatVersion == 1)
-                    {
-                        ParseSentence(reader, _currentPartIndex, ref _cumulativeUnits[_currentPartIndex]);
-                    }
+                    HandleElement(reader);
                 }
+            }
+        }
+
+        private void HandleElement(XmlReader reader)
+        {
+            switch (reader.Name)
+            {
+                case "MELODY":
+                    ParseMelodyAttributes(reader);
+                    break;
+
+                case "TRACK":
+                    string? trackName = reader.GetAttribute("Name");
+                    _currentPartIndex = (trackName?.Equals("Player2",
+                        StringComparison.OrdinalIgnoreCase) == true) ? 1 : 0;
+
+                    if (_formatVersion == 2)
+                        ParseTrack(reader);
+                    break;
+
+                case "SENTENCE":
+                    if (_formatVersion == 1)
+                        ParseSentence(reader, _currentPartIndex,
+                            ref _cumulativeUnits[_currentPartIndex]);
+                    break;
             }
         }
 
@@ -186,16 +181,17 @@ namespace YARG.Core.Chart.Loaders.SingStar
         /// </summary>
         private void ParseComment(string comment)
         {
-            comment = comment.Trim();
+            var parts = comment.Split(':', 2);
+            if (parts.Length < 2) return;
 
-            if (comment.StartsWith("Artist:", StringComparison.OrdinalIgnoreCase))
-            {
-                _metadata["ARTIST"] = comment["Artist:".Length..].Trim();
-            }
-            else if (comment.StartsWith("Title:", StringComparison.OrdinalIgnoreCase))
-            {
-                _metadata["TITLE"] = comment["Title:".Length..].Trim();
-            }
+            string key = parts[0].Trim();
+            string value = parts[1].Trim();
+
+            if (key.Equals("Artist", StringComparison.OrdinalIgnoreCase))
+                _metadata["ARTIST"] = value;
+            else if (key.Equals("Title", StringComparison.OrdinalIgnoreCase))
+                _metadata["TITLE"] = value;
+
         }
 
         /// <summary>
@@ -285,6 +281,10 @@ namespace YARG.Core.Chart.Loaders.SingStar
                 if (!isRest)
                 {
                     lyric = ProcessLyricForMelisma(lyric, ref inMelismaContinuation);
+                }
+                else
+                {
+                    inMelismaContinuation = false;
                 }
 
                 _partNotes[partIndex].Add(new SingStarNote
@@ -602,17 +602,11 @@ namespace YARG.Core.Chart.Loaders.SingStar
         #region Utilities
 
         /// <summary>
-        ///     Removes SingStar word-continuation markers (" -" suffix) from lyric text
-        ///     so only the clean syllable text is stored.
+        ///     Trims lyric text
         /// </summary>
         private static string FormatLyric(string raw)
         {
             raw = raw.Trim();
-            if (raw.EndsWith(" -", StringComparison.Ordinal))
-            {
-                raw = raw[..^2].TrimEnd() + "-";
-            }
-
             return raw;
         }
 
@@ -643,7 +637,7 @@ namespace YARG.Core.Chart.Loaders.SingStar
                 return lyric.Substring(0, lyric.Length - 2).TrimEnd();
             }
 
-            if (lyric.EndsWith("-", StringComparison.Ordinal))
+            if (lyric.Length == 1 && lyric.EndsWith("-", StringComparison.Ordinal))
             {
                 return lyric.Substring(0, lyric.Length - 1).TrimEnd();
             }

--- a/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/SingStar/SingStarLoader.cs
@@ -1,0 +1,734 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using YARG.Core.IO;
+using YARG.Core.Logging;
+
+namespace YARG.Core.Chart.Loaders.SingStar
+{
+    internal class SingStarLoader : ISongLoader
+    {
+        public SingStarLoader(FixedArray<byte> file)
+        {
+            ParseSingStarFile(file);
+        }
+
+        public string? GetMetadata(string key) => _metadata.GetValueOrDefault(key);
+
+        #region SingStarNote
+
+        private class SingStarNote
+        {
+            public int    PartIndex       { get; set; }
+            public int    MidiNote        { get; set; } // Absolute MIDI pitch; 0 = rest/silence
+            public uint   StartUnit       { get; set; } // Cumulative position in 1/8-note units
+            public uint   Duration        { get; set; } // Length in 1/8-note units
+            public string Lyric           { get; set; } = string.Empty;
+            public bool   IsBonus         { get; set; } // Bonus="Yes" -> power star
+            public bool   IsSentenceStart { get; set; }
+
+            // A rest is a note with MidiNote == 0 AND no lyric text.
+            public bool IsRest   => MidiNote == SINGSTAR_REST_NOTE && string.IsNullOrEmpty(Lyric);
+            public bool IsGolden => IsBonus;
+        }
+
+        #endregion
+
+        #region Constants
+
+        private const int  SINGSTAR_REST_NOTE      = 0;
+        private const uint SINGSTAR_UNITS_PER_BEAT = 8;
+
+        #endregion
+
+        #region Fields
+
+        private readonly Dictionary<string, string> _metadata     = new(StringComparer.OrdinalIgnoreCase);
+        private          uint                       _ticksPerBeat = 120;
+        private          double                     _bpm          = 120.0;
+
+        private List<TextEvent>? _globalEvents;
+        private List<Section>?   _sections;
+        private SyncTrack?       _syncTrack;
+        private VenueTrack?      _venueTrack;
+        private LyricsTrack?     _lyricsTrack;
+
+        private uint _barMarkerDelay;
+        private int  _formatVersion = 2;
+        private int  _currentPartIndex;
+
+        private readonly uint[] _cumulativeUnits = new uint[2];
+
+        // Key 0 = Player1, Key 1 = Player2
+        private readonly Dictionary<int, List<SingStarNote>> _partNotes = new()
+        {
+            [0] = new List<SingStarNote>(),
+            [1] = new List<SingStarNote>(),
+        };
+
+        #endregion
+
+        #region Parsing
+
+        private void ParseSingStarFile(FixedArray<byte> file)
+        {
+            unsafe
+            {
+                using var stream = new UnmanagedMemoryStream(file.Ptr, file.Length);
+
+                var settings = new XmlReaderSettings
+                {
+                    IgnoreComments = false, // Read Artist/Title from comments
+                    IgnoreWhitespace = true,
+                    DtdProcessing = DtdProcessing.Ignore,
+                    XmlResolver = null,
+                };
+
+                using var reader = XmlReader.Create(stream, settings);
+
+                // Read global attributes from <MELODY> root first
+                while (reader.Read())
+                {
+                    if (reader.NodeType == XmlNodeType.Comment)
+                    {
+                        ParseComment(reader.Value);
+                        continue;
+                    }
+
+                    if (reader.NodeType != XmlNodeType.Element)
+                    {
+                        continue;
+                    }
+
+                    if (reader.Name == "MELODY")
+                    {
+                        ParseMelodyAttributes(reader);
+                        continue;
+                    }
+
+                    if (reader.Name == "TRACK")
+                    {
+                        string? name = reader.GetAttribute("Name");
+                        _currentPartIndex = (name != null &&
+                            name.Equals("Player2", StringComparison.OrdinalIgnoreCase))
+                            ? 1
+                            : 0;
+
+                        if (_formatVersion == 2)
+                        {
+                            ParseTrack(reader); // Version 2: SENTENCE in TRACK
+                        }
+
+                        // Version 1: TRACK is empty
+                        continue;
+                    }
+
+                    if (reader.Name == "SENTENCE" && _formatVersion == 1)
+                    {
+                        ParseSentence(reader, _currentPartIndex, ref _cumulativeUnits[_currentPartIndex]);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Reads global metadata from the MELODY element attributes.
+        ///     Example: Tempo="106.2" Genre="Pop" Year="2001" Duet="Yes"
+        /// </summary>
+        private void ParseMelodyAttributes(XmlReader reader)
+        {
+            string? tempo = reader.GetAttribute("Tempo");
+            if (tempo != null && double.TryParse(
+                    tempo.Replace(',', '.'),
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out double bpm) && bpm > 0)
+            {
+                _bpm = bpm;
+            }
+
+            string? genre = reader.GetAttribute("Genre");
+            string? year = reader.GetAttribute("Year");
+            string? duet = reader.GetAttribute("Duet");
+            string? version = reader.GetAttribute("Version");
+            if (version != null && int.TryParse(version, out int v))
+            {
+                _formatVersion = v;
+            }
+
+            if (genre != null)
+            {
+                _metadata["GENRE"] = genre;
+            }
+
+            if (year != null)
+            {
+                _metadata["YEAR"] = year;
+            }
+
+            if (duet != null && duet.Equals("Yes", StringComparison.OrdinalIgnoreCase))
+            {
+                _metadata["PARTS"] = "2";
+            }
+
+            string? res = reader.GetAttribute("Resolution");
+            if (res != null)
+            {
+                _metadata["RESOLUTION"] = res;
+            }
+        }
+
+        /// <summary>
+        ///     Parses Artist and Title from XML comments
+        /// </summary>
+        private void ParseComment(string comment)
+        {
+            comment = comment.Trim();
+
+            if (comment.StartsWith("Artist:", StringComparison.OrdinalIgnoreCase))
+            {
+                _metadata["ARTIST"] = comment["Artist:".Length..].Trim();
+            }
+            else if (comment.StartsWith("Title:", StringComparison.OrdinalIgnoreCase))
+            {
+                _metadata["TITLE"] = comment["Title:".Length..].Trim();
+            }
+        }
+
+        /// <summary>
+        ///     Parses a single TRACK element (Player1 or Player2).
+        ///     Each TRACK contains SENTENCE elements, each of which contains NOTE elements.
+        ///     Notes carry cumulative Duration — we sum them to get absolute positions.
+        /// </summary>
+        private void ParseTrack(XmlReader reader)
+        {
+            string? name = reader.GetAttribute("Name");
+            int partIndex = (name != null && name.Equals("Player2", StringComparison.OrdinalIgnoreCase))
+                ? 1
+                : 0;
+
+            if (!_partNotes.ContainsKey(partIndex))
+            {
+                _partNotes[partIndex] = new List<SingStarNote>();
+            }
+
+            uint cumulativeUnits = 0; // Running position in 1/8-note units
+
+            // Read through the TRACK subtree
+            using var subtree = reader.ReadSubtree();
+            while (subtree.Read())
+            {
+                if (subtree.NodeType != XmlNodeType.Element)
+                {
+                    continue;
+                }
+
+                if (subtree.Name == "SENTENCE")
+                {
+                    ParseSentence(subtree, partIndex, ref cumulativeUnits);
+                }
+            }
+        }
+
+        /// <summary>
+        ///     Parses one SENTENCE (phrase). Each SENTENCE is a lyric line.
+        ///     Notes inside are positional — each note starts exactly where the previous one ended
+        /// </summary>
+        private void ParseSentence(XmlReader reader, int partIndex, ref uint cumulativeUnits)
+        {
+            using var subtree = reader.ReadSubtree();
+
+            bool inMelismaContinuation = false;
+            bool firstNote = true;
+
+            while (subtree.Read())
+            {
+                if (subtree.NodeType != XmlNodeType.Element || subtree.Name != "NOTE")
+                {
+                    continue;
+                }
+
+                if (subtree.Name == "LABEL")
+                {
+                    string? labelName = subtree.GetAttribute("Name");
+                    string? delayStr = subtree.GetAttribute("Delay");
+                    if ("Bar Marker".Equals(labelName, StringComparison.OrdinalIgnoreCase)
+                        && delayStr != null
+                        && uint.TryParse(delayStr, out uint delay)
+                        && _barMarkerDelay == 0)
+                    {
+                        _barMarkerDelay = delay;
+                    }
+                }
+
+                string? midiStr = subtree.GetAttribute("MidiNote");
+                string? durStr = subtree.GetAttribute("Duration");
+                string? lyric = subtree.GetAttribute("Lyric") ?? string.Empty;
+                string? bonus = subtree.GetAttribute("Bonus");
+
+                if (midiStr == null || durStr == null)
+                {
+                    continue;
+                }
+
+                if (!int.TryParse(midiStr, out int midiNote) ||
+                    !uint.TryParse(durStr, out uint duration))
+                {
+                    continue;
+                }
+
+                bool isRest = midiNote == SINGSTAR_REST_NOTE;
+
+                if (!isRest)
+                {
+                    lyric = ProcessLyricForMelisma(lyric, ref inMelismaContinuation);
+                }
+
+                _partNotes[partIndex].Add(new SingStarNote
+                {
+                    PartIndex = partIndex,
+                    MidiNote = midiNote,
+                    StartUnit = cumulativeUnits,
+                    Duration = duration,
+                    Lyric = lyric,
+                    IsBonus = bonus != null && bonus.Equals("Yes", StringComparison.OrdinalIgnoreCase),
+                    IsSentenceStart = firstNote,
+                });
+
+                firstNote = false;
+
+                cumulativeUnits += duration;
+            }
+        }
+
+        #endregion
+
+        #region Time Conversion
+
+        // SingStar Resolution="Demisemiquaver" means 1 unit = 1/8 of a beat.
+        // To convert units to beats:  beats = units / 8
+        // To convert beats to ticks:  ticks = beats * _ticksPerBeat
+        // To convert beats to seconds: seconds = beats * 60.0 / _bpm
+
+        private double UnitsToTime(uint units) =>
+            (units - (double) _barMarkerDelay) / SINGSTAR_UNITS_PER_BEAT * (60.0 / _bpm);
+
+        private double UnitsDurationToSeconds(uint durationUnits) =>
+            durationUnits / (double) SINGSTAR_UNITS_PER_BEAT * (60.0 / _bpm);
+
+        private uint UnitsToTick(uint units)
+        {
+            double beats = (units - (double) _barMarkerDelay) / SINGSTAR_UNITS_PER_BEAT;
+            return beats >= 0 ? (uint) (beats * _ticksPerBeat) : 0u;
+        }
+
+        #endregion
+
+        #region Loading
+
+        public List<TextEvent> LoadGlobalEvents() => _globalEvents ??= new List<TextEvent>();
+        public List<Section> LoadSections() => _sections ??= new List<Section>();
+        public VenueTrack LoadVenueTrack() => _venueTrack ??= new VenueTrack();
+
+        public InstrumentTrack<GuitarNote> LoadGuitarTrack(Instrument i) => throw new NotSupportedException();
+        public InstrumentTrack<ProGuitarNote> LoadProGuitarTrack(Instrument i) => throw new NotSupportedException();
+        public InstrumentTrack<ProKeysNote> LoadProKeysTrack(Instrument i) => throw new NotSupportedException();
+
+        public InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument i, InstrumentTrack<EliteDrumNote>? e) =>
+            throw new NotSupportedException();
+
+        public InstrumentTrack<EliteDrumNote> LoadEliteDrumsTrack(Instrument i) => throw new NotSupportedException();
+
+        public SyncTrack LoadSyncTrack()
+        {
+            if (_syncTrack != null)
+            {
+                return _syncTrack;
+            }
+
+            double delaySeconds = _barMarkerDelay / (double) SINGSTAR_UNITS_PER_BEAT * (60.0 / _bpm);
+
+            _syncTrack = new SyncTrack(120,
+                new List<TempoChange>
+                {
+                    new(_bpm, -delaySeconds, 0u),
+                },
+                new List<TimeSignatureChange>
+                {
+                    new(4, 4, -delaySeconds, 0u, 0u, 0u, 0u, 0.0),
+                },
+                new List<Beatline>());
+
+            return _syncTrack;
+        }
+
+        public LyricsTrack LoadLyrics()
+        {
+            if (_lyricsTrack != null)
+            {
+                return _lyricsTrack;
+            }
+
+            var phrases = new List<LyricsPhrase>();
+            var lyricSource = _partNotes[0];
+
+            foreach (var group in GroupNotesIntoPhrases(lyricSource))
+            {
+                if (group.Count == 0)
+                {
+                    continue;
+                }
+
+                uint startTick = UnitsToTick(group[0].StartUnit);
+                uint endTick = UnitsToTick(group[^1].StartUnit + group[^1].Duration);
+                double startTime = UnitsToTime(group[0].StartUnit);
+                double endTime = UnitsToTime(group[^1].StartUnit + group[^1].Duration);
+
+                var events = new List<LyricEvent>();
+                foreach (var n in group)
+                {
+                    if (n.IsRest || string.IsNullOrWhiteSpace(n.Lyric))
+                    {
+                        continue;
+                    }
+
+                    events.Add(new LyricEvent(
+                        LyricSymbolFlags.None,
+                        FormatLyric(n.Lyric),
+                        UnitsToTime(n.StartUnit),
+                        UnitsToTick(n.StartUnit)));
+                }
+
+                if (events.Count > 0)
+                {
+                    phrases.Add(new LyricsPhrase(
+                        startTime, endTime - startTime,
+                        startTick, endTick - startTick,
+                        events));
+                }
+            }
+
+            _lyricsTrack = new LyricsTrack(phrases);
+            return _lyricsTrack;
+        }
+
+        public VocalsTrack LoadVocalsTrack(Instrument instrument)
+        {
+            if (instrument != Instrument.Vocals && instrument != Instrument.Harmony)
+            {
+                throw new ArgumentException("SingStar only supports Vocals and Harmony.", nameof(instrument));
+            }
+
+            var parts = new List<VocalsPart>();
+
+            if (instrument == Instrument.Vocals)
+            {
+                parts.Add(BuildVocalsPart(_partNotes[0], false));
+            }
+            else if (instrument == Instrument.Harmony)
+            {
+                bool isDuet = _metadata.TryGetValue("PARTS", out var p) && p == "2";
+
+                parts.Add(BuildVocalsPart(_partNotes[0], true));
+                if (isDuet)
+                {
+                    parts.Add(BuildVocalsPart(_partNotes[1], true));
+                }
+            }
+
+            return new VocalsTrack(Instrument.Vocals, parts, new List<VocalsRangeShift>());
+        }
+
+        #endregion
+
+        #region Vocals Processing
+
+        private VocalsPart BuildVocalsPart(List<SingStarNote> notes, bool isHarmony)
+        {
+            var phrases = new List<VocalsPhrase>();
+            var otherPhrases = new List<Phrase>();
+            var textEvents = new List<TextEvent>();
+
+            int harmonyIndex = isHarmony ? 1 : 0;
+
+            foreach (var group in GroupNotesIntoPhrases(notes))
+            {
+                if (group.Count == 0)
+                {
+                    continue;
+                }
+
+                var phrase = CreateVocalsPhrase(group, harmonyIndex);
+                if (phrase == null)
+                {
+                    continue;
+                }
+
+                phrases.Add(phrase);
+
+                if (group.Any(n => n.IsGolden))
+                {
+                    otherPhrases.Add(new Phrase(
+                        PhraseType.StarPower,
+                        phrase.Time,
+                        phrase.TimeLength,
+                        phrase.Tick,
+                        phrase.TickLength));
+                }
+            }
+
+            otherPhrases = otherPhrases.OrderBy(p => p.Tick).ToList();
+
+            return new VocalsPart(isHarmony, phrases, new List<VocalsPhrase>(), otherPhrases, textEvents);
+        }
+
+        /// <summary>
+        ///     Groups notes into phrases (lyric lines). In SingStar, phrase boundaries are
+        ///     implicit - a SENTENCE element defines each phrase
+        /// </summary>
+        private List<List<SingStarNote>> GroupNotesIntoPhrases(List<SingStarNote> notes)
+        {
+            var groups = new List<List<SingStarNote>>();
+            var currentGroup = new List<SingStarNote>();
+
+            foreach (var note in notes.OrderBy(n => n.StartUnit))
+            {
+                if (note.IsSentenceStart)
+                {
+                    if (currentGroup.Count > 0)
+                    {
+                        groups.Add(currentGroup);
+                    }
+                    currentGroup = new List<SingStarNote>();
+                }
+                currentGroup.Add(note);
+            }
+
+            if (currentGroup.Count > 0)
+            {
+                groups.Add(currentGroup);
+            }
+
+            return groups;
+        }
+
+        private VocalsPhrase? CreateVocalsPhrase(List<SingStarNote> phraseNotes, int partIndex)
+        {
+            if (phraseNotes.Count == 0)
+            {
+                return null;
+            }
+
+            uint phraseStartTick = UnitsToTick(phraseNotes[0].StartUnit);
+            uint phraseEndTick = UnitsToTick(phraseNotes[^1].StartUnit + phraseNotes[^1].Duration);
+            uint phraseTickLen = phraseEndTick - phraseStartTick;
+            double phraseStartTime = UnitsToTime(phraseNotes[0].StartUnit);
+            double phraseEndTime = UnitsToTime(phraseNotes[^1].StartUnit + phraseNotes[^1].Duration);
+            double phraseTimeLen = phraseEndTime - phraseStartTime;
+
+            var parentNote = new VocalNote(
+                NoteFlags.None, false,
+                phraseStartTime, phraseTimeLen,
+                phraseStartTick, phraseTickLen);
+
+            var lyrics = new List<LyricEvent>();
+            int harmonyPart = partIndex == 0 ? 0 : 1;
+
+            foreach (var sNote in phraseNotes)
+            {
+                uint noteTick = UnitsToTick(sNote.StartUnit);
+                uint noteTickLen = UnitsToTick(sNote.StartUnit + sNote.Duration) - noteTick;
+                double noteTime = UnitsToTime(sNote.StartUnit);
+                double noteTimeLen = UnitsDurationToSeconds(sNote.Duration);
+
+                // SingStar pitch is already absolute MIDI — no conversion needed.
+                // Clamp to valid range just in case.
+                float midiPitch = Math.Clamp(sNote.MidiNote, 0, 127);
+
+                if (sNote.IsRest)
+                {
+                    continue;
+                }
+
+                var childNote = new VocalNote(
+                    midiPitch,
+                    harmonyPart,
+                    VocalNoteType.Lyric,
+                    noteTime,
+                    noteTimeLen,
+                    noteTick,
+                    noteTickLen);
+
+                parentNote.AddChildNote(childNote);
+
+                if (!string.IsNullOrWhiteSpace(sNote.Lyric))
+                {
+                    lyrics.Add(new LyricEvent(
+                        LyricSymbolFlags.None,
+                        FormatLyric(sNote.Lyric),
+                        noteTime,
+                        noteTick));
+                }
+            }
+
+            if (phraseNotes.Any(n => n.IsGolden))
+            {
+                parentNote.ActivateFlag(NoteFlags.StarPower);
+            }
+
+            if (parentNote.ChildNotes.Count == 0)
+            {
+                YargLogger.LogWarning($"[SingStar] Phrase at tick {phraseStartTick} has 0 child notes — skipping");
+                return null;
+            }
+
+            return new VocalsPhrase(
+                phraseStartTime, phraseTimeLen,
+                phraseStartTick, phraseTickLen,
+                parentNote, lyrics);
+        }
+
+        #endregion
+
+        #region Utilities
+
+        /// <summary>
+        ///     Removes SingStar word-continuation markers (" -" suffix) from lyric text
+        ///     so only the clean syllable text is stored.
+        /// </summary>
+        private static string FormatLyric(string raw)
+        {
+            raw = raw.Trim();
+            if (raw.EndsWith(" -", StringComparison.Ordinal))
+            {
+                raw = raw[..^2].TrimEnd() + "-";
+            }
+
+            return raw;
+        }
+
+        private static bool EndsWithSlideMarker(string lyric)
+        {
+            if (string.IsNullOrWhiteSpace(lyric))
+            {
+                return false;
+            }
+
+            lyric = lyric.TrimEnd();
+
+            return lyric.EndsWith(" -", StringComparison.Ordinal) ||
+                (lyric.EndsWith("-", StringComparison.Ordinal) && lyric.Length == 1);
+        }
+
+        private static string RemoveSlideMarker(string lyric)
+        {
+            if (string.IsNullOrWhiteSpace(lyric))
+            {
+                return string.Empty;
+            }
+
+            lyric = lyric.TrimEnd();
+
+            if (lyric.EndsWith(" -", StringComparison.Ordinal))
+            {
+                return lyric.Substring(0, lyric.Length - 2).TrimEnd();
+            }
+
+            if (lyric.EndsWith("-", StringComparison.Ordinal))
+            {
+                return lyric.Substring(0, lyric.Length - 1).TrimEnd();
+            }
+
+            return lyric;
+        }
+
+        private static string ProcessLyricForMelisma(string lyric, ref bool inMelismaContinuation)
+        {
+            lyric ??= string.Empty;
+            string trimmed = lyric.Trim();
+
+            bool isStandaloneDash = trimmed == "-";
+            bool endsWithSlideMarker = EndsWithSlideMarker(trimmed);
+
+            // Case 1:
+            // We are already in continuation mode
+            if (inMelismaContinuation)
+            {
+                // "-" means another continuation note => "+"
+                if (isStandaloneDash)
+                {
+                    return "+";
+                }
+
+                // Normal lyric while continuing => "word+"
+                // If it also ends with "-" then continuation remains active
+                if (endsWithSlideMarker)
+                {
+                    string baseLyric = RemoveSlideMarker(trimmed);
+                    return string.IsNullOrEmpty(baseLyric) ? "+" : baseLyric + "+";
+                }
+
+                // Normal lyric closes the continuation
+                inMelismaContinuation = false;
+                return string.IsNullOrEmpty(trimmed) ? "+" : trimmed + "+";
+            }
+
+            // Case 2:
+            // Not in continuation mode yet
+
+            // "word -" starts continuation
+            if (endsWithSlideMarker && !isStandaloneDash)
+            {
+                inMelismaContinuation = true;
+                return RemoveSlideMarker(trimmed);
+            }
+
+            // Standalone "-" without active continuation
+            // safest behavior: treat as "+"
+            if (isStandaloneDash)
+            {
+                return "+";
+            }
+
+            return trimmed;
+        }
+
+        public void DumpToLog()
+        {
+            int totalNotes = _partNotes.Values.Sum(list => list.Count);
+            YargLogger.LogDebug($"[SingStar] BPM={_bpm} TOTAL_NOTES={totalNotes}");
+
+            foreach (var kvp in _partNotes.OrderBy(k => k.Key))
+            {
+                int partIndex = kvp.Key;
+                var notes = kvp.Value;
+
+                YargLogger.LogDebug($"[SingStar] Part {partIndex + 1}: notes={notes.Count}");
+
+                var groups = GroupNotesIntoPhrases(notes);
+                YargLogger.LogDebug($"[SingStar] Part {partIndex + 1}: phrase groups={groups.Count}");
+
+                for (int gi = 0; gi < groups.Count; gi++)
+                {
+                    var g = groups[gi];
+                    YargLogger.LogDebug($"[SingStar] Part {partIndex + 1} Phrase {gi}: {g.Count} notes, " +
+                        $"units {g[0].StartUnit}–{g[^1].StartUnit + g[^1].Duration}, " +
+                        $"time {UnitsToTime(g[0].StartUnit):F3}s–{UnitsToTime(g[^1].StartUnit + g[^1].Duration):F3}s");
+
+                    foreach (var n in g)
+                    {
+                        YargLogger.LogDebug($"[SingStar]   P{partIndex + 1} midi={n.MidiNote} " +
+                            $"start={n.StartUnit} dur={n.Duration} " +
+                            $"tick={UnitsToTick(n.StartUnit)} time={UnitsToTime(n.StartUnit):F3}s " +
+                            $"lyric='{n.Lyric}' golden={n.IsGolden}");
+                    }
+                }
+            }
+        }
+
+        #endregion
+    }
+}

--- a/YARG.Core/Chart/SongChart.SingStar.cs
+++ b/YARG.Core/Chart/SongChart.SingStar.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace YARG.Core.Chart
+{
+    /// <summary>
+    ///     Extends SongChart with SingStar .xml factory methods.
+    ///     Drop this file next to SongChart.cs (same namespace, partial class).
+    /// </summary>
+    public partial class SongChart
+    {
+        /// <summary>Loads a SongChart from a SingStar melody .xml file path.</summary>
+        public static SongChart FromSingStarFile(in ParseSettings settings, string filePath)
+        {
+            var loader = MoonSongLoader.LoadSingStar(settings, filePath);
+            return new SongChart(loader);
+        }
+
+        /// <summary>Loads a SongChart from raw SingStar melody .xml bytes.</summary>
+        public static SongChart FromSingStarBytes(in ParseSettings settings, ReadOnlySpan<byte> data)
+        {
+            var loader = MoonSongLoader.LoadSingStar(settings, data.ToArray());
+            return new SongChart(loader);
+        }
+    }
+}

--- a/YARG.Core/IO/ChartFormat.cs
+++ b/YARG.Core/IO/ChartFormat.cs
@@ -5,6 +5,7 @@
         Mid, 
         Midi,
         Chart,
-        UltraStar
+        UltraStar,
+        SingStar
     }
 }

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -798,8 +798,8 @@ namespace YARG.Core.Song.Cache
         private bool ScanIniEntry(in FileCollection collection, IniEntryGroup group, string defaultPlaylist)
         {
             bool hasIni = collection.FindFile("song.ini", out var ini);
-            int i = hasIni ? 0 : 3;
-            while (i < 4)
+            int i = 0;
+            while (i < 5)
             {
                 if (!collection.FindFile(IniSubEntry.CHART_FILE_TYPES[i].Filename, out var chart))
                 {

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -798,50 +798,49 @@ namespace YARG.Core.Song.Cache
         private bool ScanIniEntry(in FileCollection collection, IniEntryGroup group, string defaultPlaylist)
         {
             bool hasIni = collection.FindFile("song.ini", out var ini);
-            int i = 0;
-            while (i < 5)
-            {
-                if (!collection.FindFile(IniSubEntry.CHART_FILE_TYPES[i].Filename, out var chart))
-                {
-                    ++i;
-                    continue;
-                }
 
-                // Can't play a song without any audio can you?
-                //
-                // Note though that this is purely a pre-add check.
-                // We will not invalidate an entry from cache if the user removes the audio after the fact.
+            for (int i = 0; i < IniSubEntry.CHART_FILE_TYPES.Length; i++)
+            {
+                var fileType = IniSubEntry.CHART_FILE_TYPES[i];
+
+                if (!collection.FindFile(fileType.Filename, out var chart))
+                    continue;
+
                 if (!collection.ContainsAudio())
                 {
                     AddToBadSongs(chart.FullName, ScanResult.NoAudio);
-                    break;
+                    return false;
                 }
 
                 try
                 {
-                    var entry = UnpackedIniEntry.ProcessNewEntry(collection.Directory, chart, IniSubEntry.CHART_FILE_TYPES[i].Format, hasIni ? ini : null, defaultPlaylist);
+                    var entry = UnpackedIniEntry.ProcessNewEntry(
+                        collection.Directory,
+                        chart,
+                        i,
+                        hasIni ? ini : null,
+                        defaultPlaylist);
+
                     if (entry)
                     {
                         AddEntry(entry.Value);
                         group.AddEntry(entry.Value);
+                        return true;
                     }
                     else
                     {
                         AddToBadSongs(chart.FullName, entry.Error);
+                        continue;
                     }
-                }
-                catch (PathTooLongException)
-                {
-                    YargLogger.LogFormatError("Path {0} is too long for the file system!", chart);
-                    AddToBadSongs(chart.FullName, ScanResult.PathTooLong);
                 }
                 catch (Exception e)
                 {
                     YargLogger.LogException(e, $"Error while scanning chart file {chart}!");
                     AddToBadSongs(collection.Directory, ScanResult.IniEntryCorruption);
+                    continue;
                 }
-                return true;
             }
+
             return false;
         }
 
@@ -870,7 +869,7 @@ namespace YARG.Core.Song.Cache
 
                 try
                 {
-                    var entry = SngEntry.ProcessNewEntry(in sngFile, in chart, info, IniSubEntry.CHART_FILE_TYPES[i].Format, defaultPlaylist);
+                    var entry = SngEntry.ProcessNewEntry(in sngFile, in chart, info, i, defaultPlaylist);
                     if (entry.HasValue)
                     {
                         AddEntry(entry.Value);

--- a/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
@@ -1,49 +1,80 @@
-﻿using MoonscraperChartEditor.Song.IO;
-using System;
+﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using MoonscraperChartEditor.Song.IO;
 using YARG.Core.Chart;
+using YARG.Core.Chart.Loaders.SingStar;
 using YARG.Core.Chart.Loaders.UltraStar;
 using YARG.Core.Extensions;
 using YARG.Core.IO;
 using YARG.Core.IO.Ini;
-using YARG.Core.Logging;
 
 namespace YARG.Core.Song
 {
     public static class IniAudio
     {
-        public static readonly string[] SupportedStems = { "song", "guitar", "bass", "rhythm", "keys", "vocals", "vocals_1", "vocals_2", "drums", "drums_1", "drums_2", "drums_3", "drums_4", "crowd", };
-        public static readonly string[] SupportedFormats = { ".opus", ".ogg", ".mp3", ".wav", ".aiff", };
+        public static readonly string[] SupportedStems =
+        {
+            "song",
+            "guitar",
+            "bass",
+            "rhythm",
+            "keys",
+            "vocals",
+            "vocals_1",
+            "vocals_2",
+            "drums",
+            "drums_1",
+            "drums_2",
+            "drums_3",
+            "drums_4",
+            "crowd",
+        };
+        public static readonly string[] SupportedFormats =
+        {
+            ".opus",
+            ".ogg",
+            ".mp3",
+            ".wav",
+            ".aiff",
+        };
         private static readonly HashSet<string> SupportedAudioFiles = new();
 
         static IniAudio()
         {
             foreach (string stem in SupportedStems)
-                foreach (string format in SupportedFormats)
+            foreach (string format in SupportedFormats)
             {
                 SupportedAudioFiles.Add(stem + format);
             }
         }
 
-        public static bool IsAudioFile(string file)
-        {
-            return SupportedAudioFiles.Contains(file);
-        }
+        public static bool IsAudioFile(string file) => SupportedAudioFiles.Contains(file);
     }
 
     internal abstract class IniSubEntry : SongEntry
     {
+        private const int GUITAR_FIVEFRET_MAX = 5;
+        private const int OPEN_NOTE           = 7;
         public static readonly (string Filename, ChartFormat Format)[] CHART_FILE_TYPES =
         {
-            ("notes.mid"  , ChartFormat.Mid),
-            ("notes.midi" , ChartFormat.Midi),
+            ("notes.mid", ChartFormat.Mid),
+            ("notes.midi", ChartFormat.Midi),
             ("notes.chart", ChartFormat.Chart),
-            ("notes.txt"  , ChartFormat.UltraStar),
+            ("notes.txt", ChartFormat.UltraStar),
+            ("vocals.xml", ChartFormat.SingStar),
         };
 
-        protected static readonly string[] ALBUMART_FILES;
-        protected static readonly string[] PREVIEW_FILES;
+        protected static readonly string[]    ALBUMART_FILES;
+        protected static readonly string[]    PREVIEW_FILES;
+        protected readonly        ChartFormat _chartFormat;
+        protected readonly        DateTime    _chartLastWrite;
+
+        protected readonly string _location;
+        protected          string _background = string.Empty;
+        protected          string _cover      = string.Empty;
+        protected          string _video      = string.Empty;
 
         static IniSubEntry()
         {
@@ -60,16 +91,16 @@ namespace YARG.Core.Song
             }
         }
 
-        protected readonly string _location;
-        protected readonly DateTime _chartLastWrite;
-        protected readonly ChartFormat _chartFormat;
-        protected string _background = string.Empty;
-        protected string _video = string.Empty;
-        protected string _cover = string.Empty;
+        protected IniSubEntry(string location, in DateTime chartLastWrite, ChartFormat chartFormat)
+        {
+            _location = location;
+            _chartLastWrite = chartLastWrite;
+            _chartFormat = chartFormat;
+        }
 
         public override string SortBasedLocation => _location;
-        public override string ActualLocation => _location;
-        public override DateTime GetLastWriteTime() { return _chartLastWrite; }
+        public override string ActualLocation    => _location;
+        public override DateTime GetLastWriteTime() => _chartLastWrite;
 
         protected abstract FixedArray<byte>? GetChartData(string filename);
 
@@ -90,19 +121,24 @@ namespace YARG.Core.Song
                 return null;
             }
 
-            var parseSettings = new ParseSettings()
+            var parseSettings = new ParseSettings
             {
                 HopoThreshold = _settings.HopoThreshold,
                 SustainCutoffThreshold = _settings.SustainCutoffThreshold,
                 StarPowerNote = _settings.OverdiveMidiNote,
                 TuningOffsetCents = _settings.TuningOffsetCents,
                 DrumsType = ParseDrumsType(in _parts),
-                ChordHopoCancellation = _chartFormat != ChartFormat.Chart
+                ChordHopoCancellation = _chartFormat != ChartFormat.Chart,
             };
 
             if (_chartFormat == ChartFormat.UltraStar)
             {
                 return SongChart.FromUltraStarBytes(in parseSettings, data.ReadOnlySpan);
+            }
+
+            if (_chartFormat == ChartFormat.SingStar)
+            {
+                return SongChart.FromSingStarBytes(in parseSettings, data.ReadOnlySpan);
             }
 
             using var stream = data.ToReferenceStream();
@@ -115,10 +151,7 @@ namespace YARG.Core.Song
             return SongChart.FromDotChart(in parseSettings, reader.ReadToEnd());
         }
 
-        public override FixedArray<byte>? LoadMiloData()
-        {
-            return null;
-        }
+        public override FixedArray<byte>? LoadMiloData() => null;
 
         protected new void Deserialize(ref FixedArrayStream stream, CacheReadStrings strings)
         {
@@ -129,14 +162,8 @@ namespace YARG.Core.Song
             (_parsedYear, _yearAsNumber) = ParseYear(_metadata.Year);
         }
 
-        protected IniSubEntry(string location, in DateTime chartLastWrite, ChartFormat chartFormat)
-        {
-            _location = location;
-            _chartLastWrite = chartLastWrite;
-            _chartFormat = chartFormat;
-        }
-
-        protected internal static ScanResult ScanChart(IniSubEntry entry, FixedArray<byte> file, IniModifierCollection modifiers)
+        protected internal static ScanResult ScanChart(IniSubEntry entry, FixedArray<byte> file,
+            IniModifierCollection modifiers)
         {
             var drums_type = DrumsType.FourOrFive;
             if (modifiers.Extract("five_lane_drums", out bool fiveLaneDrums))
@@ -147,6 +174,13 @@ namespace YARG.Core.Song
             if (entry._chartFormat == ChartFormat.UltraStar)
             {
                 return ScanUltraStar(entry, file);
+            }
+
+            if (entry._chartFormat == ChartFormat.SingStar)
+            {
+                SongMetadata.FillFromIni(ref entry._metadata, modifiers);
+                SetIntensities(modifiers, ref entry._parts);
+                return ScanSingStar(entry, file);
             }
 
             ScanExpected<long> resolution;
@@ -205,7 +239,8 @@ namespace YARG.Core.Song
                 entry._settings.TuningOffsetCents = tuningOffsetCents;
             }
 
-            if (!modifiers.Extract("hopo_frequency", out entry._settings.HopoThreshold) || entry._settings.HopoThreshold <= 0)
+            if (!modifiers.Extract("hopo_frequency", out entry._settings.HopoThreshold) ||
+                entry._settings.HopoThreshold <= 0)
             {
                 if (modifiers.Extract("eighthnote_hopo", out bool eighthNoteHopo))
                 {
@@ -221,7 +256,7 @@ namespace YARG.Core.Song
                         3 => 8,
                         4 => 6,
                         5 => 4,
-                        _ => throw new NotImplementedException($"Unhandled hopofreq value {hopoFreq}!")
+                        _ => throw new NotImplementedException($"Unhandled hopofreq value {hopoFreq}!"),
                     };
                     entry._settings.HopoThreshold = 4 * resolution.Value / denominator;
                 }
@@ -242,14 +277,16 @@ namespace YARG.Core.Song
 
             // .chart defaults to no sustain cutoff whatsoever if the ini does not define the value.
             // Since a failed `Extract` sets the value to zero, we need no additional work unless it's .mid
-            if (!modifiers.Extract("sustain_cutoff_threshold", out entry._settings.SustainCutoffThreshold) && entry._chartFormat != ChartFormat.Chart)
+            if (!modifiers.Extract("sustain_cutoff_threshold", out entry._settings.SustainCutoffThreshold) &&
+                entry._chartFormat != ChartFormat.Chart)
             {
                 entry._settings.SustainCutoffThreshold = resolution.Value / 3;
             }
 
             if (entry._chartFormat == ChartFormat.Mid || entry._chartFormat == ChartFormat.Midi)
             {
-                if (!modifiers.Extract("multiplier_note", out entry._settings.OverdiveMidiNote) || entry._settings.OverdiveMidiNote != 103)
+                if (!modifiers.Extract("multiplier_note", out entry._settings.OverdiveMidiNote) ||
+                    entry._settings.OverdiveMidiNote != 103)
                 {
                     entry._settings.OverdiveMidiNote = 116;
                 }
@@ -278,6 +315,7 @@ namespace YARG.Core.Song
                     entry._metadata.SongLength = (long) (mixer.Length * SongMetadata.MILLISECOND_FACTOR);
                 }
             }
+
             return ScanResult.Success;
         }
 
@@ -294,7 +332,7 @@ namespace YARG.Core.Song
                 }
             }
 
-            foreach (var (shortname, image) in dict)
+            foreach ((string? shortname, var image) in dict)
             {
                 if (!shortname.StartsWith("background"))
                 {
@@ -317,6 +355,7 @@ namespace YARG.Core.Song
                 value = default!;
                 return false;
             }
+
             value = images[BACKROUND_RNG.Next(images.Count)];
             return true;
         }
@@ -327,14 +366,17 @@ namespace YARG.Core.Song
             {
                 return DrumsType.FourLane;
             }
+
             if (parts.FiveLaneDrums.IsActive())
             {
                 return DrumsType.FiveLane;
             }
+
             return DrumsType.Unknown;
         }
 
-        private static ScanExpected<long> ParseDotChart<TChar>(ref YARGTextContainer<TChar> container, IniModifierCollection modifiers, ref AvailableParts parts, ref DrumsType drumsType)
+        private static ScanExpected<long> ParseDotChart<TChar>(ref YARGTextContainer<TChar> container,
+            IniModifierCollection modifiers, ref AvailableParts parts, ref DrumsType drumsType)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             if (drumsType != DrumsType.FiveLane && modifiers.Extract("pro_drums", out bool proDrums) && proDrums)
@@ -355,6 +397,7 @@ namespace YARG.Core.Song
                         return new ScanUnexpected(ScanResult.InvalidResolution);
                     }
                 }
+
                 modifiers.Union(chartMods);
             }
 
@@ -365,10 +408,12 @@ namespace YARG.Core.Song
                     YARGChartFileReader.SkipToNextTrack(ref container);
                 }
             }
+
             return resolution;
         }
 
-        private static ScanExpected<long> ParseDotMidi(FixedArray<byte> file, IniModifierCollection modifiers, ref AvailableParts parts, ref DrumsType drumsType)
+        private static ScanExpected<long> ParseDotMidi(FixedArray<byte> file, IniModifierCollection modifiers,
+            ref AvailableParts parts, ref DrumsType drumsType)
         {
             if (drumsType != DrumsType.FiveLane && (!modifiers.Extract("pro_drums", out bool proDrums) || proDrums))
             {
@@ -376,11 +421,13 @@ namespace YARG.Core.Song
                 drumsType |= DrumsType.ProDrums;
                 drumsType &= ~DrumsType.FourLane;
             }
+
             return ParseMidi(file, ref parts, ref drumsType);
         }
 
         /// <returns>Whether the track was fully traversed</returns>
-        private static unsafe bool TraverseChartTrack<TChar>(ref YARGTextContainer<TChar> container, ref AvailableParts parts, ref DrumsType drumsType)
+        private static bool TraverseChartTrack<TChar>(ref YARGTextContainer<TChar> container, ref AvailableParts parts,
+            ref DrumsType drumsType)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             if (!YARGChartFileReader.ValidateInstrument(ref container, out var instrument, out var difficulty))
@@ -390,23 +437,23 @@ namespace YARG.Core.Song
 
             return instrument switch
             {
-                Instrument.FiveFretGuitar     => ScanFiveFret(ref parts.FiveFretGuitar,               ref container, difficulty),
-                Instrument.FiveFretBass       => ScanFiveFret(ref parts.FiveFretBass,                 ref container, difficulty),
-                Instrument.FiveFretRhythm     => ScanFiveFret(ref parts.FiveFretRhythm,               ref container, difficulty),
-                Instrument.FiveFretCoopGuitar => ScanFiveFret(ref parts.FiveFretCoopGuitar,           ref container, difficulty),
-                Instrument.Keys               => ScanFiveFret(ref parts.Keys,                         ref container, difficulty),
-                Instrument.SixFretGuitar      => ScanSixFret (ref parts.SixFretGuitar,                ref container, difficulty),
-                Instrument.SixFretBass        => ScanSixFret (ref parts.SixFretBass,                  ref container, difficulty),
-                Instrument.SixFretRhythm      => ScanSixFret (ref parts.SixFretRhythm,                ref container, difficulty),
-                Instrument.SixFretCoopGuitar  => ScanSixFret (ref parts.SixFretCoopGuitar,            ref container, difficulty),
-                Instrument.FourLaneDrums      => ScanDrums   (ref parts.FourLaneDrums, ref drumsType, ref container, difficulty),
+                Instrument.FiveFretGuitar     => ScanFiveFret(ref parts.FiveFretGuitar, ref container, difficulty),
+                Instrument.FiveFretBass       => ScanFiveFret(ref parts.FiveFretBass, ref container, difficulty),
+                Instrument.FiveFretRhythm     => ScanFiveFret(ref parts.FiveFretRhythm, ref container, difficulty),
+                Instrument.FiveFretCoopGuitar => ScanFiveFret(ref parts.FiveFretCoopGuitar, ref container, difficulty),
+                Instrument.Keys               => ScanFiveFret(ref parts.Keys, ref container, difficulty),
+                Instrument.SixFretGuitar      => ScanSixFret(ref parts.SixFretGuitar, ref container, difficulty),
+                Instrument.SixFretBass        => ScanSixFret(ref parts.SixFretBass, ref container, difficulty),
+                Instrument.SixFretRhythm      => ScanSixFret(ref parts.SixFretRhythm, ref container, difficulty),
+                Instrument.SixFretCoopGuitar  => ScanSixFret(ref parts.SixFretCoopGuitar, ref container, difficulty),
+                Instrument.FourLaneDrums => ScanDrums(ref parts.FourLaneDrums, ref drumsType, ref container,
+                    difficulty),
                 _ => false,
             };
         }
 
-        private const int GUITAR_FIVEFRET_MAX = 5;
-        private const int OPEN_NOTE = 7;
-        private static bool ScanFiveFret<TChar>(ref PartValues part, ref YARGTextContainer<TChar> container, Difficulty difficulty)
+        private static bool ScanFiveFret<TChar>(ref PartValues part, ref YARGTextContainer<TChar> container,
+            Difficulty difficulty)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             if (part[difficulty])
@@ -428,10 +475,12 @@ namespace YARG.Core.Song
                     }
                 }
             }
+
             return true;
         }
 
-        private static bool ScanSixFret<TChar>(ref PartValues part, ref YARGTextContainer<TChar> container, Difficulty difficulty)
+        private static bool ScanSixFret<TChar>(ref PartValues part, ref YARGTextContainer<TChar> container,
+            Difficulty difficulty)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             const int SIX_FRET_BLACK1 = 8;
@@ -454,17 +503,19 @@ namespace YARG.Core.Song
                     }
                 }
             }
+
             return true;
         }
 
-        private static bool ScanDrums<TChar>(ref PartValues part, ref DrumsType drumsType, ref YARGTextContainer<TChar> container, Difficulty difficulty)
+        private static bool ScanDrums<TChar>(ref PartValues part, ref DrumsType drumsType,
+            ref YARGTextContainer<TChar> container, Difficulty difficulty)
             where TChar : unmanaged, IEquatable<TChar>, IConvertible
         {
             const int YELLOW_CYMBAL = 66;
             const int GREEN_CYMBAL = 68;
             const int DOUBLE_BASS_MODIFIER = 32;
 
-            var diff_mask = (DifficultyMask)(1 << (int)difficulty);
+            var diff_mask = (DifficultyMask) (1 << (int) difficulty);
             // No point in scan a difficulty that already exists
             if ((part.Difficulties & diff_mask) > DifficultyMask.None)
             {
@@ -513,12 +564,14 @@ namespace YARG.Core.Song
                     }
 
                     //  Testing against zero would not work in expert
-                    if ((part.Difficulties & requiredMask) == requiredMask && drumsType is DrumsType.ProDrums or DrumsType.FiveLane)
+                    if ((part.Difficulties & requiredMask) == requiredMask &&
+                        drumsType is DrumsType.ProDrums or DrumsType.FiveLane)
                     {
                         return false;
                     }
                 }
             }
+
             return true;
         }
 
@@ -543,8 +596,8 @@ namespace YARG.Core.Song
 
             if (loader.GetMetadata("GAP") is string gapStr &&
                 double.TryParse(gapStr,
-                    System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
                     out double gapMs))
             {
                 entry._metadata.SongOffset = 0;
@@ -552,8 +605,8 @@ namespace YARG.Core.Song
 
             if (loader.GetMetadata("PREVIEWSTART") is string previewStr &&
                 double.TryParse(previewStr,
-                    System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
                     out double previewMs))
             {
                 entry._metadata.Preview.Start = (long) previewMs;
@@ -593,6 +646,71 @@ namespace YARG.Core.Song
             return ScanResult.Success;
         }
 
+        private static ScanResult ScanSingStar(IniSubEntry entry, FixedArray<byte> file)
+        {
+            var loader = new SingStarLoader(file);
+
+            // fallbacks to XML comments (.ini main source)
+            if (string.IsNullOrWhiteSpace(entry._metadata.Name))
+            {
+                string? title = loader.GetMetadata("TITLE");
+                if (string.IsNullOrWhiteSpace(title))
+                    return ScanResult.NoName;
+                entry._metadata.Name = title;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry._metadata.Artist) ||
+                entry._metadata.Artist == SongMetadata.DEFAULT_ARTIST)
+            {
+                string? artist = loader.GetMetadata("ARTIST");
+                if (!string.IsNullOrWhiteSpace(artist))
+                    entry._metadata.Artist = artist;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry._metadata.Genre))
+            {
+                entry._metadata.Genre = loader.GetMetadata("GENRE") ?? string.Empty;
+            }
+
+            if (string.IsNullOrWhiteSpace(entry._metadata.Year) ||
+                entry._metadata.Year == SongMetadata.DEFAULT_YEAR)
+            {
+                entry._metadata.Year = loader.GetMetadata("YEAR") ?? SongMetadata.DEFAULT_YEAR;
+            }
+
+            // Vocals parts
+            entry._parts.LeadVocals.Difficulties = DifficultyMask.None;
+            entry._parts.HarmonyVocals.Difficulties = DifficultyMask.None;
+
+            entry._parts.LeadVocals.SubTracks = 1;
+            entry._parts.LeadVocals.ActivateDifficulty(Difficulty.Expert);
+            entry._parts.LeadVocals.Intensity = 0;
+
+            if (loader.GetMetadata("PARTS") == "2")
+            {
+                entry._parts.HarmonyVocals.SubTracks = 2;
+                entry._parts.HarmonyVocals.Intensity = 0;
+                entry._parts.HarmonyVocals.ActivateDifficulty(Difficulty.Expert);
+            }
+            else
+            {
+                entry._parts.HarmonyVocals.SubTracks = 0;
+            }
+
+            entry._hash = HashWrapper.Hash(file.ReadOnlySpan);
+            (entry._parsedYear, entry._yearAsNumber) = ParseYear(entry._metadata.Year);
+            entry.SetSortStrings();
+
+            if (entry._metadata.SongLength <= 0)
+            {
+                using var mixer = entry.LoadAudio(0, 0);
+                if (mixer != null)
+                    entry._metadata.SongLength = (long) (mixer.Length * SongMetadata.MILLISECOND_FACTOR);
+            }
+
+            return ScanResult.Success;
+        }
+
         private static void SetIntensities(IniModifierCollection modifiers, ref AvailableParts parts)
         {
             if (modifiers.Extract("diff_band", out int intensity))
@@ -606,12 +724,14 @@ namespace YARG.Core.Song
 
             if (modifiers.Extract("diff_guitar", out intensity))
             {
-                parts.ProGuitar_22Fret.Intensity = parts.ProGuitar_17Fret.Intensity = parts.FiveFretGuitar.Intensity = (sbyte) intensity;
+                parts.ProGuitar_22Fret.Intensity = parts.ProGuitar_17Fret.Intensity =
+                    parts.FiveFretGuitar.Intensity = (sbyte) intensity;
             }
 
             if (modifiers.Extract("diff_bass", out intensity))
             {
-                parts.ProBass_22Fret.Intensity = parts.ProBass_17Fret.Intensity = parts.FiveFretBass.Intensity = (sbyte) intensity;
+                parts.ProBass_22Fret.Intensity =
+                    parts.ProBass_17Fret.Intensity = parts.FiveFretBass.Intensity = (sbyte) intensity;
             }
 
             if (modifiers.Extract("diff_rhythm", out intensity))
@@ -770,6 +890,7 @@ namespace YARG.Core.Song
                     {
                         number = 10 * number + str[curr] - '0';
                     }
+
                     ++curr;
                 }
 
@@ -778,6 +899,7 @@ namespace YARG.Core.Song
                     return (str[start..curr], number);
                 }
             }
+
             return (str, int.MaxValue);
         }
     }

--- a/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
@@ -9,6 +9,7 @@ using YARG.Core.Chart.Loaders.UltraStar;
 using YARG.Core.Extensions;
 using YARG.Core.IO;
 using YARG.Core.IO.Ini;
+using YARG.Core.Logging;
 
 namespace YARG.Core.Song
 {
@@ -29,7 +30,7 @@ namespace YARG.Core.Song
             "drums_2",
             "drums_3",
             "drums_4",
-            "crowd",
+            "crowd"
         };
         public static readonly string[] SupportedFormats =
         {
@@ -63,13 +64,33 @@ namespace YARG.Core.Song
             ("notes.midi", ChartFormat.Midi),
             ("notes.chart", ChartFormat.Chart),
             ("notes.txt", ChartFormat.UltraStar),
+            ("notes.xml", ChartFormat.SingStar),
             ("vocals.xml", ChartFormat.SingStar),
+            ("melody_1.xml", ChartFormat.SingStar),
+            ("melody_2.xml", ChartFormat.SingStar),
+            ("melody_3.xml", ChartFormat.SingStar),
+            ("melody_4.xml", ChartFormat.SingStar),
+            ("melody_5.xml", ChartFormat.SingStar),
+            ("melody_6.xml", ChartFormat.SingStar),
         };
 
-        protected static readonly string[]    ALBUMART_FILES;
-        protected static readonly string[]    PREVIEW_FILES;
-        protected readonly        ChartFormat _chartFormat;
-        protected readonly        DateTime    _chartLastWrite;
+        protected static int FindChartFileTypeIndex(ChartFormat format)
+        {
+            for (int i = 0; i < CHART_FILE_TYPES.Length; i++)
+            {
+                if (CHART_FILE_TYPES[i].Format == format)
+                {
+                    return i;
+                }
+            }
+            return 0; // fallback
+        }
+        
+    protected static readonly string[]    ALBUMART_FILES;
+    protected static readonly string[]    PREVIEW_FILES;
+    protected readonly        ChartFormat _chartFormat;
+    protected readonly        DateTime    _chartLastWrite;
+    protected readonly        int         _chartFileTypeIndex;
 
         protected readonly string _location;
         protected          string _background = string.Empty;
@@ -91,11 +112,12 @@ namespace YARG.Core.Song
             }
         }
 
-        protected IniSubEntry(string location, in DateTime chartLastWrite, ChartFormat chartFormat)
+        protected IniSubEntry(string location, in DateTime chartLastWrite, ChartFormat chartFormat, int chartFileTypeIndex)
         {
             _location = location;
             _chartLastWrite = chartLastWrite;
             _chartFormat = chartFormat;
+            _chartFileTypeIndex = chartFileTypeIndex;
         }
 
         public override string SortBasedLocation => _location;
@@ -114,7 +136,7 @@ namespace YARG.Core.Song
 
         public override SongChart? LoadChart()
         {
-            using var data = GetChartData(CHART_FILE_TYPES[(int) _chartFormat].Filename);
+            using var data = GetChartData(CHART_FILE_TYPES[_chartFileTypeIndex].Filename);
 
             if (data == null)
             {
@@ -651,7 +673,7 @@ namespace YARG.Core.Song
             var loader = new SingStarLoader(file);
 
             // fallbacks to XML comments (.ini main source)
-            if (string.IsNullOrWhiteSpace(entry._metadata.Name))
+            if (string.IsNullOrWhiteSpace(entry._metadata.Name) || entry._metadata.Name == SongMetadata.DEFAULT_NAME)
             {
                 string? title = loader.GetMetadata("TITLE");
                 if (string.IsNullOrWhiteSpace(title))
@@ -659,8 +681,7 @@ namespace YARG.Core.Song
                 entry._metadata.Name = title;
             }
 
-            if (string.IsNullOrWhiteSpace(entry._metadata.Artist) ||
-                entry._metadata.Artist == SongMetadata.DEFAULT_ARTIST)
+            if (string.IsNullOrWhiteSpace(entry._metadata.Artist) || entry._metadata.Name == SongMetadata.DEFAULT_ARTIST)
             {
                 string? artist = loader.GetMetadata("ARTIST");
                 if (!string.IsNullOrWhiteSpace(artist))

--- a/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs
@@ -681,7 +681,7 @@ namespace YARG.Core.Song
                 entry._metadata.Name = title;
             }
 
-            if (string.IsNullOrWhiteSpace(entry._metadata.Artist) || entry._metadata.Name == SongMetadata.DEFAULT_ARTIST)
+            if (string.IsNullOrWhiteSpace(entry._metadata.Artist) || entry._metadata.Artist == SongMetadata.DEFAULT_ARTIST)
             {
                 string? artist = loader.GetMetadata("ARTIST");
                 if (!string.IsNullOrWhiteSpace(artist))

--- a/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.Sng.cs
@@ -240,15 +240,16 @@ namespace YARG.Core.Song
             return mixer;
         }
 
-        private SngEntry(uint version, string location, in DateTime lastWrite, ChartFormat format)
-            : base(location, in lastWrite, format)
+        private SngEntry(uint version, string location, in DateTime lastWrite, ChartFormat format, int chartFileTypeIndex)
+            : base(location, in lastWrite, format, chartFileTypeIndex)
         {
             _version = version;
         }
 
-        public static ScanExpected<SngEntry> ProcessNewEntry(in SngFile sng, in SngFileListing listing, FileInfo info, ChartFormat format, string defaultPlaylist)
+        public static ScanExpected<SngEntry> ProcessNewEntry(in SngFile sng, in SngFileListing listing, FileInfo info, int chartFileTypeIndex, string defaultPlaylist)
         {
-            var entry = new SngEntry(sng.Version, info.FullName, AbridgedFileInfo.NormalizedLastWrite(info), format);
+            var format = CHART_FILE_TYPES[chartFileTypeIndex].Format;
+            var entry = new SngEntry(sng.Version, info.FullName, AbridgedFileInfo.NormalizedLastWrite(info), format, chartFileTypeIndex);
             entry._metadata.Playlist = defaultPlaylist;
 
             using var file = sng.LoadAllBytes(in listing);
@@ -272,8 +273,9 @@ namespace YARG.Core.Song
                 return null;
             }
 
-            var format = CHART_FILE_TYPES[stream.ReadByte()].Format;
-            var entry = new SngEntry(version, location, in lastWrite, format);
+            int chartFileTypeIndex = stream.ReadByte();
+            var format = CHART_FILE_TYPES[chartFileTypeIndex].Format;
+            var entry = new SngEntry(version, location, in lastWrite, format, chartFileTypeIndex);
             entry.Deserialize(ref stream, strings);
             return entry;
         }
@@ -284,8 +286,9 @@ namespace YARG.Core.Song
             string location = Path.Combine(baseDirectory, relative);
             var lastWrite = DateTime.FromBinary(stream.Read<long>(Endianness.Little));
             uint version = stream.Read<uint>(Endianness.Little);
-            var format = CHART_FILE_TYPES[stream.ReadByte()].Format;
-            var entry = new SngEntry(version, location, in lastWrite, format);
+            int chartFileTypeIndex = stream.ReadByte();
+            var format = CHART_FILE_TYPES[chartFileTypeIndex].Format;
+            var entry = new SngEntry(version, location, in lastWrite, format, chartFileTypeIndex);
             entry.Deserialize(ref stream, strings);
             return entry;
         }

--- a/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
@@ -20,7 +20,7 @@ namespace YARG.Core.Song
 
         internal override void Serialize(MemoryStream stream, CacheWriteIndices node)
         {
-            stream.WriteByte((byte) _chartFormat);
+            stream.WriteByte((byte) _chartFileTypeIndex);
             stream.Write(_chartLastWrite.ToBinary(), Endianness.Little);
             stream.Write(_iniLastWrite.HasValue);
             if (_iniLastWrite.HasValue)
@@ -201,13 +201,13 @@ namespace YARG.Core.Song
             return files;
         }
 
-        private UnpackedIniEntry(string directory, in DateTime chartLastWrite, in DateTime? iniLastWrite, in ChartFormat format)
-            : base(directory, in chartLastWrite, format)
+        private UnpackedIniEntry(string directory, in DateTime chartLastWrite, in DateTime? iniLastWrite, in ChartFormat format, int chartFileTypeIndex)
+            : base(directory, in chartLastWrite, format, chartFileTypeIndex)
         {
             _iniLastWrite = iniLastWrite;
         }
 
-        public static ScanExpected<UnpackedIniEntry> ProcessNewEntry(string directory, FileInfo chartInfo, ChartFormat format, FileInfo? iniFile, string defaultPlaylist)
+        public static ScanExpected<UnpackedIniEntry> ProcessNewEntry(string directory, FileInfo chartInfo, int chartFileTypeIndex, FileInfo? iniFile, string defaultPlaylist)
         {
             IniModifierCollection iniModifiers;
             DateTime? iniLastWrite = default;
@@ -221,7 +221,8 @@ namespace YARG.Core.Song
                 iniModifiers = new();
             }
 
-            var entry = new UnpackedIniEntry(directory, AbridgedFileInfo.NormalizedLastWrite(chartInfo), in iniLastWrite, format);
+            var format = CHART_FILE_TYPES[chartFileTypeIndex].Format;
+            var entry = new UnpackedIniEntry(directory, AbridgedFileInfo.NormalizedLastWrite(chartInfo), in iniLastWrite, format, chartFileTypeIndex);
             entry._metadata.Playlist = defaultPlaylist;
 
             using var file = FixedArray.LoadFile(chartInfo.FullName);
@@ -233,7 +234,8 @@ namespace YARG.Core.Song
         public static UnpackedIniEntry? TryDeserialize(string baseDirectory, ref FixedArrayStream stream, CacheReadStrings strings)
         {
             string directory = Path.Combine(baseDirectory, stream.ReadString());
-            ref readonly var chart = ref CHART_FILE_TYPES[stream.ReadByte()];
+            int chartFileTypeIndex = stream.ReadByte();
+            ref readonly var chart = ref CHART_FILE_TYPES[chartFileTypeIndex];
             var chartLastWrite = DateTime.FromBinary(stream.Read<long>(Endianness.Little));
             if (!AbridgedFileInfo.Validate(Path.Combine(directory, chart.Filename), chartLastWrite))
             {
@@ -255,7 +257,7 @@ namespace YARG.Core.Song
                 return null;
             }
 
-            var entry = new UnpackedIniEntry(directory, in chartLastWrite, in iniLastWrite, chart.Format);
+            var entry = new UnpackedIniEntry(directory, in chartLastWrite, in iniLastWrite, chart.Format, chartFileTypeIndex);
             entry.Deserialize(ref stream, strings);
             return entry;
         }
@@ -263,10 +265,11 @@ namespace YARG.Core.Song
         public static UnpackedIniEntry ForceDeserialize(string baseDirectory, ref FixedArrayStream stream, CacheReadStrings strings)
         {
             string directory = Path.Combine(baseDirectory, stream.ReadString());
-            ref readonly var chart = ref CHART_FILE_TYPES[stream.ReadByte()];
+            int chartFileTypeIndex = stream.ReadByte();
+            ref readonly var chart = ref CHART_FILE_TYPES[chartFileTypeIndex];
             var chartLastWrite = DateTime.FromBinary(stream.Read<long>(Endianness.Little));
             DateTime? iniLastWrite = stream.ReadBoolean() ? DateTime.FromBinary(stream.Read<long>(Endianness.Little)) : default;
-            var entry = new UnpackedIniEntry(directory, in chartLastWrite, in iniLastWrite, chart.Format);
+            var entry = new UnpackedIniEntry(directory, in chartLastWrite, in iniLastWrite, chart.Format, chartFileTypeIndex);
             entry.Deserialize(ref stream, strings);
             return entry;
         }

--- a/YARG.Core/Song/Entries/SongEnums.cs
+++ b/YARG.Core/Song/Entries/SongEnums.cs
@@ -5,7 +5,8 @@
         Mid,
         Midi,
         Chart,
-        UltraStar
+        UltraStar,
+        SingStar
     };
 
     public enum EntryType


### PR DESCRIPTION
Implements support for loading vocals from SingStar `.xml` chart files

## Features
- Full XML parsing for SingStar `.xml` vocal chart files
- Support for Version 1 (single player) and Version 2+ (duet/multi-player) formats
- Support for XML Version 4
- Parses note data: MIDI pitch, duration, lyrics, and bonus notes
- Handles phrase breaks for long rest notes (gap detection)
- Extracts metadata: Artist, Title, Genre, and Year from XML comments and attributes
- Parses the `Part` attribute from `<SENTENCE Part="Verse">` elements
- Creates `Section` objects when the `Part` changes between sentences
- Sections are sorted and deduplicated when copying to `MoonSong` for duet compatibility
- Practice Mode displays real section names (Verse, Chorus, Bridge, etc.) instead of auto-generated percentage ranges
- Parses Player 1 and Player 2 tracks independently

## Testing
50 unit tests covering:
- Basic parsing
- Lyrics handling
- Star power phrases
- Duet support
- Section handling
- Sentence handling

## How to import SingStar charts
Place the following files in a song folder

| File | Notes |
|------|-------|
| `notes.xml` / `vocals.xml` / `melody_1.xml` - `melody_6.xml` | Vocal chart (required) |
| `song.` | Audio file in a supported format (required) |
| `song.ini` | Recommended provides difficulty and additional metadata |
| `album.jpg` | Album artwork (optional) |
| `video.mp4` | Background video (optional) |

> **Planned**: I intend to add support for using video.mp4 as the sole audio source in a future PR, removing the requirement for a separate audio file