### PR TITLE
Target dotnet 10.0 with the unit test and benchmark projects

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Restore
         run: dotnet restore YARG.Core.sln

--- a/YARG.Core.Benchmarks/YARG.Core.Benchmarks.csproj
+++ b/YARG.Core.Benchmarks/YARG.Core.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
@@ -11,7 +11,6 @@
     <Optimize>true</Optimize>
     <Configuration>Release</Configuration>
     <IsPackable>false</IsPackable>
-    <LangVersion>12</LangVersion>
     <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
 

--- a/YARG.Core.UnitTests/YARG.Core.UnitTests.csproj
+++ b/YARG.Core.UnitTests/YARG.Core.UnitTests.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I suspect this would make it easier for people to run the tests locally since they can just download the most recent version of dotnet.