### PR TITLE
﻿Fix unison phrase logic when starts are the same but ends are far apart

### DIFF
--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -135,7 +135,7 @@ namespace YARG.Core.Engine
 
             public bool EndTickAlmostEquals(StarPowerSection other, uint tolerance)
             {
-                return TickEnd - other.TickEnd <= tolerance || other.Tick - Tick <= tolerance;
+                return TickEnd - other.TickEnd <= tolerance || other.TickEnd - TickEnd <= tolerance;
             }
         }
 


### PR DESCRIPTION
An example is the first phrases on guitar and bass of Misirlou GH2. The starts are exactly the same while the ends are more than a beat apart, but they are currently unison phrases.