### PR TITLE
Fix natural HOPO state when HOPO follows a chord in the same lane

### DIFF
--- a/YARG.Core/MoonscraperChartParser/Events/MoonNote.cs
+++ b/YARG.Core/MoonscraperChartParser/Events/MoonNote.cs
@@ -278,7 +278,7 @@ namespace MoonscraperChartEditor.Song
             // Checking state in this order is important
             return !isChord &&
                 previous != null &&
-                (previous.isChord || rawNote != previous.rawNote) &&
+                (mask & previous.mask) == 0 &&
                 tick - previous.tick <= hopoThreshold;
         }
 


### PR DESCRIPTION
This fixes incorrect parser behaviour, that seems to only affect .chart, although in theory also applies to .mid, where notes that are within the hopo threshold, but are in the same lane as any of the chord frets, and incorrectly treated as hopos, where they should be strums. FWIW, both ChartForge and Moonscraper also have this incorrect behaviour.

See [issue 1 here](https://gist.github.com/elicwhite/27ffd91bb601446679bcab2869802620) and [paragraph 1 here](https://thenathannator.github.io/GuitarGame_ChartFormats/Chart-File-Formats/chart-format/Tracks/5-Fret-Guitar/#note-mechanics) for proof this is unintended.

This is done by just not caring if the previous note was a chord. We just check if the fret masks have no overlap, and if that is the case, it becomes a hopo, otherwise it does not.

Test chart:
[Test Chart 1.zip](https://github.com/user-attachments/files/26937652/Test.Chart.1.zip)
