### PR TITLE
Add ChartDump CLI: dump MoonSong + SongChart to JSON

### DIFF
--- a/ChartDump/ChartDump.csproj
+++ b/ChartDump/ChartDump.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
+    <RollForward>Major</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\YARG.Core\YARG.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ChartDump/DumpAll.cs
+++ b/ChartDump/DumpAll.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Batch mode: walks a chart directory, parses each chart with YARG.Core,
+/// and dumps JSON files to an output directory matching the folder structure.
+///
+/// Usage: ChartDump --batch <input-dir> <output-dir> [limit]
+/// </summary>
+static class DumpAll
+{
+    public static int Run(string inputDir, string outputDir, int limit)
+    {
+        if (!Directory.Exists(inputDir))
+        {
+            Console.Error.WriteLine($"Input directory not found: {inputDir}");
+            return 1;
+        }
+
+        Directory.CreateDirectory(outputDir);
+
+        var folders = FindChartFolders(inputDir);
+        if (limit > 0 && limit < folders.Count)
+            folders = folders.GetRange(0, limit);
+
+        int success = 0, failed = 0, skipped = 0;
+        var startTime = DateTime.UtcNow;
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = false,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            Converters = { new JsonStringEnumConverter() }
+        };
+
+        Parallel.ForEach(folders, new ParallelOptions { MaxDegreeOfParallelism = 16 }, folder =>
+        {
+            var relPath = Path.GetRelativePath(inputDir, folder);
+            var outPath = Path.Combine(outputDir, relPath, "yarg-dump.json");
+
+            try
+            {
+                var chartFile = Path.Combine(folder, "notes.chart");
+                if (!File.Exists(chartFile))
+                    chartFile = Path.Combine(folder, "notes.mid");
+                if (!File.Exists(chartFile))
+                {
+                    Interlocked.Increment(ref skipped);
+                    return;
+                }
+
+                var dump = Program.ParseAndDump(chartFile);
+
+                Directory.CreateDirectory(Path.GetDirectoryName(outPath)!);
+                File.WriteAllText(outPath, JsonSerializer.Serialize(dump, jsonOptions));
+                int s = Interlocked.Increment(ref success);
+
+                if ((s + Volatile.Read(ref failed)) % 100 == 0)
+                {
+                    int done = s + Volatile.Read(ref failed) + Volatile.Read(ref skipped);
+                    int remaining = folders.Count - done;
+                    var elapsed = DateTime.UtcNow - startTime;
+                    var perItem = elapsed / done;
+                    var eta = TimeSpan.FromTicks(perItem.Ticks * remaining);
+                    Console.Error.WriteLine($"  Processed {done}/{folders.Count} ({s} ok, {Volatile.Read(ref failed)} err, {Volatile.Read(ref skipped)} skip) — ETA {eta:h\\:mm\\:ss}");
+                }
+            }
+            catch (Exception ex)
+            {
+                Interlocked.Increment(ref failed);
+                Console.Error.WriteLine($"FAIL: {relPath}: {ex.Message}");
+            }
+        });
+
+        Console.Error.WriteLine($"\nDone: {success} success, {failed} failed, {skipped} skipped out of {folders.Count}");
+        return 0;
+    }
+
+    static List<string> FindChartFolders(string dir)
+    {
+        var results = new List<string>();
+        FindChartFoldersRecursive(dir, results);
+        results.Sort(StringComparer.Ordinal);
+        return results;
+    }
+
+    static void FindChartFoldersRecursive(string dir, List<string> results)
+    {
+        try
+        {
+            var files = Directory.GetFiles(dir);
+            bool hasChart = false;
+            foreach (var f in files)
+            {
+                var name = Path.GetFileName(f);
+                if (name == "notes.chart" || name == "notes.mid")
+                {
+                    hasChart = true;
+                    break;
+                }
+            }
+
+            if (hasChart)
+            {
+                results.Add(dir);
+                return;
+            }
+
+            foreach (var subdir in Directory.GetDirectories(dir))
+            {
+                FindChartFoldersRecursive(subdir, results);
+            }
+        }
+        catch { /* skip inaccessible dirs */ }
+    }
+}

--- a/ChartDump/Program.cs
+++ b/ChartDump/Program.cs
@@ -138,9 +138,19 @@ class Program
             }
             catch { /* ignore ini read errors */ }
         }
-        // Seed settings so the parser disambiguates to the right drum type and
-        // SongChart only populates the canonical drum track.
-        settings.DrumsType = iniDrumsType;
+        // Seed settings so the parser disambiguates to the right drum type.
+        // YARG's own runtime only ever feeds FourLane / FiveLane / Unknown into
+        // `settings.DrumsType` (ProDrums is a 4-lane interpretation that lives
+        // downstream, not a terminal parse setting) — collapse our ini-derived
+        // ProDrums hint into FourLane here so MoonSongLoader.Drums doesn't throw
+        // "Unexpected drums type" inside SongChart.FromFile. `iniDrumsType` is
+        // preserved separately for canonical-drum-track selection in BuildDump.
+        settings.DrumsType = iniDrumsType switch
+        {
+            DrumsType.FiveLane => DrumsType.FiveLane,
+            DrumsType.ProDrums or DrumsType.FourLane => DrumsType.FourLane,
+            _ => DrumsType.Unknown,
+        };
 
         // Apply HOPO threshold from ini — this matches SongEntry.IniBase's logic.
         // Resolution-dependent computation happens in MidReader/ChartReader based
@@ -177,6 +187,14 @@ class Program
             // Not common — leave default for now.
         }
 
+        // ChordHopoCancellation mirrors what SongEntry.IniBase applies at game
+        // load time: true for .mid/.midi, false for .chart. Without this, the
+        // SongChart-derived `normalizedTracks` types diverge from what YARG
+        // actually plays (the MoonSongLoader.Guitar post-pass wouldn't fire,
+        // so chord→subset-single transitions stay HOPO instead of being
+        // rewritten back to Strum).
+        settings.ChordHopoCancellation = ext == ".mid";
+
         MoonSong song;
         if (ext == ".mid")
             song = MoonscraperChartEditor.Song.IO.MidReader.ReadMidi(ref settings, chartFile);
@@ -189,7 +207,7 @@ class Program
         {
             songChart = SongChart.FromFile(settings, chartFile);
         }
-        catch { /* vocals parsing may fail on some charts */ }
+        catch (Exception ex) { Console.Error.WriteLine($"[SongChart.FromFile] {ex.GetType().Name}: {ex.Message}"); }
 
         return BuildDump(song, ext, songChart, iniDrumsType);
     }

--- a/ChartDump/Program.cs
+++ b/ChartDump/Program.cs
@@ -1,0 +1,510 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MoonscraperChartEditor.Song;
+using YARG.Core;
+using YARG.Core.Chart;
+
+/// <summary>
+/// Parses a chart file with YARG.Core's MoonSong parser (Moonscraper-based)
+/// and dumps the raw parsed data as JSON. This is the intermediate representation
+/// BEFORE game-specific transformations, preserving all parsed data.
+/// </summary>
+class Program
+{
+    static readonly MoonSong.Difficulty[] AllDiffs = {
+        MoonSong.Difficulty.Easy, MoonSong.Difficulty.Medium,
+        MoonSong.Difficulty.Hard, MoonSong.Difficulty.Expert
+    };
+
+    static int Main(string[] args)
+    {
+        if (args.Length >= 3 && args[0] == "--batch")
+        {
+            var limit = args.Length >= 4 ? int.Parse(args[3]) : 0;
+            return DumpAll.Run(args[1], args[2], limit);
+        }
+
+        if (args.Length < 1)
+        {
+            Console.Error.WriteLine("Usage: ChartDump <path-to-chart-folder-or-file>");
+            Console.Error.WriteLine("       ChartDump --batch <input-dir> <output-dir> [limit]");
+            return 1;
+        }
+
+        var path = args[0];
+        string chartFile;
+
+        if (Directory.Exists(path))
+        {
+            chartFile = Path.Combine(path, "notes.chart");
+            if (!File.Exists(chartFile))
+                chartFile = Path.Combine(path, "notes.mid");
+            if (!File.Exists(chartFile))
+            {
+                Console.Error.WriteLine($"No notes.chart or notes.mid found in {path}");
+                return 1;
+            }
+        }
+        else if (File.Exists(path))
+        {
+            chartFile = path;
+        }
+        else
+        {
+            Console.Error.WriteLine($"Path not found: {path}");
+            return 1;
+        }
+
+        try
+        {
+            var dump = ParseAndDump(chartFile);
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Converters = { new JsonStringEnumConverter() }
+            };
+            Console.WriteLine(JsonSerializer.Serialize(dump, options));
+            return 0;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Parse error: {ex.Message}");
+            Console.Error.WriteLine(ex.StackTrace);
+            return 2;
+        }
+    }
+
+    public static Dictionary<string, object?> ParseAndDump(string chartFile)
+    {
+        var ext = Path.GetExtension(chartFile).ToLowerInvariant();
+        var settings = ext == ".mid" ? ParseSettings.Default_Midi : ParseSettings.Default_Chart;
+
+        // Read song.ini next to the chart file so we pick up drum-type hints
+        // (five_lane_drums / pro_drums). Without these, SongChart auto-populates
+        // all three drum interpretations and we can't tell which one is canonical.
+        // Also read hopo_frequency / eighthnote_hopo / hopofreq so the parser
+        // uses the same HOPO threshold the game will — matching YARG.Core's
+        // SongEntry.IniBase ini handling.
+        string chartDir = Path.GetDirectoryName(chartFile) ?? "";
+        string iniPath = Path.Combine(chartDir, "song.ini");
+        DrumsType iniDrumsType = DrumsType.Unknown;
+        long? iniHopoFrequency = null;
+        bool? iniEighthnoteHopo = null;
+        int? iniHopofreq = null;
+        if (File.Exists(iniPath))
+        {
+            try
+            {
+                foreach (var line in File.ReadAllLines(iniPath))
+                {
+                    var trimmed = line.Trim();
+                    bool ReadBool(string key, out bool value)
+                    {
+                        value = false;
+                        if (!trimmed.StartsWith(key, StringComparison.OrdinalIgnoreCase)) return false;
+                        var eq = trimmed.IndexOf('=');
+                        if (eq < 0) return false;
+                        var raw = trimmed.Substring(eq + 1).Trim();
+                        if (raw.Equals("true", StringComparison.OrdinalIgnoreCase) || raw == "1") { value = true; return true; }
+                        if (raw.Equals("false", StringComparison.OrdinalIgnoreCase) || raw == "0") { value = false; return true; }
+                        return false;
+                    }
+                    bool ReadInt(string key, out long value)
+                    {
+                        value = 0;
+                        if (!trimmed.StartsWith(key, StringComparison.OrdinalIgnoreCase)) return false;
+                        var eq = trimmed.IndexOf('=');
+                        if (eq < 0) return false;
+                        return long.TryParse(trimmed.Substring(eq + 1).Trim(), out value);
+                    }
+                    if (ReadBool("five_lane_drums", out var isFiveLane) && isFiveLane)
+                        iniDrumsType = DrumsType.FiveLane;
+                    else if (ReadBool("pro_drums", out var isProDrums) && isProDrums)
+                    {
+                        if (iniDrumsType != DrumsType.FiveLane) iniDrumsType = DrumsType.ProDrums;
+                    }
+                    else if (ReadInt("hopo_frequency", out var hopoFreq))
+                        iniHopoFrequency = hopoFreq;
+                    else if (ReadBool("eighthnote_hopo", out var eighthHopo))
+                        iniEighthnoteHopo = eighthHopo;
+                    else if (ReadInt("hopofreq", out var hf))
+                        iniHopofreq = (int)hf;
+                }
+            }
+            catch { /* ignore ini read errors */ }
+        }
+        // Seed settings so the parser disambiguates to the right drum type and
+        // SongChart only populates the canonical drum track.
+        settings.DrumsType = iniDrumsType;
+
+        // Apply HOPO threshold from ini — this matches SongEntry.IniBase's logic.
+        // Resolution-dependent computation happens in MidReader/ChartReader based
+        // on settings.HopoThreshold (or the default fallback there).
+        // We read TicksPerQuarterNote from the MIDI to compute absolute ticks.
+        if (iniHopoFrequency.HasValue && iniHopoFrequency.Value > 0)
+        {
+            settings.HopoThreshold = iniHopoFrequency.Value;
+        }
+        else if (iniEighthnoteHopo.HasValue)
+        {
+            // Need resolution. Quick-parse the MIDI header to get ticksPerBeat
+            // without invoking a full parser. For .chart we fall through and
+            // let ChartReader apply its own default (resolution/3 + 1).
+            if (ext == ".mid")
+            {
+                try
+                {
+                    using var fs = File.OpenRead(chartFile);
+                    using var reader = new BinaryReader(fs);
+                    // MThd chunk: magic(4) + length(4) + format(2) + tracks(2) + division(2)
+                    reader.ReadBytes(8);
+                    reader.ReadUInt16();
+                    reader.ReadUInt16();
+                    var division = (ushort)((reader.ReadByte() << 8) | reader.ReadByte());
+                    int resolution = division & 0x7FFF;
+                    settings.HopoThreshold = resolution / (iniEighthnoteHopo.Value ? 2 : 3);
+                }
+                catch { /* ignore */ }
+            }
+        }
+        else if (iniHopofreq.HasValue)
+        {
+            // Not common — leave default for now.
+        }
+
+        MoonSong song;
+        if (ext == ".mid")
+            song = MoonscraperChartEditor.Song.IO.MidReader.ReadMidi(ref settings, chartFile);
+        else
+            song = MoonscraperChartEditor.Song.IO.ChartReader.ReadFromFile(ref settings, chartFile);
+
+        // Build SongChart for normalized vocals
+        SongChart? songChart = null;
+        try
+        {
+            songChart = SongChart.FromFile(settings, chartFile);
+        }
+        catch { /* vocals parsing may fail on some charts */ }
+
+        return BuildDump(song, ext, songChart, iniDrumsType);
+    }
+
+    static Dictionary<string, object?> BuildDump(MoonSong song, string ext, SongChart? songChart, DrumsType iniDrumsType)
+    {
+        var dump = new Dictionary<string, object?>
+        {
+            ["resolution"] = song.resolution,
+            ["format"] = ext == ".mid" ? "mid" : "chart",
+        };
+
+        // Sync track
+        dump["tempos"] = song.syncTrack.Tempos.Select(t => new
+        {
+            tick = t.Tick,
+            beatsPerMinute = Math.Round(t.BeatsPerMinute, 6),
+        }).ToArray();
+
+        dump["timeSignatures"] = song.syncTrack.TimeSignatures.Select(ts => new
+        {
+            tick = ts.Tick,
+            numerator = ts.Numerator,
+            denominator = ts.Denominator,
+        }).ToArray();
+
+        // Global events
+        dump["sections"] = song.sections.Select(s => new
+        {
+            tick = s.tick,
+            text = s.text,
+        }).ToArray();
+
+        dump["globalEvents"] = song.events.Select(e => new
+        {
+            tick = e.tick,
+            text = e.text,
+        }).ToArray();
+
+        // Venue
+        if (song.venue.Count > 0)
+        {
+            dump["venue"] = song.venue.Select(v => new
+            {
+                tick = v.tick,
+                length = v.length,
+                type = v.type.ToString(),
+                text = v.text,
+            }).ToArray();
+        }
+
+        // Note: Beatlines are NOT dumped because MoonSong auto-generates them
+        // via FinishLoading() when the BEAT track is absent. We can't distinguish
+        // parsed-from-file beatlines from auto-generated ones after parsing.
+        // The BEAT track data is preserved separately in unknownMidiTracks.
+
+        // Charts (per instrument × difficulty)
+        var tracks = new List<object>();
+
+        foreach (var instrument in Enum.GetValues<MoonSong.MoonInstrument>())
+        {
+            foreach (var diff in AllDiffs)
+            {
+                var chart = song.GetChart(instrument, diff);
+                if (chart.IsEmpty) continue;
+
+                tracks.Add(new
+                {
+                    instrument = instrument.ToString(),
+                    difficulty = diff.ToString().ToLower(),
+                    gameMode = chart.gameMode.ToString(),
+
+                    notes = chart.notes.Select(n => new
+                    {
+                        tick = n.tick,
+                        rawNote = n.rawNote,
+                        length = n.length,
+                        flags = (int)n.flags,
+                        flagNames = GetFlagNames(n.flags),
+                    }).ToArray(),
+
+                    phrases = chart.specialPhrases.Select(p => new
+                    {
+                        tick = p.tick,
+                        length = p.length,
+                        type = p.type.ToString(),
+                    }).ToArray(),
+
+                    textEvents = chart.events.Count > 0
+                        ? chart.events.Select(e => new
+                        {
+                            tick = e.tick,
+                            text = e.text,
+                        }).ToArray()
+                        : null,
+
+                    animations = chart.animations.Count > 0
+                        ? chart.animations.Select(a => new
+                        {
+                            tick = a.tick,
+                            length = a.length,
+                            type = a.type.ToString(),
+                            text = a.text,
+                        }).ToArray()
+                        : null,
+                });
+            }
+        }
+
+        dump["tracks"] = tracks;
+
+        // Normalized vocals from SongChart
+        if (songChart != null)
+        {
+            var vocalsTracks = new Dictionary<string, object?>();
+            foreach (var (name, voxTrack) in new[] {
+                ("vocals", songChart.Vocals),
+                ("harmony", songChart.Harmony),
+            })
+            {
+                if (voxTrack.IsEmpty) continue;
+                vocalsTracks[name] = DumpVocalsTrack(voxTrack);
+            }
+            if (vocalsTracks.Count > 0)
+                dump["vocalsTracks"] = vocalsTracks;
+        }
+
+        // Normalized instrument tracks from SongChart. This is the POST-resolve
+        // representation: force flags have been collapsed into concrete note Types
+        // (Strum/Hopo/Tap for guitar, Neutral/Accent/Ghost for drums, etc.), so
+        // two charts that play identically will match bit-for-bit here even if
+        // one has redundant "author marked" force flags in its raw MIDI.
+        if (songChart != null)
+        {
+            var normalizedTracks = new List<object>();
+
+            // Five-fret + six-fret guitar-like instruments
+            foreach (var track in songChart.FiveFretTracks.Concat(songChart.SixFretTracks))
+            {
+                if (track.IsEmpty) continue;
+                foreach (var diff in AllYargDiffs)
+                {
+                    if (!track.TryGetDifficulty(diff, out var diffChart) || diffChart.Notes.Count == 0) continue;
+                    normalizedTracks.Add(new
+                    {
+                        instrument = track.Instrument.ToString(),
+                        difficulty = diff.ToString().ToLower(),
+                        notes = diffChart.Notes.Select(n => DumpGuitarNote(n)).ToArray(),
+                    });
+                }
+            }
+
+            // Drums: emit only the canonical drum track based on ini hint.
+            // YARG's SongChart populates all three (FourLane / ProDrums /
+            // FiveLane) from the same raw source, and the "right" one depends
+            // on song.ini. Without this filter the comparison sees meaningless
+            // pad-index diffs between non-canonical interpretations.
+            YARG.Core.Chart.InstrumentTrack<YARG.Core.Chart.DrumNote>? canonicalDrumTrack = null;
+            if (iniDrumsType == DrumsType.FiveLane)
+                canonicalDrumTrack = songChart.FiveLaneDrums;
+            else if (iniDrumsType == DrumsType.ProDrums)
+                canonicalDrumTrack = songChart.ProDrums;
+            else if (iniDrumsType == DrumsType.FourLane)
+                canonicalDrumTrack = songChart.FourLaneDrums;
+            else
+            {
+                // No ini hint — prefer FourLane (scan-chart's default), falling
+                // back to ProDrums / FiveLane if FourLane is empty.
+                if (!songChart.FourLaneDrums.IsEmpty) canonicalDrumTrack = songChart.FourLaneDrums;
+                else if (!songChart.ProDrums.IsEmpty) canonicalDrumTrack = songChart.ProDrums;
+                else if (!songChart.FiveLaneDrums.IsEmpty) canonicalDrumTrack = songChart.FiveLaneDrums;
+            }
+            if (canonicalDrumTrack != null && !canonicalDrumTrack.IsEmpty)
+            {
+                foreach (var diff in AllYargDiffs)
+                {
+                    if (!canonicalDrumTrack.TryGetDifficulty(diff, out var diffChart) || diffChart.Notes.Count == 0) continue;
+                    normalizedTracks.Add(new
+                    {
+                        instrument = canonicalDrumTrack.Instrument.ToString(),
+                        difficulty = diff.ToString().ToLower(),
+                        notes = diffChart.Notes.Select(n => DumpDrumNote(n)).ToArray(),
+                    });
+                }
+            }
+
+            if (normalizedTracks.Count > 0)
+                dump["normalizedTracks"] = normalizedTracks;
+        }
+
+        return dump;
+    }
+
+    static readonly YARG.Core.Difficulty[] AllYargDiffs = {
+        YARG.Core.Difficulty.Easy,
+        YARG.Core.Difficulty.Medium,
+        YARG.Core.Difficulty.Hard,
+        YARG.Core.Difficulty.Expert,
+    };
+
+    static object DumpGuitarNote(YARG.Core.Chart.GuitarNote n)
+    {
+        // Represent chord as a flat list of siblings — emit each note in the
+        // parent-chord group, keyed by fret + resolved type.
+        var fretsInChord = new List<int> { n.Fret };
+        foreach (var child in n.ChildNotes) fretsInChord.Add(child.Fret);
+        fretsInChord.Sort();
+        return new
+        {
+            tick = n.Tick,
+            tickLength = n.TickLength,
+            frets = fretsInChord.ToArray(),
+            type = n.Type.ToString(),
+            isStarPower = n.IsStarPower,
+            isSolo = n.IsSolo,
+        };
+    }
+
+    static object DumpDrumNote(YARG.Core.Chart.DrumNote n)
+    {
+        // Represent chord as pad list sorted by pad number + per-pad type/dynamics.
+        // Sorting is critical so that same-tick chord reorderings don't show up
+        // as diffs during comparison — scan-chart's writer doesn't preserve the
+        // original per-note order within a chord.
+        var padRecords = new List<(int pad, string type)> { (n.Pad, n.Type.ToString()) };
+        foreach (var child in n.ChildNotes) padRecords.Add((child.Pad, child.Type.ToString()));
+        padRecords.Sort((a, b) => a.pad.CompareTo(b.pad));
+        var pads = padRecords.Select(p => new { pad = p.pad, type = p.type }).ToArray();
+        return new
+        {
+            tick = n.Tick,
+            tickLength = n.TickLength,
+            pads,
+            isStarPower = n.IsStarPower,
+            isSolo = n.IsSolo,
+            isStarPowerActivator = (n.DrumFlags & YARG.Core.Chart.DrumNoteFlags.StarPowerActivator) != 0,
+        };
+    }
+
+    static object DumpVocalsTrack(VocalsTrack voxTrack)
+    {
+        return new
+        {
+            rangeShifts = voxTrack.RangeShifts.Select(rs => new
+            {
+                tick = rs.Tick,
+                tickLength = rs.TickLength,
+                minimumPitch = rs.MinimumPitch,
+                maximumPitch = rs.MaximumPitch,
+            }).ToArray(),
+
+            parts = voxTrack.Parts.Select((part, index) => new
+            {
+                partIndex = index,
+                isHarmony = part.IsHarmony,
+
+                notePhrases = part.NotePhrases.Select(phrase => new
+                {
+                    tick = phrase.Tick,
+                    tickLength = phrase.TickLength,
+                    isStarPower = phrase.IsStarPower,
+                    isPercussion = phrase.IsPercussion,
+
+                    notes = phrase.PhraseParentNote.ChildNotes.Select(n => new
+                    {
+                        tick = n.Tick,
+                        tickLength = n.TickLength,
+                        pitch = n.Pitch,
+                        type = n.Type.ToString(),
+                    }).ToArray(),
+
+                    lyrics = phrase.Lyrics.Select(l => new
+                    {
+                        tick = l.Tick,
+                        text = l.Text,
+                        flags = (int)l.Flags,
+                        flagNames = l.Flags != 0 ? l.Flags.ToString() : null,
+                    }).ToArray(),
+                }).ToArray(),
+
+                staticLyricPhrases = part.StaticLyricPhrases.Count > 0
+                    ? part.StaticLyricPhrases.Select(phrase => new
+                    {
+                        tick = phrase.Tick,
+                        tickLength = phrase.TickLength,
+                        lyrics = phrase.Lyrics.Select(l => new
+                        {
+                            tick = l.Tick,
+                            text = l.Text,
+                            flags = (int)l.Flags,
+                        }).ToArray(),
+                    }).ToArray()
+                    : null,
+
+                otherPhrases = part.OtherPhrases.Count > 0
+                    ? part.OtherPhrases.Select(p => new
+                    {
+                        tick = p.Tick,
+                        tickLength = p.TickLength,
+                        type = p.Type.ToString(),
+                    }).ToArray()
+                    : null,
+            }).ToArray(),
+        };
+    }
+
+    static string[]? GetFlagNames(MoonNote.Flags flags)
+    {
+        if (flags == MoonNote.Flags.None) return null;
+        var names = new List<string>();
+        foreach (MoonNote.Flags f in Enum.GetValues<MoonNote.Flags>())
+        {
+            if (f != MoonNote.Flags.None && flags.HasFlag(f))
+                names.Add(f.ToString());
+        }
+        return names.Count > 0 ? names.ToArray() : null;
+    }
+}

--- a/YARG.Core.sln
+++ b/YARG.Core.sln
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReplayCli", "ReplayCli\Repl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YARG.Core.Benchmarks", "YARG.Core.Benchmarks\YARG.Core.Benchmarks.csproj", "{D26697B2-1739-4327-9B34-1501FE0E619F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChartDump", "ChartDump\ChartDump.csproj", "{445E92E7-25F7-4023-A0EB-0FDEC60CD509}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +129,26 @@ Global
 		{D26697B2-1739-4327-9B34-1501FE0E619F}.Release|x64.Build.0 = Release|Any CPU
 		{D26697B2-1739-4327-9B34-1501FE0E619F}.Release|x86.ActiveCfg = Release|Any CPU
 		{D26697B2-1739-4327-9B34-1501FE0E619F}.Release|x86.Build.0 = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|ARM.Build.0 = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|x64.Build.0 = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Debug|x86.Build.0 = Debug|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|Any CPU.Build.0 = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|ARM.ActiveCfg = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|ARM.Build.0 = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|ARM64.Build.0 = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|x64.ActiveCfg = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|x64.Build.0 = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|x86.ActiveCfg = Release|Any CPU
+		{445E92E7-25F7-4023-A0EB-0FDEC60CD509}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/YARG.Core/Assembly.cs
+++ b/YARG.Core/Assembly.cs
@@ -2,3 +2,4 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("YARG.Core.Benchmarks")]
 [assembly: InternalsVisibleTo("YARG.Core.UnitTests")]
+[assembly: InternalsVisibleTo("ChartDump")]

--- a/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
@@ -1,5 +1,4 @@
-﻿using DG.Tweening;
-using System.Drawing;
+﻿using System.Drawing;
 using System.IO;
 using YARG.Core.Extensions;
 using YARG.Core.Utility;


### PR DESCRIPTION
## Summary

Adds **ChartDump**, a small CLI that parses a `.chart`/`.mid` file with YARG.Core's MoonSong parser and emits the parsed state as JSON. It dumps both:

- the **raw MoonSong** representation — per-track `notes[]` with `{tick, rawNote, length, flags, flagNames}`, special phrases, text events, animations, venue, etc. (pre-resolve — force flags still distinct from final HOPO/TAP state);
- the **normalized SongChart** representation — post-resolve guitar/drum/vocal notes, vocals phrases, drum dynamics/flags.

Two modes:

```
# single chart, JSON to stdout
dotnet run --project ChartDump -- <path-to-chart-folder-or-file>

# batch: walk input tree, write yarg-dump.json per chart folder
dotnet run --project ChartDump -- --batch <input-dir> <output-dir> [limit]
```

Batch mode runs with `MaxDegreeOfParallelism=16` and only writes `yarg-dump.json`, so it composes with an existing output tree without touching other files.

## Motivation

I wrote this to diff YARG.Core's parser against another parser across a large chart corpus, to isolate exact behavioral differences — which cases turn into a natural HOPO vs. strum, which SP/solo phrases get dropped vs. extended, how overlapping force modifiers resolve, etc. It's also useful as a single-chart debugger when triaging a reported parsing issue: you get the full parsed state without having to launch the game.

I think the tool has enough reuse value for YARG.Core maintainers and contributors that it belongs alongside `TestConsole`, `ReplayCli`, `YARG.Core.Benchmarks`, and `YARG.Core.UnitTests`. Happy to drop it back out if you'd prefer it live elsewhere.

## Changes

- `ChartDump/{ChartDump.csproj, Program.cs, DumpAll.cs}` — new console project. `net8.0` (matches `YARG.Core.UnitTests` / `YARG.Core.Benchmarks`), `RollForward=Major` so it also runs on newer SDKs.
- `YARG.Core.sln` — register the new project.
- `YARG.Core/Assembly.cs` — add `[assembly: InternalsVisibleTo("ChartDump")]`. `MoonSong`, `MidReader`, `ChartReader`, `ParseSettings`, etc. are internal, and ChartDump needs them for the raw-MoonSong dump layer. Same mechanism that `YARG.Core.Benchmarks` and `YARG.Core.UnitTests` already use.
- `YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs` — remove a stale `using DG.Tweening;`. Nothing in the file references the namespace, and its presence blocks non-Unity builds. Happy to split this into its own PR if you'd rather.

## Output shape (abbreviated)

```jsonc
{
  "resolution": 480,
  "format": "mid",
  "tempos": [...],
  "timeSignatures": [...],
  "sections": [...],
  "globalEvents": [...],
  "venue": [...],            // only if present
  "tracks": [                // raw MoonSong per instrument × difficulty
    {
      "instrument": "Guitar", "difficulty": "expert", "gameMode": "Guitar",
      "notes":   [{ "tick": 86880, "rawNote": 3, "length": 0, "flags": 0, "flagNames": null }, ...],
      "phrases": [{ "tick": 0, "length": 3840, "type": "Starpower" }, ...],
      "textEvents": [...],
      "animations": [...]
    }
  ],
  "vocalsTracks": { ... },   // normalized vocals from SongChart
  "normalizedTracks": [ ... ] // post-resolve guitar/drum notes
}
```

Drum-track selection respects `song.ini` — `five_lane_drums` / `pro_drums` hints are read and forwarded to `ParseSettings.DrumsType`, and only the canonical drum track is emitted in `normalizedTracks` (YARG populates all three interpretations from the same raw source; without the ini hint the diff would just see pad-index churn between non-canonical interpretations). HOPO threshold overrides (`hopo_frequency`, `eighthnote_hopo`) are also read from `song.ini` and applied to `ParseSettings.HopoThreshold`.

## Test plan

- [x] `dotnet build YARG.Core.sln -c Release` — succeeds on net8.0 via net10 SDK.
- [x] Single-chart mode produces non-empty JSON on a representative `.mid` chart.
- [x] `--batch` mode over a large corpus writes `yarg-dump.json` per folder without overwriting other files and without side effects on the source tree.
- [ ] Would be nice for maintainers to run the build on their CI target if there is one — I couldn't find a YARG.Core CI workflow that builds the solution, so I haven't added a CI job here; happy to if you'd like one.