### PR TITLE
Fix/tom lanes

### DIFF
--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -907,24 +907,23 @@ namespace MoonscraperChartEditor.Song.IO
             if (endTick > startTick)
                 --endTick;
 
-            long noteSnapThreshold = eventProcessParams.settings.NoteSnapThreshold;
-
             // Delay the actual processing once all the notes are actually in
             eventProcessParams.forcingProcessList.Add((ref EventProcessParams processParams) =>
             {
-                ProcessNoteOnEventAsFlagTogglePostDelay(ref processParams, startTick, endTick, flags, individualNoteSpecifier, noteSnapThreshold);
+                ProcessNoteOnEventAsFlagTogglePostDelay(ref processParams, startTick, endTick, flags, individualNoteSpecifier);
             });
         }
 
-        private static void ProcessNoteOnEventAsFlagTogglePostDelay(ref EventProcessParams eventProcessParams, uint startTick, uint endTick, MoonNote.Flags flags, int individualNoteSpecifier, long noteSnapThreshold = 0)   // individualNoteSpecifier as -1 to apply to the whole chord
+        private static void ProcessNoteOnEventAsFlagTogglePostDelay(ref EventProcessParams eventProcessParams, uint startTick, uint endTick, MoonNote.Flags flags, int individualNoteSpecifier)   // individualNoteSpecifier as -1 to apply to the whole chord
         {
             var song = eventProcessParams.song;
             var instrument = eventProcessParams.instrument;
 
             // Extend the lookup window backward to catch notes whose note-off would have overlapped
             // the marker start before note lengths were zeroed out during parsing.
-            uint lookbackStart = noteSnapThreshold > 0 && startTick >= (uint)noteSnapThreshold
-                ? startTick - (uint)noteSnapThreshold
+            uint noteSnapThreshold = (uint)eventProcessParams.settings.NoteSnapThreshold;
+            uint lookbackStart = noteSnapThreshold > 0 && startTick >= noteSnapThreshold
+                ? startTick - noteSnapThreshold
                 : startTick;
 
             foreach (var difficulty in EnumExtensions<MoonSong.Difficulty>.Values)

--- a/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
+++ b/YARG.Core/MoonscraperChartParser/IO/Midi/MidReader.cs
@@ -907,23 +907,31 @@ namespace MoonscraperChartEditor.Song.IO
             if (endTick > startTick)
                 --endTick;
 
+            long noteSnapThreshold = eventProcessParams.settings.NoteSnapThreshold;
+
             // Delay the actual processing once all the notes are actually in
             eventProcessParams.forcingProcessList.Add((ref EventProcessParams processParams) =>
             {
-                ProcessNoteOnEventAsFlagTogglePostDelay(ref processParams, startTick, endTick, flags, individualNoteSpecifier);
+                ProcessNoteOnEventAsFlagTogglePostDelay(ref processParams, startTick, endTick, flags, individualNoteSpecifier, noteSnapThreshold);
             });
         }
 
-        private static void ProcessNoteOnEventAsFlagTogglePostDelay(ref EventProcessParams eventProcessParams, uint startTick, uint endTick, MoonNote.Flags flags, int individualNoteSpecifier)   // individualNoteSpecifier as -1 to apply to the whole chord
+        private static void ProcessNoteOnEventAsFlagTogglePostDelay(ref EventProcessParams eventProcessParams, uint startTick, uint endTick, MoonNote.Flags flags, int individualNoteSpecifier, long noteSnapThreshold = 0)   // individualNoteSpecifier as -1 to apply to the whole chord
         {
             var song = eventProcessParams.song;
             var instrument = eventProcessParams.instrument;
+
+            // Extend the lookup window backward to catch notes whose note-off would have overlapped
+            // the marker start before note lengths were zeroed out during parsing.
+            uint lookbackStart = noteSnapThreshold > 0 && startTick >= (uint)noteSnapThreshold
+                ? startTick - (uint)noteSnapThreshold
+                : startTick;
 
             foreach (var difficulty in EnumExtensions<MoonSong.Difficulty>.Values)
             {
                 var chart = song.GetChart(instrument, difficulty);
 
-                MoonObjectHelper.GetRange(chart.notes, startTick, endTick, out int index, out int length);
+                MoonObjectHelper.GetRange(chart.notes, lookbackStart, endTick, out int index, out int length);
 
                 for (int i = index; i < index + length; ++i)
                 {

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -156,7 +156,8 @@ namespace YARG.Core.Song
                 StarPowerNote = _settings.OverdiveMidiNote,
                 TuningOffsetCents = _settings.TuningOffsetCents,
                 DrumsType = DrumsType.FourLane,
-                ChordHopoCancellation = true
+                ChordHopoCancellation = true,
+                NoteSnapThreshold = NOTE_SNAP_THRESHOLD
             };
             return SongChart.FromMidi(in parseSettings, midi);
         }


### PR DESCRIPTION
Second attempt. YARG cuts notes below `SustainCutoffThreshold` down to zero-length, which includes basically all drum notes, so drum notes that are authored just before tom markers (notes 110, 111, 112) begin would be skipped, even when the original engine would include them, because RB would catch note-off events under the tom marker and use that to include the note. (Seems like "any overlap" == tom)
I noticed that in `ParsingProperties.cs` There is a comment about `NoteSnapThreshold` that says:
```csharp
/// <summary>
/// The tick threshold to use for snapping together single notes into chords.
/// </summary>
/// <remarks>
/// Defaults to 10 in CON files, and 0 in other charts.
/// </remarks>
public long NoteSnapThreshold;
```
but this wasn't actually assigned as 10 anywhere, despite an existing `private const long NOTE_SNAP_THRESHOLD = 10` in `SongEntry.RBCon.cs`. So I'm using this as the threshold for aligning tom markers with drum notes by essentially treating it as chord-snapping. This adds `noteSnapThreshold` to `ProcessNoteOnEventAsFlagTogglePostDelay`, with a default value of 0, so that existing callers that expect it to be 0 do not need to change. (Also, maybe the chord-snapping wasn't fully implemented?)

This fixed the issue I was seeing in BatH where one of the final sequences of four yellow toms was showing as one yellow cymbal followed by three toms, despite clearly being tom audio. (And, an identical phrase appearing at the beginning of the song where it was aligned correctly. Given that notes are 3 ticks off the beat and the tom markers are exactly on it, this is probably an authoring error that went unnoticed due to the leniency of their parser)