### PR TITLE
Add ability to reset state of EngineManager

### DIFF
--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -78,6 +78,12 @@ namespace YARG.Core.Engine
                 YargLogger.Assert(SuccessCount <= ParticipantIds.Count, "SuccessCount mismanagement detected");
                 return false;
             }
+
+            public void Reset()
+            {
+                Awarded = false;
+                SuccessCount = 0;
+            }
         }
 
         private List<UnisonEvent> _unisonEvents = new();

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -129,6 +129,29 @@ namespace YARG.Core.Engine
             UpdateBandMultiplier();
         }
 
+        public void Reset()
+        {
+            _activeCodaCount = 0;
+            _currentStarIndex = 0;
+            _previousHappiness = 100f;
+            _starpowerCount = 0;
+            // These values are derived from others, so there's no reason to reset them
+            // Score = 0; derived from all players' Score + BandBonusScore
+            // Stars = 0; derived from Score
+
+            // Combo is calculated a bit differently, so we still reset it even though it's dependent on player combo
+            Combo = 0;
+            foreach (var engineContainer in _allEngines)
+            {
+                engineContainer.ResetHappiness();
+            }
+
+            foreach (var unisonEvent in _unisonEvents)
+            {
+                unisonEvent.Reset();
+            }
+        }
+
         public void UpdateEngines(double time)
         {
             foreach (var engine in _allEngines)


### PR DESCRIPTION
This was required for my replay fixes PR. This just adds a method to EngineManager and UnisonEvent that resets any data which encodes the current state of gameplay, similar to the methods on the engines.