### PR TITLE
Improve error reporting for encrypted MOGGs like 0x0D

### DIFF
--- a/YARG.Core.UnitTests/Song/RBCONEntryTests.cs
+++ b/YARG.Core.UnitTests/Song/RBCONEntryTests.cs
@@ -8,6 +8,8 @@ namespace YARG.Core.UnitTests.Song;
 
 public class RBCONEntryTests
 {
+    private const string TEST_NODE_NAME = "testsong";
+
     [Test]
     public void Create_AppliesFourLaneLeadVocalAndBandIntensities()
     {
@@ -113,6 +115,54 @@ public class RBCONEntryTests
     }
 
     [Test]
+    public void Create_UnpackedEntryAcceptsYargMoggVersion()
+    {
+        string root = CreateTempDirectory();
+        try
+        {
+            var entry = CreateUnpackedEntry(root, TEST_NODE_NAME, CreateBasicDta(TEST_NODE_NAME), 0xF0);
+
+            Assert.That(entry, Is.Not.Null);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
+    }
+
+    [Test]
+    public void Create_PackedEntryReportsUnsupportedEncryptionForEncryptedMogg()
+    {
+        using var stream = CreatePackedConStream(moggVersion: 0x0D);
+        var listings = CreatePackedConListings(TEST_NODE_NAME, midiLength: 1);
+        var parameters = CreateScanParameters("test-root", TEST_NODE_NAME, CreateDta(CreateBasicDta(TEST_NODE_NAME)));
+
+        var result = PackedRBCONEntry.Create(in parameters, listings, stream);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(result.HasValue, Is.False);
+            Assert.That(result.Error, Is.EqualTo(ScanResult.UnsupportedEncryption));
+        }
+    }
+
+    [Test]
+    public void Create_PackedEntryAcceptsYargMoggVersion()
+    {
+        byte[] midi = File.ReadAllBytes(GetTestMidiPath());
+        using var stream = CreatePackedConStream(moggVersion: 0xF0, midi: midi);
+        var listings = CreatePackedConListings(TEST_NODE_NAME, midi.Length);
+        var parameters = CreateScanParameters("test-root", TEST_NODE_NAME, CreateDta(CreateBasicDta(TEST_NODE_NAME)));
+
+        var result = PackedRBCONEntry.Create(in parameters, listings, stream);
+
+        Assert.That(result.HasValue, Is.True, $"Expected packed RBCON creation to succeed, but got {result.Error}.");
+    }
+
+    [Test]
     public void GetLastWriteTime_ReturnsMostRecentValueAcrossBaseUpdateAndUpgrade()
     {
         var baseMidi = new DateTime(2024, 01, 01, 0, 0, 0, DateTimeKind.Utc);
@@ -140,7 +190,7 @@ public class RBCONEntryTests
         Assert.That(entry.GetLastWriteTime(), Is.EqualTo(baseMidi));
     }
 
-    private static RBCONEntry CreateUnpackedEntry(string root, string nodeName, string dtaText)
+    private static RBCONEntry CreateUnpackedEntry(string root, string nodeName, string dtaText, int moggVersion = RBCONEntry.UNENCRYPTED_MOGG)
     {
         string songDirectory = Path.Combine(root, nodeName);
         Directory.CreateDirectory(songDirectory);
@@ -151,9 +201,18 @@ public class RBCONEntryTests
         string moggPath = Path.Combine(songDirectory, $"{nodeName}.mogg");
         using (var mogg = new FileStream(moggPath, FileMode.Create, FileAccess.Write, FileShare.None))
         {
-            mogg.Write(RBCONEntry.UNENCRYPTED_MOGG, Endianness.Little);
+            mogg.Write(moggVersion, Endianness.Little);
         }
 
+        var parameters = CreateScanParameters(root, nodeName, CreateDta(dtaText));
+
+        var result = UnpackedRBCONEntry.Create(in parameters);
+        Assert.That(result.HasValue, Is.True, $"Expected RBCON creation to succeed, but got {result.Error}.");
+        return result.Value;
+    }
+
+    private static DTAEntry CreateDta(string dtaText)
+    {
         byte[] bytes = YARGTextReader.UTF8Strict.GetBytes(dtaText);
         using var buffer = FixedArray<byte>.Alloc(bytes.Length);
         bytes.CopyTo(buffer.Span);
@@ -161,9 +220,12 @@ public class RBCONEntryTests
         var container = YARGDTAReader.Create(buffer);
         Assert.That(YARGDTAReader.StartNode(ref container), Is.True);
         string parsedNodeName = YARGDTAReader.GetNameOfNode(ref container, false);
-        var dta = DTAEntry.Create(parsedNodeName, container);
+        return DTAEntry.Create(parsedNodeName, container);
+    }
 
-        var parameters = new RBScanParameters
+    private static RBScanParameters CreateScanParameters(string root, string nodeName, DTAEntry dta)
+    {
+        return new RBScanParameters
         {
             Root = new AbridgedFileInfo(root, DateTime.UnixEpoch),
             NodeName = nodeName,
@@ -175,10 +237,74 @@ public class RBCONEntryTests
             UpdateMidi = null,
             Upgrade = null,
         };
+    }
 
-        var result = UnpackedRBCONEntry.Create(in parameters);
-        Assert.That(result.HasValue, Is.True, $"Expected RBCON creation to succeed, but got {result.Error}.");
-        return result.Value;
+    private static string CreateBasicDta(string nodeName)
+    {
+        return $$"""
+        ({{nodeName}}
+          (name "Test Song")
+          (song
+            (name "songs/{{nodeName}}/{{nodeName}}")
+            (pans (0.0))
+            (vols (0.0))
+            (cores (0.0))
+          )
+        )
+        """;
+    }
+
+    private static List<CONFileListing> CreatePackedConListings(string nodeName, int midiLength)
+    {
+        int midiBlockCount = (midiLength + CONFileStream.BYTES_PER_BLOCK - 1) / CONFileStream.BYTES_PER_BLOCK;
+        return new List<CONFileListing>
+        {
+            new()
+            {
+                Name = "songs",
+                Flags = CONFileListing.Flag.Directory,
+                PathIndex = -1,
+            },
+            new()
+            {
+                Name = $"songs/{nodeName}",
+                Flags = CONFileListing.Flag.Directory,
+                PathIndex = 0,
+            },
+            new()
+            {
+                Name = $"songs/{nodeName}/{nodeName}.mid",
+                Flags = CONFileListing.Flag.Consecutive,
+                BlockCount = midiBlockCount,
+                BlockOffset = 1,
+                PathIndex = 1,
+                Length = midiLength,
+            },
+            new()
+            {
+                Name = $"songs/{nodeName}/{nodeName}.mogg",
+                Flags = CONFileListing.Flag.Consecutive,
+                BlockCount = 1,
+                BlockOffset = 80,
+                PathIndex = 1,
+                Length = CONFileStream.BYTES_PER_BLOCK,
+            },
+        };
+    }
+
+    private static MemoryStream CreatePackedConStream(int moggVersion, byte[]? midi = null)
+    {
+        int imageLength = checked((int) (CONFileStream.CalculateBlockLocation(80, 0) + CONFileStream.BYTES_PER_BLOCK));
+        byte[] image = new byte[imageLength];
+        if (midi != null)
+        {
+            midi.CopyTo(image.AsSpan((int) CONFileStream.CalculateBlockLocation(1, 0)));
+        }
+
+        using var mogg = new MemoryStream(image, (int) CONFileStream.CalculateBlockLocation(80, 0), CONFileStream.BYTES_PER_BLOCK);
+        mogg.Write(moggVersion, Endianness.Little);
+
+        return new MemoryStream(image, writable: false);
     }
 
     private static string CreateTempDirectory()

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -330,9 +330,13 @@ namespace YARG.Core.Song.Cache
                             try
                             {
                                 using var stream = new FileStream(moggPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
-                                if (stream.Read<int>(Endianness.Little) != RBCONEntry.UNENCRYPTED_MOGG)
+                                var moggResult = RBCONEntry.ValidateMoggHeader(stream);
+                                if (moggResult != ScanResult.Success)
                                 {
-                                    AddToBadSongs(group.Root.FullName + " - " + node.Key, ScanResult.MoggError_Update);
+                                    AddToBadSongs(group.Root.FullName + " - " + node.Key,
+                                        moggResult == ScanResult.UnsupportedEncryption
+                                            ? moggResult
+                                            : ScanResult.MoggError_Update);
                                     return;
                                 }
                             }

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.PackedRBCON.cs
@@ -171,9 +171,12 @@ namespace YARG.Core.Song
                 long moggLocation = CONFileStream.CalculateBlockLocation(entry._moggListing.BlockOffset, entry._moggListing.Shift);
                 lock (stream)
                 {
-                    if (stream.Seek(moggLocation, SeekOrigin.Begin) != moggLocation || stream.Read<int>(Endianness.Little) != UNENCRYPTED_MOGG)
+                    var moggResult = stream.Seek(moggLocation, SeekOrigin.Begin) == moggLocation
+                        ? ValidateMoggHeader(stream)
+                        : ScanResult.MoggError;
+                    if (moggResult != ScanResult.Success)
                     {
-                        return new ScanUnexpected(ScanResult.MoggError);
+                        return new ScanUnexpected(moggResult);
                     }
                     mainMidi = CONFileStream.LoadFile(stream, entry._midiListing);
                 }

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -30,6 +30,7 @@ namespace YARG.Core.Song
     {
         private const long NOTE_SNAP_THRESHOLD = 10;
         public const int UNENCRYPTED_MOGG = 0xA;
+        private const int YARG_MOGG = 0xF0;
         public const string SONGUPDATES_DTA = "songs_updates.dta";
         private const float DEFAULT_VOCAL_SCROLL_SPEED = 2300f;
 
@@ -162,6 +163,26 @@ namespace YARG.Core.Song
             return SongChart.FromMidi(in parseSettings, midi);
         }
 
+        internal static ScanResult ValidateMoggHeader(Stream stream)
+        {
+            try
+            {
+                int version = stream.Read<int>(Endianness.Little);
+                return IsSupportedMoggVersion(version)
+                    ? ScanResult.Success
+                    : ScanResult.UnsupportedEncryption;
+            }
+            catch (EndOfStreamException)
+            {
+                return ScanResult.MoggError;
+            }
+        }
+
+        private static bool IsSupportedMoggVersion(int version)
+        {
+            return version is UNENCRYPTED_MOGG or YARG_MOGG;
+        }
+
         public override StemMixer? LoadAudio(float speed, double volume, params SongStem[] ignoreStems)
         {
             var stream = GetMoggStream();
@@ -171,7 +192,7 @@ namespace YARG.Core.Song
             }
 
             int version = stream.Read<int>(Endianness.Little);
-            if (version is not 0x0A and not 0xF0)
+            if (!IsSupportedMoggVersion(version))
             {
                 YargLogger.LogError("Original unencrypted mogg replaced by an encrypted mogg!");
                 stream.Dispose();

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBCON.cs
@@ -44,9 +44,10 @@ namespace YARG.Core.Song
                 if (File.Exists(moggPath))
                 {
                     using var moggStream = new FileStream(moggPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
-                    if (moggStream.Read<int>(Endianness.Little) != UNENCRYPTED_MOGG)
+                    var moggResult = ValidateMoggHeader(moggStream);
+                    if (moggResult != ScanResult.Success)
                     {
-                        return new ScanUnexpected(ScanResult.MoggError);
+                        return new ScanUnexpected(moggResult);
                     }
                 }
                 else

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBPKG.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.UnpackedRBPKG.cs
@@ -52,9 +52,10 @@ namespace YARG.Core.Song
                 if (File.Exists(moggPath))
                 {
                     using var moggStream = new FileStream(moggPath, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
-                    if (moggStream.Read<int>(Endianness.Little) != UNENCRYPTED_MOGG)
+                    var moggResult = ValidateMoggHeader(moggStream);
+                    if (moggResult != ScanResult.Success)
                     {
-                        return new ScanUnexpected(ScanResult.MoggError);
+                        return new ScanUnexpected(moggResult);
                     }
                 }
                 else


### PR DESCRIPTION
I had noticed that some of the rb3con files I found were unable to be played in YARG with a pretty generic error message. I wasn't sure if they were corrupted or encrypted. This makes that error more specific. Separately, there was a discrepancy between the scanner and loader validation check.

• ## Summary

  - Added shared RBCON MOGG header validation instead of hard-coding 0x0A checks in each scan
    path.
  - Aligned scanning with audio loading by accepting supported 0xF0 MOGGs during cache scans.
  - Report encrypted/unsupported MOGG headers, such as 0x0D, as UnsupportedEncryption instead
    of generic MoggError.
  - Applied the validation to packed CON, unpacked CON/PKG, and CON update MOGG checks.
  - Added RBCON unit coverage for supported 0xF0 MOGGs and unsupported encrypted 0x0D MOGGs.