### PR TITLE
Strip lanes from Beginner

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -13,6 +13,9 @@ namespace YARG.Core.Chart
         private uint _lastLanePhraseTick;
         private List<int>? _validLaneNotes = null;
 
+        // Used to wipe lane markers from Beginner
+        private const NoteFlags NO_LANE_FLAGS = ~(NoteFlags.LaneStart | NoteFlags.LaneEnd | NoteFlags.Tremolo | NoteFlags.Trill);
+
         public InstrumentTrack<DrumNote> LoadDrumsTrack(Instrument instrument, InstrumentTrack<EliteDrumNote>? eliteDrumsFallback)
         {
             _discoFlip = false;
@@ -106,7 +109,8 @@ namespace YARG.Core.Chart
         {
             const FourLaneDrumPad pad = FourLaneDrumPad.Wildcard;
             const DrumNoteType noteType = DrumNoteType.Neutral;
-            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases) & NO_LANE_FLAGS;
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
 
             double time = _moonSong.TickToTime(moonNote.tick);
@@ -117,7 +121,7 @@ namespace YARG.Core.Chart
         {
             const FiveLaneDrumPad pad = FiveLaneDrumPad.Wildcard;
             const DrumNoteType noteType = DrumNoteType.Neutral;
-            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases) & NO_LANE_FLAGS;
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
 
             double time = _moonSong.TickToTime(moonNote.tick);


### PR DESCRIPTION
The `.chart` drums format uniquely enables a scenario where lanes make it into Beginner charts - other `.chart` tracks do not support lanes, most `.mid` tracks employ a strict X-or-XH system for lanes, and the one `.mid` part that does support lanes on E is Pro Keys, which lacks a Beginner difficulty.

Currently the game just trips over itself when this happens, trying to load nonexistent highway ordering information for the Wildcard note type to populate the lane, which fails and produces both an error log and - weirdly - an invisible note on the highway.

Since lanes on E are utterly unused in conventional charting, and are arguably only possible as a side effect of how `.chart` works rather than as an intended feature of the format, this PR takes the simple approach of just stripping the lane flags during E->B conversion. I'd be open to seeing a proper implementation that creates highway-wide rainbow-colored lanes for the wildcards, but it's not worth getting into for now.