### PR TITLE
Fix split 2x kick OD recoloring

### DIFF
--- a/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
@@ -244,7 +244,7 @@ namespace YARG.Core.Game
                     (int)FourLaneDrumsFret.WildcardPad => DefaultWildcardStarpower,
 
                     // Exclusive to split-dedicated kick lanes
-                    (int) FourLaneDrumsFret.DoubleKick => DoubleKickNote,
+                    (int) FourLaneDrumsFret.DoubleKick => DoubleKickStarpower,
 
                     _ => default
                 };


### PR DESCRIPTION
Fixes split 2x kicks to correctly change color when inside an OD phrase

There is a "corresponding" [YARG PR](https://github.com/YARC-Official/YARG/pull/1484) for other visual fixes, but the PRs' code changes are completely independent and they can be merged separately.