### PR TITLE
Add average multiplier to BaseStats

### DIFF
--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -753,6 +753,8 @@ namespace YARG.Core.Engine
             // scoreMultiplier includes combo+star power score
             EngineStats.CommittedScore += scoreMultiplier;
 
+            EngineStats.AverageMultiplier = (float) EngineStats.CommittedScore / BaseNoteScore;
+
             if (EngineStats.IsStarPowerActive)
             {
                 // Amount of points just from Star Power is half of the current multiplier (8x total -> 4x SP points)

--- a/YARG.Core/Engine/BaseStats.cs
+++ b/YARG.Core/Engine/BaseStats.cs
@@ -216,6 +216,11 @@ namespace YARG.Core.Engine
         /// </summary>
         private readonly List<double> OffsetSamples = new();
 
+        /// <summary>
+        /// The player's average multiplier. Calculated by CommittedScore / BaseNoteScore
+        /// </summary>
+        public float AverageMultiplier;
+
         protected BaseStats()
         {
         }
@@ -317,6 +322,7 @@ namespace YARG.Core.Engine
             TotalOffset = 0.0;
             AverageOffset = 0.0;
             OffsetSamples.Clear();
+            AverageMultiplier = 0;
             // Don't reset TotalNotes
             // TotalNotes = 0;
 

--- a/YARG.Core/Engine/BaseStats.cs
+++ b/YARG.Core/Engine/BaseStats.cs
@@ -237,6 +237,7 @@ namespace YARG.Core.Engine
             MaxCombo = stats.MaxCombo;
             ScoreMultiplier = stats.ScoreMultiplier;
             BandMultiplier = stats.BandMultiplier;
+            AverageMultiplier = stats.AverageMultiplier;
 
             NotesHit = stats.NotesHit;
             LanedNotesHit = stats.LanedNotesHit;
@@ -301,6 +302,11 @@ namespace YARG.Core.Engine
 
             SoloBonuses = stream.Read<int>(Endianness.Little);
             StarPowerScore = stream.Read<int>(Endianness.Little);
+
+            if (version >= 16)
+            {
+                AverageMultiplier = stream.Read<float>(Endianness.Little);
+            }
 
             // Deliberately not read so that stars can be re-calculated if thresholds change
             // Stars = reader.ReadInt32();
@@ -374,6 +380,8 @@ namespace YARG.Core.Engine
 
             writer.Write(SoloBonuses);
             writer.Write(StarPowerScore);
+
+            writer.Write(AverageMultiplier);
 
             // Deliberately not written so that stars can be re-calculated with different thresholds
             // writer.Write(Stars);

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -29,7 +29,7 @@ namespace YARG.Core.Replays
         private static readonly EightCC REPLAY_MAGIC_HEADER_OLD = new('Y', 'A', 'R', 'G', 'P', 'L', 'A', 'Y');
         private static readonly EightCC REPLAY_MAGIC_HEADER = new('Y', 'A', 'R', 'E', 'P', 'L', 'A', 'Y');
 
-        private static readonly (int OLD_MIN, int METADATA_MIN, int DATA_MIN, int CURRENT) REPLAY_VERSIONS = (4, 6, 9, 15);
+        private static readonly (int OLD_MIN, int METADATA_MIN, int DATA_MIN, int CURRENT) REPLAY_VERSIONS = (4, 6, 9, 16);
         private const int ENGINE_VERSION = 5;
 
         public static (ReplayReadResult Result, ReplayInfo Info, ReplayData Data) TryDeserialize(string path, ReplayReadOptions replayOptions)

--- a/YARG.Core/Replays/ReplayStats/ReplayStats.cs
+++ b/YARG.Core/Replays/ReplayStats/ReplayStats.cs
@@ -17,8 +17,6 @@ namespace YARG.Core.Replays
         public readonly int    TotalOverdrivePhrases;
         public readonly int    NumOverdrivePhrasesHit;
         public readonly int    NumOverdriveActivations;
-        public readonly float  AverageMultiplier;
-        public readonly int    NumPauses;
         public readonly bool   IsReplayPlayer;
 
         protected ReplayStats(string name, BaseStats stats, bool isReplayPlayer)
@@ -29,8 +27,6 @@ namespace YARG.Core.Replays
             TotalOverdrivePhrases = stats.TotalStarPowerPhrases;
             NumOverdrivePhrasesHit = TotalOverdrivePhrases - stats.StarPowerPhrasesMissed;
             NumOverdriveActivations = stats.StarPowerActivationCount;
-            AverageMultiplier = stats.AverageMultiplier;
-            NumPauses = 0;
             IsReplayPlayer = isReplayPlayer;
         }
 
@@ -42,8 +38,13 @@ namespace YARG.Core.Replays
             TotalOverdrivePhrases = stream.Read<int>(Endianness.Little);
             NumOverdrivePhrasesHit = stream.Read<int>(Endianness.Little);
             NumOverdriveActivations = stream.Read<int>(Endianness.Little);
-            AverageMultiplier = stream.Read<float>(Endianness.Little);
-            NumPauses = stream.Read<int>(Endianness.Little);
+            if (version <= 15)
+            {
+                 // Average Multiplier
+                 stream.Read<float>(Endianness.Little);
+                 // NumPauses
+                 stream.Read<int>(Endianness.Little);
+            }
             // Figure out what version this should actually be
             if (version >= 14)
             {
@@ -64,8 +65,6 @@ namespace YARG.Core.Replays
             writer.Write(TotalOverdrivePhrases);
             writer.Write(NumOverdrivePhrasesHit);
             writer.Write(NumOverdriveActivations);
-            writer.Write(AverageMultiplier);
-            writer.Write(NumPauses);
             writer.Write(IsReplayPlayer);
         }
     }

--- a/YARG.Core/Replays/ReplayStats/ReplayStats.cs
+++ b/YARG.Core/Replays/ReplayStats/ReplayStats.cs
@@ -29,7 +29,7 @@ namespace YARG.Core.Replays
             TotalOverdrivePhrases = stats.TotalStarPowerPhrases;
             NumOverdrivePhrasesHit = TotalOverdrivePhrases - stats.StarPowerPhrasesMissed;
             NumOverdriveActivations = stats.StarPowerActivationCount;
-            AverageMultiplier = 0;
+            AverageMultiplier = stats.AverageMultiplier;
             NumPauses = 0;
             IsReplayPlayer = isReplayPlayer;
         }


### PR DESCRIPTION
This was required for my score screen replay PR. It was kind of just... a pain to access AverageMultiplier when it was somewhere else, or calculated in the score screen, so I moved it here. Not serialised, because it's in ReplayStats anyway (where it is actually saved now, hooray!) and there's no reason to bump the replay version for something you can derive anyway.

This is calculated in AddScore. I don't know if there's anything we could do with average multiplier during gameplay, but I figured it could be a useful stat at some point?