### PR TITLE
Stop counting percussion phrases in TotalNotes

### DIFF
--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -59,6 +59,14 @@ namespace YARG.Core.Engine.Vocals
             VocalsEngineParameters engineParameters, bool isBot)
             : base(chart, syncTrack, engineParameters, false, isBot)
         {
+            foreach (var note in Notes)
+            {
+                // Percussion phrases do not count as phrases, they cannot be hit and do not increment combo.
+                if (note.IsPercussionPhrase)
+                {
+                    BaseStats.TotalNotes--;
+                }
+            }
         }
 
         public override void Reset(bool keepCurrentButtons = false)
@@ -163,10 +171,11 @@ namespace YARG.Core.Engine.Vocals
                     UpdateMultiplier();
                 }
 
-                // No matter what, we still wanna count this as a phrase hit though
-                EngineStats.IncrementNotesHit(note, CurrentTime);
-
-                OnNoteHit?.Invoke(NoteIndex, note);
+                if (!note.IsPercussionPhrase)
+                {
+                    EngineStats.IncrementNotesHit(note, CurrentTime);
+                    OnNoteHit?.Invoke(NoteIndex, note);
+                }
 
                 // I want to call base.HitNote here, but I have no idea how vocals handles hit state so I'm scared to
                 NoteIndex++;


### PR DESCRIPTION
Fixes the issue where it was impossible to FC a vocals chart with percussion, since the percussion phrase counted as a phrase, but didn't increment combo.

I could have added a special case to the BaseEngine constructor but it felt weird to do that since I'd need to check if it was of type `VocalsNote` first. I don't think there are any adverse effects to not calling `OnNoteHit`/`IncrementNotesHit` on them, since percussion phrases don't really mean anything as far as I can tell, so this is essentially just not counting them as notes.