### PR TITLE
Autohit-centric lane logic

### DIFF
--- a/YARG.Core.UnitTests/Engine/HitWindowSettingsTests.cs
+++ b/YARG.Core.UnitTests/Engine/HitWindowSettingsTests.cs
@@ -1,4 +1,4 @@
-using System.Text;
+﻿using System.Text;
 using NUnit.Framework;
 using YARG.Core.Engine;
 using YARG.Core.IO;
@@ -18,7 +18,8 @@ public class HitWindowSettingsTests
             dwSlope: 1.5,
             dwScale: 0.1,
             dwGamma: 20,
-            tremoloWindow: 0.6);
+            laneAutohitWindow: 0.6,
+            laneProximityProtectionWindow: 0.6);
 
         using (Assert.EnterMultipleScope())
         {
@@ -28,7 +29,8 @@ public class HitWindowSettingsTests
             Assert.That(settings.DynamicWindowScale, Is.EqualTo(0.3).Within(0.0000001));
             Assert.That(settings.DynamicWindowGamma, Is.EqualTo(10.0).Within(0.0000001));
             Assert.That(settings.Scale, Is.EqualTo(1.0).Within(0.0000001));
-            Assert.That(settings.TremoloWindow, Is.EqualTo(0.6).Within(0.0000001));
+            Assert.That(settings.LaneAutohitWindow, Is.EqualTo(0.6).Within(0.0000001));
+            Assert.That(settings.LaneProximityProtectionWindow, Is.EqualTo(0.6).Within(0.0000001));
         }
     }
 
@@ -43,7 +45,8 @@ public class HitWindowSettingsTests
             dwSlope: 0.5,
             dwScale: 1.2,
             dwGamma: 1.1,
-            tremoloWindow: 0.5);
+            laneAutohitWindow: 0.5,
+            laneProximityProtectionWindow: 0.5);
 
         Assert.That(settings.CalculateHitWindow(0.001), Is.EqualTo(0.14).Within(0.0000001));
     }
@@ -59,7 +62,8 @@ public class HitWindowSettingsTests
             dwSlope: 0.25,
             dwScale: 1.0,
             dwGamma: 1.0,
-            tremoloWindow: 0.5);
+            laneAutohitWindow: 0.5,
+            laneProximityProtectionWindow: 0.5);
 
         double atZero = settings.CalculateHitWindow(0);
         double mid = settings.CalculateHitWindow(0.08);
@@ -85,7 +89,8 @@ public class HitWindowSettingsTests
             dwSlope: 0.5,
             dwScale: 1.0,
             dwGamma: 1.0,
-            tremoloWindow: 0.5)
+            laneAutohitWindow: 0.5,
+            laneProximityProtectionWindow: 0.5)
         {
             Scale = 1.5
         };
@@ -110,7 +115,8 @@ public class HitWindowSettingsTests
             dwSlope: 0.4,
             dwScale: 1.7,
             dwGamma: 2.2,
-            tremoloWindow: 0.035)
+            laneAutohitWindow: 0.035,
+            laneProximityProtectionWindow: 0.035)
         {
             Scale = 2.0
         };
@@ -127,45 +133,9 @@ public class HitWindowSettingsTests
             Assert.That(deserialized.DynamicWindowSlope, Is.EqualTo(original.DynamicWindowSlope).Within(0.0000001));
             Assert.That(deserialized.DynamicWindowScale, Is.EqualTo(original.DynamicWindowScale).Within(0.0000001));
             Assert.That(deserialized.DynamicWindowGamma, Is.EqualTo(original.DynamicWindowGamma).Within(0.0000001));
-            Assert.That(deserialized.TremoloWindow, Is.EqualTo(original.TremoloWindow).Within(0.0000001));
+            Assert.That(deserialized.LaneAutohitWindow, Is.EqualTo(original.LaneAutohitWindow).Within(0.0000001));
+            Assert.That(deserialized.LaneProximityProtectionWindow, Is.EqualTo(original.LaneProximityProtectionWindow).Within(0.0000001));
         }
-    }
-
-    [Test]
-    public void Deserialize_Version10InterpretsSerializedTremoloValueAsLegacyFrontEndPercent()
-    {
-        var original = new HitWindowSettings(
-            maxWindow: 0.13,
-            minWindow: 0.07,
-            frontToBackRatio: 1.1,
-            isDynamic: true,
-            dwSlope: 0.4,
-            dwScale: 1.7,
-            dwGamma: 2.2,
-            tremoloWindow: 0.35);
-
-        var deserialized = RoundTrip(original, version: 10);
-        double expectedTremoloWindow = -original.GetFrontEnd(original.MaxWindow) * original.TremoloWindow;
-
-        Assert.That(deserialized.TremoloWindow, Is.EqualTo(expectedTremoloWindow).Within(0.0000001));
-    }
-
-    [Test]
-    public void Deserialize_Version9LeavesTremoloWindowAtDefault()
-    {
-        var original = new HitWindowSettings(
-            maxWindow: 0.13,
-            minWindow: 0.07,
-            frontToBackRatio: 1.1,
-            isDynamic: true,
-            dwSlope: 0.4,
-            dwScale: 1.7,
-            dwGamma: 2.2,
-            tremoloWindow: 0.35);
-
-        var deserialized = RoundTrip(original, version: 9);
-
-        Assert.That(deserialized.TremoloWindow, Is.Zero.Within(0.0000001));
     }
 
     private static HitWindowSettings RoundTrip(HitWindowSettings settings, int version)

--- a/YARG.Core.UnitTests/Engine/HitWindowSettingsTests.cs
+++ b/YARG.Core.UnitTests/Engine/HitWindowSettingsTests.cs
@@ -104,40 +104,6 @@ public class HitWindowSettingsTests
         }
     }
 
-    [Test]
-    public void SerializeAndDeserialize_RoundTripAllFieldsForVersion12()
-    {
-        var original = new HitWindowSettings(
-            maxWindow: 0.13,
-            minWindow: 0.07,
-            frontToBackRatio: 1.1,
-            isDynamic: true,
-            dwSlope: 0.4,
-            dwScale: 1.7,
-            dwGamma: 2.2,
-            laneAutohitWindow: 0.035,
-            laneProximityProtectionWindow: 0.035)
-        {
-            Scale = 2.0
-        };
-
-        var deserialized = RoundTrip(original, version: 12);
-
-        using (Assert.EnterMultipleScope())
-        {
-            Assert.That(deserialized.Scale, Is.EqualTo(1.0).Within(0.0000001));
-            Assert.That(deserialized.MaxWindow, Is.EqualTo(original.MaxWindow).Within(0.0000001));
-            Assert.That(deserialized.MinWindow, Is.EqualTo(original.MinWindow).Within(0.0000001));
-            Assert.That(deserialized.FrontToBackRatio, Is.EqualTo(original.FrontToBackRatio).Within(0.0000001));
-            Assert.That(deserialized.IsDynamic, Is.EqualTo(original.IsDynamic));
-            Assert.That(deserialized.DynamicWindowSlope, Is.EqualTo(original.DynamicWindowSlope).Within(0.0000001));
-            Assert.That(deserialized.DynamicWindowScale, Is.EqualTo(original.DynamicWindowScale).Within(0.0000001));
-            Assert.That(deserialized.DynamicWindowGamma, Is.EqualTo(original.DynamicWindowGamma).Within(0.0000001));
-            Assert.That(deserialized.LaneAutohitWindow, Is.EqualTo(original.LaneAutohitWindow).Within(0.0000001));
-            Assert.That(deserialized.LaneProximityProtectionWindow, Is.EqualTo(original.LaneProximityProtectionWindow).Within(0.0000001));
-        }
-    }
-
     private static HitWindowSettings RoundTrip(HitWindowSettings settings, int version)
     {
         using var stream = new MemoryStream();

--- a/YARG.Core.UnitTests/Engine/VocalsEngineTests.cs
+++ b/YARG.Core.UnitTests/Engine/VocalsEngineTests.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using YARG.Core.Chart;
 using YARG.Core.Engine;
 using YARG.Core.Engine.Vocals;
@@ -19,7 +19,7 @@ public sealed class VocalsEngineTests
     };
 
     private static readonly VocalsEngineParameters EngineParameters = new(
-        new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1, 1, 0),
+        new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1, 1, 0, 0),
         4,
         StarMultiplierThresholds,
         SoloBonusStarMultiplierThresholds,

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -55,8 +55,6 @@ namespace YARG.Core.Engine
         public override BaseEngineParameters BaseParameters => EngineParameters;
         public override BaseStats            BaseStats      => EngineStats;
 
-        protected const double LANE_PROXIMITY_LENIENCY = 0.080;
-
         protected BaseEngine(InstrumentDifficulty<TNoteType> chart, SyncTrack syncTrack,
             TEngineParams engineParameters, bool isChordSeparate, bool isBot)
             : base(syncTrack, isChordSeparate, isBot)
@@ -679,8 +677,8 @@ namespace YARG.Core.Engine
 
         protected void UpdateLaneAutohitExpireTime()
         {
-            LaneAutohitExpireTime = CurrentTime + EngineParameters.HitWindow.TremoloWindow;
-            YargLogger.LogFormatDebug("LaneExpireTime extended to {0}. TremoloWindow {1}. Increment {2}.", LaneAutohitExpireTime, EngineParameters.HitWindow.TremoloWindow, LaneAutohitExpireTime - CurrentTime);
+            LaneAutohitExpireTime = CurrentTime + EngineParameters.HitWindow.LaneAutohitWindow;
+            YargLogger.LogFormatDebug("LaneExpireTime extended to {0}. LaneAutohitWindow {1}. Increment {2}.", LaneAutohitExpireTime, EngineParameters.HitWindow.LaneAutohitWindow, LaneAutohitExpireTime - CurrentTime);
         }
 
         protected bool SkipPreviousNotes(TNoteType current)

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using YARG.Core.Chart;
@@ -55,7 +55,7 @@ namespace YARG.Core.Engine
         public override BaseEngineParameters BaseParameters => EngineParameters;
         public override BaseStats            BaseStats      => EngineStats;
 
-        protected const double LANE_END_LENIENCY = 0.080;
+        protected const double LANE_PROXIMITY_LENIENCY = 0.080;
 
         protected BaseEngine(InstrumentDifficulty<TNoteType> chart, SyncTrack syncTrack,
             TEngineParams engineParameters, bool isChordSeparate, bool isBot)
@@ -339,9 +339,9 @@ namespace YARG.Core.Engine
 
             if (IsLaneActive)
             {
-                if (IsTimeBetween(LaneExpireTime, previousTime, nextTime))
+                if (IsTimeBetween(LaneAutohitExpireTime, previousTime, nextTime))
                 {
-                    QueueUpdateTime(LaneExpireTime, "Potential Lane Expiration Time");
+                    QueueUpdateTime(LaneAutohitExpireTime, "Potential Lane Expiration Time");
                 }
             }
         }
@@ -359,6 +359,8 @@ namespace YARG.Core.Engine
 
         protected override void UpdateTimeVariables(double time)
         {
+            YargLogger.LogTrace($"REQUIRED LANE NOTE: {RequiredLaneNote}");
+
             if (time < CurrentTime)
             {
                 YargLogger.FailFormat("Time cannot go backwards! Current time: {0}, new time: {1}", CurrentTime,
@@ -415,17 +417,6 @@ namespace YARG.Core.Engine
 
                         CurrentWaitCountdownIndex++;
                     }
-                }
-            }
-
-            if (IsLaneActive)
-            {
-                if (CurrentTime >= LaneExpireTime)
-                {
-                    // Lane forgiveness window expired, disable all lane behavior
-                    RequiredLaneNote = -1;
-                    NextTrillNote = -1;
-                    YargLogger.LogFormatTrace("Lane behavior turned off at {0}", CurrentTime);
                 }
             }
         }
@@ -518,12 +509,12 @@ namespace YARG.Core.Engine
                 AdvanceToNextNote(note);
             }
 
-            if (!LanesExist || !note.IsLane || !BaseParameters.EnableLanes)
+            if ((!LanesExist && !note.IsLaneEnd) || !note.IsLane || !BaseParameters.EnableLanes)
             {
                 return;
             }
 
-            if (note.IsLaneStart || note.Time > LaneExpireTime)
+            if (note.IsLaneStart)
             {
                 YargLogger.LogFormatTrace("Starting lane behavior at time {0}. ", CurrentTime);
 
@@ -540,23 +531,22 @@ namespace YARG.Core.Engine
                 }
 
                 // Future updates during this lane will be handled on SubmitLaneNote inputs
-                UpdateLaneExpireTime();
+                UpdateLaneAutohitExpireTime();
             }
             else if (note.IsLaneEnd)
             {
-                // Lane ends with this note, continue overstrum leniency while transitioning out of this lane
                 YargLogger.LogFormatTrace("Lane ending at {0}", CurrentTime);
-
-                UpdateLaneExpireTime();
+                RequiredLaneNote = -1;
+                NextTrillNote = -1;
             }
 
             YargLogger.LogFormatTrace("Lane note hit at {0}", CurrentTime);
         }
 
         // Intercept a missed note while a lane phrase is active
-        protected bool HitNoteFromLane(TNoteType note)
+        protected bool AutohitNoteFromLane(TNoteType note)
         {
-            if (note.Time > LaneExpireTime)
+            if (note.Time > LaneAutohitExpireTime)
             {
                 return false;
             }
@@ -565,7 +555,7 @@ namespace YARG.Core.Engine
             {
                 if (note.IsLaneStart)
                 {
-                    // The leniency window at the end of the previous lane overlaps with the start of this one
+                    // The autohit window at the end of the previous lane overlaps with the start of this one
                     // The first note in a lane must be manually hit in order to count
                     return false;
                 }
@@ -594,6 +584,20 @@ namespace YARG.Core.Engine
             if (note.ParentOrSelf.WasFullyHitOrMissed())
             {
                 AdvanceToNextNote(note);
+            }
+
+            // If that note was the start of a lane, set the lane note values
+            if (note.IsLaneStart)
+            {
+                RequiredLaneNote = note.LaneNote;
+                NextTrillNote = note.IsTremolo ? -1 : note.NextNote!.LaneNote;
+            }
+
+            // If that note was the end of a lane, and we haven't already transitioned into a new lane, then clear the lane note values
+            if (note.IsLaneEnd && (RequiredLaneNote == note.LaneNote || NextTrillNote == note.LaneNote))
+            {
+                RequiredLaneNote = -1;
+                NextTrillNote = -1;
             }
         }
 
@@ -628,7 +632,7 @@ namespace YARG.Core.Engine
                 }
 
 
-                UpdateLaneExpireTime();
+                UpdateLaneAutohitExpireTime();
 
                 // Update next required note for trills to ensure alternating inputs
                 if (NextTrillNote != -1)
@@ -653,10 +657,30 @@ namespace YARG.Core.Engine
             return false;
         }
 
-        protected void UpdateLaneExpireTime()
+        protected bool LaneAboutToStartIncludesNote(int inputNote, TNoteType laneStart)
         {
-            LaneExpireTime = CurrentTime + EngineParameters.HitWindow.TremoloWindow;
-            YargLogger.LogFormatDebug("LaneExpireTime extended to {0}. TremoloWindow {1}. Increment {2}.", LaneExpireTime, EngineParameters.HitWindow.TremoloWindow, LaneExpireTime - CurrentTime);
+            var inputMask = 1 << inputNote;
+
+            var requiredLaneNote = laneStart.LaneNote;
+            var nextTrillNote = laneStart.IsTremolo ? -1 : laneStart.NextNote!.LaneNote;
+
+            return inputMask == requiredLaneNote || (nextTrillNote != -1 && inputMask == nextTrillNote);
+        }
+
+        protected bool LaneThatJustEndedIncludesNote(int inputNote, TNoteType laneEnd)
+        {
+            var inputMask = 1 << inputNote;
+
+            var requiredLaneNote = laneEnd.LaneNote;
+            var nextTrillNote = laneEnd.IsTremolo ? -1 : laneEnd.PreviousNote!.LaneNote;
+
+            return inputMask == requiredLaneNote || (nextTrillNote != -1 && inputMask == nextTrillNote);
+        }
+
+        protected void UpdateLaneAutohitExpireTime()
+        {
+            LaneAutohitExpireTime = CurrentTime + EngineParameters.HitWindow.TremoloWindow;
+            YargLogger.LogFormatDebug("LaneExpireTime extended to {0}. TremoloWindow {1}. Increment {2}.", LaneAutohitExpireTime, EngineParameters.HitWindow.TremoloWindow, LaneAutohitExpireTime - CurrentTime);
         }
 
         protected bool SkipPreviousNotes(TNoteType current)
@@ -665,7 +689,7 @@ namespace YARG.Core.Engine
             var prevNote = current.PreviousNote;
             while (prevNote is not null && !prevNote.WasFullyHitOrMissed())
             {
-                if (HitNoteFromLane(prevNote))
+                if (AutohitNoteFromLane(prevNote))
                 {
                     // Save this note from being counted as a skip if it satisfies the active lane
                     continue;

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -655,33 +655,9 @@ namespace YARG.Core.Engine
             return false;
         }
 
-        // Lenient version, which only cares about proximity to any lane, not the contents of the lane.
-        // Used by Guitar engines to allow for fretting flexibility during transitions
-        protected bool IsInLaneLeniencyWindow()
-        {
-            if (IsLaneActive)
-            {
-                return false;
-            }
-
-            if (
-                NoteIndex < Notes.Count && // There is a next note
-                Notes[NoteIndex].IsLaneStart && // That note is a lane start
-                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane is starting soon
-            )
-            {
-                return true;
-            }
-
-            return (
-                NoteIndex > 0 && // There is a previous note
-                Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
-                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane ended recently
-            );
-        }
-
-        // Strict version, which cares whether the input would satisfy the lane that's providing leniency.
-        // Used by Drums and Keys engines to provide forgiveness only for inputs that would satisfy a nearby lane, not for unrelated inputs
+        // This cares whether the input would satisfy the lane that's providing leniency.
+        // Used by Drums and Keys engines to provide forgiveness only for inputs that would satisfy a nearby lane, not for unrelated inputs.
+        // Guitar engine has a parameterless version that doesn't check inputs against adjacent lanes.
         protected bool IsInLaneLeniencyWindow(int inputNote)
         {
             if (IsLaneActive)

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -655,24 +655,80 @@ namespace YARG.Core.Engine
             return false;
         }
 
-        protected bool LaneAboutToStartIncludesNote(int inputNote, TNoteType laneStart)
+        // Lenient version, which only cares about proximity to any lane, not the contents of the lane.
+        // Used by Guitar engines to allow for fretting flexibility during transitions
+        protected bool IsInLeniencyWindow()
         {
-            var inputMask = 1 << inputNote;
+            if (IsLaneActive)
+            {
+                return false;
+            }
 
-            var requiredLaneNote = laneStart.LaneNote;
-            var nextTrillNote = laneStart.IsTremolo ? -1 : laneStart.NextNote!.LaneNote;
+            if (
+                NoteIndex < Notes.Count && // There is a next note
+                Notes[NoteIndex].IsLaneStart && // That note is a lane start
+                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane is starting soon
+            )
+            {
+                return true;
+            }
 
-            return inputMask == requiredLaneNote || (nextTrillNote != -1 && inputMask == nextTrillNote);
+            return (
+                NoteIndex > 0 && // There is a previous note
+                Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
+                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane ended recently
+            );
         }
 
-        protected bool LaneThatJustEndedIncludesNote(int inputNote, TNoteType laneEnd)
+        // Strict version, which cares whether the input would satisfy the lane that's providing leniency.
+        // Used by Drums and Keys engines to provide forgiveness only for inputs that would satisfy a nearby lane, not for unrelated inputs
+        protected bool IsInLeniencyWindow(int inputNote)
+        {
+            if (IsLaneActive)
+            {
+                return false;
+            }
+
+            if (
+                NoteIndex < Notes.Count && // There is a next note
+                Notes[NoteIndex].IsLaneStart && // That note is a lane start
+                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane is starting soon
+                LaneIncludesNote(inputNote, Notes[NoteIndex]) // That lane would accept this input
+            )
+            {
+                return true;
+            }
+
+            return (
+                NoteIndex > 0 && // There is a previous note
+                Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
+                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane ended recently
+                LaneIncludesNote(inputNote, Notes[NoteIndex - 1]) // That lane would accept this input
+            );
+        }
+
+        protected bool LaneIncludesNote(int inputNote, TNoteType laneNote)
         {
             var inputMask = 1 << inputNote;
 
-            var requiredLaneNote = laneEnd.LaneNote;
-            var nextTrillNote = laneEnd.IsTremolo ? -1 : laneEnd.PreviousNote!.LaneNote;
+            var requiredLaneNote = laneNote.LaneNote;
 
-            return inputMask == requiredLaneNote || (nextTrillNote != -1 && inputMask == nextTrillNote);
+            int otherNoteInTrill;
+
+            if (laneNote.IsTremolo)
+            {
+                otherNoteInTrill = -1;
+            }
+            else if (laneNote.IsLaneEnd)
+            {
+                otherNoteInTrill = laneNote.PreviousNote.LaneNote;
+            }
+            else
+            {
+                otherNoteInTrill = laneNote.NextNote.LaneNote;
+            }
+
+            return inputMask == requiredLaneNote || (otherNoteInTrill != -1 && inputMask == otherNoteInTrill);
         }
 
         protected void UpdateLaneAutohitExpireTime()

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -707,7 +707,7 @@ namespace YARG.Core.Engine
             );
         }
 
-        protected bool LaneIncludesNote(int inputNote, TNoteType laneNote)
+        private bool LaneIncludesNote(int inputNote, TNoteType laneNote)
         {
             var inputMask = 1 << inputNote;
 

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -657,7 +657,7 @@ namespace YARG.Core.Engine
 
         // Lenient version, which only cares about proximity to any lane, not the contents of the lane.
         // Used by Guitar engines to allow for fretting flexibility during transitions
-        protected bool IsInLeniencyWindow()
+        protected bool IsInLaneLeniencyWindow()
         {
             if (IsLaneActive)
             {
@@ -682,7 +682,7 @@ namespace YARG.Core.Engine
 
         // Strict version, which cares whether the input would satisfy the lane that's providing leniency.
         // Used by Drums and Keys engines to provide forgiveness only for inputs that would satisfy a nearby lane, not for unrelated inputs
-        protected bool IsInLeniencyWindow(int inputNote)
+        protected bool IsInLaneLeniencyWindow(int inputNote)
         {
             if (IsLaneActive)
             {
@@ -707,7 +707,7 @@ namespace YARG.Core.Engine
             );
         }
 
-        private bool LaneIncludesNote(int inputNote, TNoteType laneNote)
+        protected bool LaneIncludesNote(int inputNote, TNoteType laneNote)
         {
             var inputMask = 1 << inputNote;
 

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -142,7 +142,8 @@ namespace YARG.Core.Engine
         protected uint CurrentLaneIndex;
         protected int RequiredLaneNote;
         protected int NextTrillNote;
-        protected double LaneExpireTime;
+
+        protected double LaneAutohitExpireTime;
         public bool IsLaneActive => RequiredLaneNote != -1;
         public bool LanesExist => CurrentLaneIndex <= TotalLanes;
 
@@ -426,7 +427,7 @@ namespace YARG.Core.Engine
             CurrentLaneIndex = 1;
             RequiredLaneNote = -1;
             NextTrillNote = -1;
-            LaneExpireTime = -1;
+            LaneAutohitExpireTime = -1;
 
             IsWaitCountdownActive = false;
             IsStarPowerInputActive = false;

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -259,7 +259,6 @@ namespace YARG.Core.Engine
         private void RunQueuedUpdates(double time)
         {
             GenerateAndSortQueuedUpdates(time);
-            _scheduledUpdates.Sort((x, y) => x.Time.CompareTo(y.Time));
 
             if (_scheduledUpdates.Count > 0)
             {

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -271,29 +271,30 @@ namespace YARG.Core.Engine
 
             while (_scheduledUpdates.Count > 0)
             {
-                double updateTime = _scheduledUpdates[0].Time;
+                var update = _scheduledUpdates[0];
 
                 // Skip updates that are in the past
-                if (updateTime < CurrentTime)
+                if (update.Time < CurrentTime)
                 {
                     YargLogger.FailFormat(
                         "Scheduled update is in the past! Current time: {0}, update time: {1}", CurrentTime,
-                        updateTime);
+                        update.Time);
 
                     _scheduledUpdates.RemoveAt(0);
+                    continue;
                 }
 
                 // There should be no scheduled updates for times beyond the one we want to update to
-                if (updateTime >= time)
+                if (update.Time >= time)
                 {
                     YargLogger.FailFormat("Update time is >= than the given time! Update time: {0} ({1}), given time: {2}",
-                        updateTime, _scheduledUpdates[0].Reason, time);
+                        update.Time, update.Reason, time);
                     break;
                 }
 
-                YargLogger.LogFormatTrace("Running scheduled update at {0} ({1})", updateTime,
-                    item2: _scheduledUpdates[0].Reason);
-                RunEngineLoop(updateTime);
+                YargLogger.LogFormatTrace("Running scheduled update at {0} ({1})", update.Time,
+                    item2: update.Reason);
+                RunEngineLoop(update.Time);
 
                 _scheduledUpdates.RemoveAt(0);
 
@@ -302,15 +303,19 @@ namespace YARG.Core.Engine
                 // (For example: a sustain starting then ending within the range of already existing updates)
                 if (_scheduledUpdates.Count > 0)
                 {
-                    GenerateQueuedUpdates(_scheduledUpdates[0].Time);
+                    GenerateAndSortQueuedUpdates(_scheduledUpdates[0].Time);
                 }
                 else
                 {
-                    GenerateQueuedUpdates(time);
+                    GenerateAndSortQueuedUpdates(time);
                 }
-
-                _scheduledUpdates.Sort((x, y) => x.Time.CompareTo(y.Time));
             }
+        }
+
+        private void GenerateAndSortQueuedUpdates(double nextTime)
+        {
+            GenerateQueuedUpdates(nextTime);
+            _scheduledUpdates.Sort((x, y) => x.Time.CompareTo(y.Time));
         }
 
         protected abstract void UpdateBot(double time);
@@ -318,9 +323,6 @@ namespace YARG.Core.Engine
         protected virtual void GenerateQueuedUpdates(double nextTime)
         {
             YargLogger.LogFormatTrace("Generating queued updates up to {0}", nextTime);
-            var previousTime = CurrentTime;
-
-
         }
 
         protected abstract void UpdateTimeVariables(double time);

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -261,7 +261,7 @@ namespace YARG.Core.Engine
             // 'for' is used here to prevent enumeration exceptions,
             // the list of scheduled updates will be modified by the updates we're running
 
-            GenerateQueuedUpdates(time);
+            GenerateAndSortQueuedUpdates(time);
             _scheduledUpdates.Sort((x, y) => x.Time.CompareTo(y.Time));
 
             if (_scheduledUpdates.Count > 0)

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -258,9 +258,6 @@ namespace YARG.Core.Engine
 
         private void RunQueuedUpdates(double time)
         {
-            // 'for' is used here to prevent enumeration exceptions,
-            // the list of scheduled updates will be modified by the updates we're running
-
             GenerateAndSortQueuedUpdates(time);
             _scheduledUpdates.Sort((x, y) => x.Time.CompareTo(y.Time));
 

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -98,7 +98,7 @@ namespace YARG.Core.Engine.Drums
             if (
                 !IsLaneActive && // Not in a lane
                 Notes[NoteIndex].IsLaneStart && // The next note is a lane start
-                Notes[NoteIndex].Time - CurrentTime < LANE_PROXIMITY_LENIENCY && // That lane is starting soon
+                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane is starting soon
                 LaneAboutToStartIncludesNote((int)PadHit, Notes[NoteIndex]) // The overhit matches the lane that's about to begin
             )
             {
@@ -111,7 +111,7 @@ namespace YARG.Core.Engine.Drums
                 !IsLaneActive && // Not in a lane
                 NoteIndex > 0 && // A previous note exists
                 Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
-                CurrentTime - Notes[NoteIndex - 1].Time < LANE_PROXIMITY_LENIENCY && // The lane ended recently
+                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // The lane ended recently
                 LaneThatJustEndedIncludesNote((int)PadHit, Notes[NoteIndex - 1]) // The overhit matches the lane that just ended
             )
             {

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -94,10 +94,28 @@ namespace YARG.Core.Engine.Drums
                 return;
             }
 
-            // Prevent overstrum too close to the expiration of lane behavior
-            if (!IsLaneActive && CurrentTime - LaneExpireTime < LANE_END_LENIENCY)
+            // Prevent overhit too close to the beginning of a lane that accepts the overhit
+            if (
+                !IsLaneActive && // Not in a lane
+                Notes[NoteIndex].IsLaneStart && // The next note is a lane start
+                Notes[NoteIndex].Time - CurrentTime < LANE_PROXIMITY_LENIENCY && // That lane is starting soon
+                LaneAboutToStartIncludesNote((int)PadHit, Notes[NoteIndex]) // The overhit matches the lane that's about to begin
+            )
             {
-                YargLogger.LogFormatTrace("Overstrum prevented by lane end leniency at {0}", CurrentTime);
+                YargLogger.LogFormatTrace("Overhit prevented by lane start leniency at {0}", CurrentTime);
+                return;
+            }
+
+            // Prevent overhit too soon after the end of a lane that accepts the overhit
+            if (
+                !IsLaneActive && // Not in a lane
+                NoteIndex > 0 && // A previous note exists
+                Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
+                CurrentTime - Notes[NoteIndex - 1].Time < LANE_PROXIMITY_LENIENCY && // The lane ended recently
+                LaneThatJustEndedIncludesNote((int)PadHit, Notes[NoteIndex - 1]) // The overhit matches the lane that just ended
+            )
+            {
+                YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
                 return;
             }
 

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -94,26 +94,8 @@ namespace YARG.Core.Engine.Drums
                 return;
             }
 
-            // Prevent overhit too close to the beginning of a lane that accepts the overhit
-            if (
-                !IsLaneActive && // Not in a lane
-                Notes[NoteIndex].IsLaneStart && // The next note is a lane start
-                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane is starting soon
-                LaneAboutToStartIncludesNote((int)PadHit, Notes[NoteIndex]) // The overhit matches the lane that's about to begin
-            )
-            {
-                YargLogger.LogFormatTrace("Overhit prevented by lane start leniency at {0}", CurrentTime);
-                return;
-            }
-
-            // Prevent overhit too soon after the end of a lane that accepts the overhit
-            if (
-                !IsLaneActive && // Not in a lane
-                NoteIndex > 0 && // A previous note exists
-                Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
-                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // The lane ended recently
-                LaneThatJustEndedIncludesNote((int)PadHit, Notes[NoteIndex - 1]) // The overhit matches the lane that just ended
-            )
+            // Prevent overhit too close to a lane that accepts the overhit
+            if (IsInLeniencyWindow((int)PadHit))
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
                 return;

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -95,7 +95,7 @@ namespace YARG.Core.Engine.Drums
             }
 
             // Prevent overhit too close to a lane that accepts the overhit
-            if (IsInLeniencyWindow((int)PadHit))
+            if (IsInLaneLeniencyWindow((int)PadHit))
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
                 return;

--- a/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/Engines/YargDrumsEngine.cs
@@ -117,7 +117,7 @@ namespace YARG.Core.Engine.Drums.Engines
                             foreach (var missedNote in parentNote.AllNotes)
                             {
                                 // Intercept missed note while lane phrase is active and missed note is in forgiveness window
-                                if (HitNoteFromLane(missedNote))
+                                if (AutohitNoteFromLane(missedNote))
                                 {
                                     continue;
                                 }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
@@ -244,12 +244,13 @@ namespace YARG.Core.Engine.Guitar.Engines
                     if (isFirstNoteInWindow && missed)
                     {
                         // Intercept missed note while lane phrase is active
-                        if (HitNoteFromLane(note))
+                        if (AutohitNoteFromLane(note))
                         {
                             break;
                         }
 
                         MissNote(note);
+
                         YargLogger.LogFormatTrace("Missed note (Index: {0}, Mask: {1}) at {2}", i,
                             note.NoteMask, CurrentTime);
                     }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
@@ -546,11 +546,14 @@ namespace YARG.Core.Engine.Guitar.Engines
                 return false;
             }
 
-            // Input is a hammer-on if the highest fret held is higher than the highest fret of the previous mask
-            bool isHammerOn = GetMostSignificantBit(EffectiveButtonMask) > GetMostSignificantBit(LastButtonMask);
+            var highestHeldFret = GetMostSignificantBit(EffectiveButtonMask);
 
-            // Input is a hammer-on and the button pressed is not part of the note mask (incorrect fret)
-            if (isHammerOn && (EffectiveButtonMask & note.NoteMask) == 0)
+            // Input is a hammer-on if the highest fret held is higher than the highest fret of the previous mask
+            bool isHammerOn = highestHeldFret > GetMostSignificantBit(LastButtonMask);
+
+            // Input is a hammer-on and the button pressed is neither part of the note mask (incorrect fret) nor forgiven by
+            // a nearby trill lane
+            if (isHammerOn && (EffectiveButtonMask & note.NoteMask) == 0 && !IsGhostInTrillLeniencyWindow(highestHeldFret - 1))
             {
                 return true;
             }
@@ -619,6 +622,33 @@ namespace YARG.Core.Engine.Guitar.Engines
             }
 
             return codaSections;
+        }
+
+        protected bool IsGhostInTrillLeniencyWindow(int inputNote)
+        {
+            if (IsLaneActive)
+            {
+                return false;
+            }
+
+            if (
+                NoteIndex < Notes.Count && // There is a next note
+                Notes[NoteIndex].IsLaneStart && // That note is a lane start
+                Notes[NoteIndex].IsTrill && // That lane is a trill
+                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That trill is starting soon
+                LaneIncludesNote(inputNote, Notes[NoteIndex]) // That lane would accept this input
+            )
+            {
+                return true;
+            }
+
+            return (
+                NoteIndex > 0 && // There is a previous note
+                Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
+                Notes[NoteIndex - 1].IsTrill && // That lane was a trill
+                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That trill ended recently
+                LaneIncludesNote(inputNote, Notes[NoteIndex - 1]) // That lane would have accepted this input
+            );
         }
     }
 }

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -161,7 +161,7 @@ namespace YARG.Core.Engine.Guitar
             if (
                 !IsLaneActive && // Not in a lane
                 Notes[NoteIndex].IsLaneStart && // The next note is a lane start
-                Notes[NoteIndex].Time - CurrentTime < LANE_PROXIMITY_LENIENCY // That lane is starting soon
+                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane is starting soon
             )
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane start leniency at {0}", CurrentTime);
@@ -174,7 +174,7 @@ namespace YARG.Core.Engine.Guitar
                 !IsLaneActive && // Not in a lane
                 NoteIndex > 0 && // A previous note exists
                 Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
-                CurrentTime - Notes[NoteIndex - 1].Time < LANE_PROXIMITY_LENIENCY // The lane ended recently
+                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow // The lane ended recently
             )
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -139,14 +139,8 @@ namespace YARG.Core.Engine.Guitar
             var laneMask = GetLaneMask();
             if (ActiveLaneIncludesNote(laneMask))
             {
-                UpdateLaneExpireTime();
+                UpdateLaneAutohitExpireTime();
                 return;
-            }
-
-            // Prevent overstrum too close to the expiration of lane behavior
-            if (!IsLaneActive && CurrentTime - LaneExpireTime < LANE_END_LENIENCY)
-            {
-                YargLogger.LogFormatTrace("Overstrum prevented by lane end leniency at {0}", CurrentTime);
             }
 
             // Prevent overstrum during coda
@@ -160,6 +154,31 @@ namespace YARG.Core.Engine.Guitar
             {
                 YargLogger.LogFormatTrace("Overstrum punished during post-BRE coda section at {0}", CurrentTime);
                 Codas[CurrentCodaIndex].Overhit();
+            }
+
+            // Prevent overstrum too close to the beginning of a lane. Unlike the Keys and Drums engines,
+            // don't enforce the correct fretting; the player has the flexibility to adjust their fretting hand
+            if (
+                !IsLaneActive && // Not in a lane
+                Notes[NoteIndex].IsLaneStart && // The next note is a lane start
+                Notes[NoteIndex].Time - CurrentTime < LANE_PROXIMITY_LENIENCY // That lane is starting soon
+            )
+            {
+                YargLogger.LogFormatTrace("Overhit prevented by lane start leniency at {0}", CurrentTime);
+                return;
+            }
+
+            // Prevent overstrum too soon after the end of a lane. Unlike the Keys and Drums engines, don't
+            // enforce the correct fretting; the player has the flexibility to adjust their fretting hand
+            if (
+                !IsLaneActive && // Not in a lane
+                NoteIndex > 0 && // A previous note exists
+                Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
+                CurrentTime - Notes[NoteIndex - 1].Time < LANE_PROXIMITY_LENIENCY // The lane ended recently
+            )
+            {
+                YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
+                return;
             }
 
             if (IsLaneActive)

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -143,6 +143,15 @@ namespace YARG.Core.Engine.Guitar
                 return;
             }
 
+            // Prevent overstrum too close to a lane. Unlike the Keys and Drums engines, use the lenient
+            // version which doesn't enforce the correct fretting; the player has the flexibility to adjust
+            // their fretting hand.
+            if (IsInLaneLeniencyWindow())
+            {
+                YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
+                return;
+            }
+
             // Prevent overstrum during coda
             if (IsCodaActive)
             {
@@ -154,15 +163,6 @@ namespace YARG.Core.Engine.Guitar
             {
                 YargLogger.LogFormatTrace("Overstrum punished during post-BRE coda section at {0}", CurrentTime);
                 Codas[CurrentCodaIndex].Overhit();
-            }
-
-            // Prevent overstrum too close to a lane. Unlike the Keys and Drums engines, use the lenient
-            // version which doesn't enforce the correct fretting; the player has the flexibility to adjust
-            // their fretting hand.
-            if (IsInLaneLeniencyWindow())
-            {
-                YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
-                return;
             }
 
             if (IsLaneActive)
@@ -513,6 +513,30 @@ namespace YARG.Core.Engine.Guitar
             return laneMask;
         }
 
+        // Parameterless version of the same method found in BaseEngine.Generic, which only cares about proximity to any lane, not the
+        // contents of the lane. Used by Guitar engines to allow for fretting flexibility during transitions
+        private bool IsInLaneLeniencyWindow()
+        {
+            if (IsLaneActive)
+            {
+                return false;
+            }
+
+            if (
+                NoteIndex < Notes.Count && // There is a next note
+                Notes[NoteIndex].IsLaneStart && // That note is a lane start
+                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane is starting soon
+            )
+            {
+                return true;
+            }
+
+            return (
+                NoteIndex > 0 && // There is a previous note
+                Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
+                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane ended recently
+            );
+        }
         protected static bool IsFretInput(GameInput input)
         {
             return input.GetAction<GuitarAction>() switch

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -156,26 +156,10 @@ namespace YARG.Core.Engine.Guitar
                 Codas[CurrentCodaIndex].Overhit();
             }
 
-            // Prevent overstrum too close to the beginning of a lane. Unlike the Keys and Drums engines,
-            // don't enforce the correct fretting; the player has the flexibility to adjust their fretting hand
-            if (
-                !IsLaneActive && // Not in a lane
-                Notes[NoteIndex].IsLaneStart && // The next note is a lane start
-                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow // That lane is starting soon
-            )
-            {
-                YargLogger.LogFormatTrace("Overhit prevented by lane start leniency at {0}", CurrentTime);
-                return;
-            }
-
-            // Prevent overstrum too soon after the end of a lane. Unlike the Keys and Drums engines, don't
-            // enforce the correct fretting; the player has the flexibility to adjust their fretting hand
-            if (
-                !IsLaneActive && // Not in a lane
-                NoteIndex > 0 && // A previous note exists
-                Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
-                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow // The lane ended recently
-            )
+            // Prevent overstrum too close to a lane. Unlike the Keys and Drums engines, use the lenient
+            // version which doesn't enforce the correct fretting; the player has the flexibility to adjust
+            // their fretting hand.
+            if (IsInLeniencyWindow())
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
                 return;

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -159,7 +159,7 @@ namespace YARG.Core.Engine.Guitar
             // Prevent overstrum too close to a lane. Unlike the Keys and Drums engines, use the lenient
             // version which doesn't enforce the correct fretting; the player has the flexibility to adjust
             // their fretting hand.
-            if (IsInLeniencyWindow())
+            if (IsInLaneLeniencyWindow())
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
                 return;

--- a/YARG.Core/Engine/HitWindowSettings.cs
+++ b/YARG.Core/Engine/HitWindowSettings.cs
@@ -45,14 +45,19 @@ namespace YARG.Core.Engine
         public readonly double FrontToBackRatio;
 
         /// <summary>
-        /// The size of the forgiveness window for trill/tremolo/roll lanes
+        /// The size of the autohitting window for trill/tremolo/roll lanes
         /// </summary>
-        public readonly double TremoloWindow;
+        public readonly double LaneAutohitWindow;
+
+        /// <summary>
+        /// The size of the forgiveness window for inputting shortly before or after a lane
+        /// </summary>
+        public readonly double LaneProximityProtectionWindow;
 
         private readonly double _minMaxWindowRatio;
 
         public HitWindowSettings(double maxWindow, double minWindow, double frontToBackRatio, bool isDynamic,
-            double dwSlope, double dwScale, double dwGamma, double tremoloWindow)
+            double dwSlope, double dwScale, double dwGamma, double laneAutohitWindow, double laneProximityProtectionWindow)
         {
             // Swap max and min if necessary to ensure that max is always larger than min
             if (maxWindow < minWindow)
@@ -70,7 +75,8 @@ namespace YARG.Core.Engine
             DynamicWindowScale = Math.Clamp(dwScale, 0.3, 3);
             DynamicWindowGamma = Math.Clamp(dwGamma, 0.1, 10);
 
-            TremoloWindow = tremoloWindow;
+            LaneAutohitWindow = laneAutohitWindow;
+            LaneProximityProtectionWindow = laneProximityProtectionWindow;
 
             _minMaxWindowRatio = MinWindow / MaxWindow;
         }
@@ -90,12 +96,17 @@ namespace YARG.Core.Engine
             if (version is >= 10 and < 12)
             {
                 var tremoloFrontendPercent = stream.Read<double>(Endianness.Little);
-                TremoloWindow = -GetFrontEnd(MaxWindow) * tremoloFrontendPercent;
+                LaneAutohitWindow = -GetFrontEnd(MaxWindow) * tremoloFrontendPercent;
             }
 
             if (version >= 12)
             {
-                TremoloWindow = stream.Read<double>(Endianness.Little);
+                LaneAutohitWindow = stream.Read<double>(Endianness.Little);
+            }
+
+            if (version >= 15)
+            {
+                LaneProximityProtectionWindow = stream.Read<double>(Endianness.Little);
             }
 
             _minMaxWindowRatio = MinWindow / MaxWindow;
@@ -112,7 +123,8 @@ namespace YARG.Core.Engine
             writer.Write(DynamicWindowScale);
             writer.Write(DynamicWindowGamma);
 
-            writer.Write(TremoloWindow);
+            writer.Write(LaneAutohitWindow);
+            writer.Write(LaneProximityProtectionWindow);
         }
 
         /// <summary>

--- a/YARG.Core/Engine/Keys/FiveLaneKeys/YargFiveLaneKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/FiveLaneKeys/YargFiveLaneKeysEngine.cs
@@ -96,7 +96,7 @@ namespace YARG.Core.Engine.Keys.Engines
                 if (missed)
                 {
                     // Intercept missed note while lane phrase is active
-                    if (!HitNoteFromLane(parentNote))
+                    if (!AutohitNoteFromLane(parentNote))
                     {
                         // If one of the notes in the chord was missed out the back end,
                         // that means all of them would miss.
@@ -154,7 +154,7 @@ namespace YARG.Core.Engine.Keys.Engines
                                 }
                                 else
                                 {
-                                    if (HitNoteFromLane(note))
+                                    if (AutohitNoteFromLane(note))
                                     {
                                         YargLogger.LogFormatTrace("Forgiving chord staggering for note {0} due to lane phrase", (int)note.FiveLaneKeysAction);
                                     }

--- a/YARG.Core/Engine/Keys/KeysEngine.cs
+++ b/YARG.Core/Engine/Keys/KeysEngine.cs
@@ -138,7 +138,7 @@ namespace YARG.Core.Engine.Keys
             if (
                 !IsLaneActive && // Not in a lane
                 Notes[NoteIndex].IsLaneStart && // The next note is a lane start
-                Notes[NoteIndex].Time - CurrentTime < LANE_PROXIMITY_LENIENCY && // That lane is starting soon
+                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane is starting soon
                 LaneAboutToStartIncludesNote(key, Notes[NoteIndex]) // The overhit matches the lane that's about to begin
             )
             {
@@ -151,7 +151,7 @@ namespace YARG.Core.Engine.Keys
                 !IsLaneActive && // Not in a lane
                 NoteIndex > 0 && // A previous note exists
                 Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
-                CurrentTime - Notes[NoteIndex - 1].Time < LANE_PROXIMITY_LENIENCY && // The lane ended recently
+                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // The lane ended recently
                 LaneThatJustEndedIncludesNote(key, Notes[NoteIndex - 1]) // The overhit matches the lane that just ended
             )
             {

--- a/YARG.Core/Engine/Keys/KeysEngine.cs
+++ b/YARG.Core/Engine/Keys/KeysEngine.cs
@@ -134,6 +134,31 @@ namespace YARG.Core.Engine.Keys
                 return;
             }
 
+            // Prevent overhit too close to the beginning of a lane that accepts the overhit
+            if (
+                !IsLaneActive && // Not in a lane
+                Notes[NoteIndex].IsLaneStart && // The next note is a lane start
+                Notes[NoteIndex].Time - CurrentTime < LANE_PROXIMITY_LENIENCY && // That lane is starting soon
+                LaneAboutToStartIncludesNote(key, Notes[NoteIndex]) // The overhit matches the lane that's about to begin
+            )
+            {
+                YargLogger.LogFormatTrace("Overhit prevented by lane start leniency at {0}", CurrentTime);
+                return;
+            }
+
+            // Prevent overhit too soon after the end of a lane that accepts the overhit
+            if (
+                !IsLaneActive && // Not in a lane
+                NoteIndex > 0 && // A previous note exists
+                Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
+                CurrentTime - Notes[NoteIndex - 1].Time < LANE_PROXIMITY_LENIENCY && // The lane ended recently
+                LaneThatJustEndedIncludesNote(key, Notes[NoteIndex - 1]) // The overhit matches the lane that just ended
+            )
+            {
+                YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
+                return;
+            }
+
             // Prevent overhit during coda
             if (IsCodaActive)
             {

--- a/YARG.Core/Engine/Keys/KeysEngine.cs
+++ b/YARG.Core/Engine/Keys/KeysEngine.cs
@@ -135,7 +135,7 @@ namespace YARG.Core.Engine.Keys
             }
 
             // Prevent overhit too close to a lane that accepts the overhit
-            if (IsInLeniencyWindow(key))
+            if (IsInLaneLeniencyWindow(key))
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
                 return;

--- a/YARG.Core/Engine/Keys/KeysEngine.cs
+++ b/YARG.Core/Engine/Keys/KeysEngine.cs
@@ -134,26 +134,8 @@ namespace YARG.Core.Engine.Keys
                 return;
             }
 
-            // Prevent overhit too close to the beginning of a lane that accepts the overhit
-            if (
-                !IsLaneActive && // Not in a lane
-                Notes[NoteIndex].IsLaneStart && // The next note is a lane start
-                Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane is starting soon
-                LaneAboutToStartIncludesNote(key, Notes[NoteIndex]) // The overhit matches the lane that's about to begin
-            )
-            {
-                YargLogger.LogFormatTrace("Overhit prevented by lane start leniency at {0}", CurrentTime);
-                return;
-            }
-
-            // Prevent overhit too soon after the end of a lane that accepts the overhit
-            if (
-                !IsLaneActive && // Not in a lane
-                NoteIndex > 0 && // A previous note exists
-                Notes[NoteIndex - 1].IsLaneEnd && // The previous note was a lane end
-                CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // The lane ended recently
-                LaneThatJustEndedIncludesNote(key, Notes[NoteIndex - 1]) // The overhit matches the lane that just ended
-            )
+            // Prevent overhit too close to a lane that accepts the overhit
+            if (IsInLeniencyWindow(key))
             {
                 YargLogger.LogFormatTrace("Overhit prevented by lane end leniency at {0}", CurrentTime);
                 return;

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
@@ -136,7 +136,7 @@ namespace YARG.Core.Engine.Keys.Engines
                 if (missed)
                 {
                     // Intercept missed note while lane phrase is active
-                    if (!HitNoteFromLane(parentNote))
+                    if (!AutohitNoteFromLane(parentNote))
                     {
                         // If one of the notes in the chord was missed out the back end,
                         // that means all of them would miss.

--- a/YARG.Core/Game/Presets/EnginePreset.Defaults.cs
+++ b/YARG.Core/Game/Presets/EnginePreset.Defaults.cs
@@ -16,21 +16,24 @@ namespace YARG.Core.Game
                 StrumLeniencySmall = 0.03,
                 HitWindow =
                 {
-                    TremoloWindow = 0.200
+                    LaneAutohitWindow = 0.200,
+                    LaneProximityProtectionWindow = 0.100
                 }
             },
             Drums =
             {
                 HitWindow =
                 {
-                    TremoloWindow = 0.200
+                    LaneAutohitWindow = 0.200,
+                    LaneProximityProtectionWindow = 0.100
                 }
             },
             ProKeys =
             {
                 HitWindow =
                 {
-                    TremoloWindow = 0.200
+                    LaneAutohitWindow = 0.200,
+                    LaneProximityProtectionWindow = 0.100
                 }
             },
             Vocals =
@@ -53,7 +56,8 @@ namespace YARG.Core.Game
                     DynamicScale = 1,
                     DynamicSlope = 0.93,
                     DynamicGamma = 1.5,
-                    TremoloWindow = 0.160
+                    LaneAutohitWindow = 0.160,
+                    LaneProximityProtectionWindow = 0.080
                 }
             },
             Drums =
@@ -66,7 +70,8 @@ namespace YARG.Core.Game
                     DynamicScale = 1,
                     DynamicSlope = 0.60615,
                     DynamicGamma = 2,
-                    TremoloWindow = 0.160
+                    LaneAutohitWindow = 0.160,
+                    LaneProximityProtectionWindow = 0.080
                 }
             },
             Vocals =

--- a/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
+++ b/YARG.Core/Game/Presets/EnginePreset.Instruments.cs
@@ -47,12 +47,16 @@ namespace YARG.Core.Game
 
             [SettingType(SettingType.MillisecondInput)]
             [SettingRange(min: 0f)]
-            public double TremoloWindow = 0.160;
+            public double LaneAutohitWindow = 0.160;
+
+            [SettingType(SettingType.MillisecondInput)]
+            [SettingRange(min: 0f)]
+            public double LaneProximityProtectionWindow = 0.080;
 
             public HitWindowSettings Create()
             {
                 return new HitWindowSettings(MaxWindow, MinWindow, FrontToBackRatio, IsDynamic,
-                    DynamicSlope, DynamicScale, DynamicGamma, TremoloWindow);
+                    DynamicSlope, DynamicScale, DynamicGamma, LaneAutohitWindow, LaneProximityProtectionWindow);
             }
 
             public HitWindowPreset Copy()
@@ -69,7 +73,8 @@ namespace YARG.Core.Game
 
                     FrontToBackRatio = FrontToBackRatio,
 
-                    TremoloWindow = TremoloWindow
+                    LaneAutohitWindow = LaneAutohitWindow,
+                    LaneProximityProtectionWindow = LaneProximityProtectionWindow
                 };
             }
         }
@@ -117,7 +122,7 @@ namespace YARG.Core.Game
                 MinWindow = 0.14,
                 IsDynamic = false,
                 FrontToBackRatio = 1.0,
-                TremoloWindow = 0.160
+                LaneAutohitWindow = 0.160
             };
 
             public FiveFretGuitarPreset Copy()
@@ -176,7 +181,7 @@ namespace YARG.Core.Game
                 MinWindow = 0.14,
                 IsDynamic = false,
                 FrontToBackRatio = 1.0,
-                TremoloWindow = 0.160
+                LaneAutohitWindow = 0.160
             };
 
             public DrumsPreset Copy()
@@ -301,7 +306,7 @@ namespace YARG.Core.Game
                 };
 
                 var hitWindow = new HitWindowSettings(
-                    PercussionHitWindow, PercussionHitWindow, 1, false, 0, 0, 0, 0);
+                    PercussionHitWindow, PercussionHitWindow, 1, false, 0, 0, 0, 0, 0);
 
                 return new VocalsEngineParameters(
                     hitWindow,
@@ -347,7 +352,7 @@ namespace YARG.Core.Game
                 MinWindow = 0.14,
                 IsDynamic = false,
                 FrontToBackRatio = 1.0,
-                TremoloWindow = 0.160
+                LaneAutohitWindow = 0.160
             };
 
             public ProKeysPreset Copy()

--- a/YARG.Core/Replays/ReplayIO.cs
+++ b/YARG.Core/Replays/ReplayIO.cs
@@ -29,8 +29,8 @@ namespace YARG.Core.Replays
         private static readonly EightCC REPLAY_MAGIC_HEADER_OLD = new('Y', 'A', 'R', 'G', 'P', 'L', 'A', 'Y');
         private static readonly EightCC REPLAY_MAGIC_HEADER = new('Y', 'A', 'R', 'E', 'P', 'L', 'A', 'Y');
 
-        private static readonly (int OLD_MIN, int METADATA_MIN, int DATA_MIN, int CURRENT) REPLAY_VERSIONS = (4, 6, 9, 14);
-        private const int ENGINE_VERSION = 4;
+        private static readonly (int OLD_MIN, int METADATA_MIN, int DATA_MIN, int CURRENT) REPLAY_VERSIONS = (4, 6, 9, 15);
+        private const int ENGINE_VERSION = 5;
 
         public static (ReplayReadResult Result, ReplayInfo Info, ReplayData Data) TryDeserialize(string path, ReplayReadOptions replayOptions)
         {


### PR DESCRIPTION
[Corresponding YARG PR](https://github.com/YARC-Official/YARG/pull/1491)

This PR changes the fundamentals of lanes work:
* Within a lane, overhit protection (for the inputs that the lane expects) is never revoked under any circumstances
* `LaneExpireTime` and `TremoloWindow` no longer exist per se, but are closely replaced by `LaneAutohitExpireTime` and `LaneAutohitWindow`
* `LaneAutohitExpireTime` is set to `CurrentTime + LaneAutohitWindow` whenever a lane receives an input, regardless of whether that input hit a note - as long as you're spamming inputs to the lane, you're keeping your autohit up
* When a laned note would pass out of the back of the hit window, we check if it's within the current autohit time and autohit it if so
* There is also a new `LaneProximityProtectionWindow` parameter (bit of a mouthful, feel free to suggest a rename) that drives autohit protection immediately before and after a lane (the latter was previously driven by the expire time, but is now flat from the end of the lane regardless of inputs)
  * On Drums and Keys, these protection windows only apply to inputs that would have satisfied the lane (e.g. you can't be forgiven for overhitting a Gcym right after a snare roll)
  * On Guitar, these protection windows apply to any overstrum at all, to provide forgiveness to players who might be transitioning between two tremolos and briefly fretting some intermediate state. They also protect against ghosting, but only for trills, and only for inputs that match the trill that's providing the forgiveness

The most important change here is that we no longer revoke overhit protection during lanes, and instead only revoke autohitting (a.k.a. underhit protection). This matches RB and CH's handling of lanes (despite what the RBN docs will tell you) and allows for lanes to be charted more sparsely than they would otherwise need to be to avoid unfair overhits.

Aside from that, these changes also produce a happy middle-ground between RB and CH's systems:
* RB's system (hardcoded input speed requirement for literally any lane) enables lanes to preserve playability for any charted NPS (which many RB charts take advantage of), but makes the contents of the lane completely irrelevant
* CH's system (forgive every-other note in the lane) keeps the contents of the lane relevant to gameplay, but hits limitations with particularly fast lanes (found in many RB charts) where even half of the charted input speed is oppressive
* This system keeps the charted speed relevant to gameplay like CH, but also introduces a limit on the required speed to keep everything playable like RB. The `LaneAutohitWindow` engine parameter allows players to configure that speed limit if they find it inadequate or overly generous

Some notes for the reviewer:
* I'm unsure if I correctly updated the replay and engine version numbers
* I've tested these changes in gameplay, but not super robustly and will continue to verify that things work as intended
* I'm not married to any of the parameter names or tooltips, if you want to editorialize
* I'm also not married to the default values for the parameters; happy to retune
* This also sneaks in a few `BaseEngine` replay consistency fixes suggested by @jstnlef; see his comments for details