### PR TITLE
fix highway lowering early bug in some charts

### DIFF
--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -182,13 +182,16 @@ namespace YARG.Core.Chart
             if (notes.Count < 1)
                 return 0;
 
-            // Chart events are sorted
-            var chartEvent = notes[^1];
-            var timeEnd = chartEvent.TimeEnd;
-            //child notes may have later end times
-            foreach (var child in chartEvent.ChildNotes)
+            double timeEnd = 0;
+
+            //child notes or earlier notes may have later end times
+            foreach (var chord in notes)
             {
-                timeEnd = Math.Max(timeEnd, child.TimeEnd);
+                timeEnd = Math.Max(timeEnd, chord.TimeEnd);
+                foreach (var child in chord.ChildNotes)
+                {
+                    timeEnd = Math.Max(timeEnd, child.TimeEnd);
+                }
             }
             return timeEnd;
         }

--- a/YARG.Core/Chart/Events/ChartEventExtensions.cs
+++ b/YARG.Core/Chart/Events/ChartEventExtensions.cs
@@ -176,6 +176,23 @@ namespace YARG.Core.Chart
             return chartEvent.TimeEnd;
         }
 
+        public static double GetNoteEndTime<TNote>(this List<TNote> notes)
+            where TNote : Note<TNote>
+        {
+            if (notes.Count < 1)
+                return 0;
+
+            // Chart events are sorted
+            var chartEvent = notes[^1];
+            var timeEnd = chartEvent.TimeEnd;
+            //child notes may have later end times
+            foreach (var child in chartEvent.ChildNotes)
+            {
+                timeEnd = Math.Max(timeEnd, child.TimeEnd);
+            }
+            return timeEnd;
+        }
+
         public static uint GetFirstTick<TEvent>(this List<TEvent> events)
             where TEvent : ChartEvent
         {

--- a/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
+++ b/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
@@ -78,6 +78,7 @@ namespace YARG.Core.Chart
         public double GetEndTime()
         {
             double totalEndTime = 0;
+
             totalEndTime = Math.Max(Notes.GetNoteEndTime(), totalEndTime);
 
             totalEndTime = Math.Max(Phrases.GetEndTime(), totalEndTime);

--- a/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
+++ b/YARG.Core/Chart/Tracks/InstrumentDifficulty.cs
@@ -78,8 +78,7 @@ namespace YARG.Core.Chart
         public double GetEndTime()
         {
             double totalEndTime = 0;
-
-            totalEndTime = Math.Max(Notes.GetEndTime(), totalEndTime);
+            totalEndTime = Math.Max(Notes.GetNoteEndTime(), totalEndTime);
 
             totalEndTime = Math.Max(Phrases.GetEndTime(), totalEndTime);
             totalEndTime = Math.Max(TextEvents.GetEndTime(), totalEndTime);
@@ -94,7 +93,7 @@ namespace YARG.Core.Chart
 
         public double GetLastNoteEndTime()
         {
-            return Notes.GetEndTime();
+            return Notes.GetNoteEndTime();
         }
 
         public uint GetFirstTick()


### PR DESCRIPTION
if the last note of a chart is a chord with different length notes currently we lower the highway after the parent note in the chord ends.
this leads to for example any GRYBO non-sustain note on top of an open sustain lowering the highway immediately, because an open note in a chord is reliably parsed as a child.

To Fix this, this PR adds a new method to replace GetEndTime for Lists of Notes that iterates over the children of the last note to get the actual end of the chord.