### PR TITLE
Glissando behavior fixes

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using MoonscraperChartEditor.Song;
+using YARG.Core.Extensions;
 
 namespace YARG.Core.Chart
 {
@@ -45,8 +46,26 @@ namespace YARG.Core.Chart
             if (currentPhrases.TryGetValue(MoonPhrase.Type.ProKeys_Glissando, out var glissando) &&
                 IsEventInPhrase(moonNote, glissando, inclusiveEnd: true))
             {
+                // Sustains are not allowed in glissandos, so make sure the note has zero length
+                moonNote.length = 0;
+
                 flags |= ProKeysNoteFlags.Glissando;
+
+                var previous = moonNote.PreviousSeperateMoonNote;
+                var next = moonNote.NextSeperateMoonNote;
+
+                if (previous is null || !IsEventInPhrase(previous, glissando, inclusiveEnd: true))
+                {
+                    flags |= ProKeysNoteFlags.GlissandoStart;
+                }
+
+                if (next is null || !IsEventInPhrase(next, glissando, inclusiveEnd: true))
+                {
+                    flags |= ProKeysNoteFlags.GlissandoEnd;
+                }
             }
+
+
 
             return flags;
         }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
@@ -64,8 +64,6 @@ namespace YARG.Core.Chart
                 }
             }
 
-
-
             return flags;
         }
     }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using MoonscraperChartEditor.Song;
-using YARG.Core.Extensions;
 
 namespace YARG.Core.Chart
 {

--- a/YARG.Core/Chart/Notes/ProKeysNote.cs
+++ b/YARG.Core/Chart/Notes/ProKeysNote.cs
@@ -13,6 +13,8 @@ namespace YARG.Core.Chart
         public int NoteMask     { get; private set; }
 
         public bool IsGlissando => (ProKeysFlags & ProKeysNoteFlags.Glissando) != 0;
+        public bool IsGlissandoStart => (ProKeysFlags & ProKeysNoteFlags.GlissandoStart) != 0;
+        public bool IsGlissandoEnd => (ProKeysFlags & ProKeysNoteFlags.GlissandoEnd) != 0;
 
         public bool IsSustain => TickLength > 0;
 
@@ -77,5 +79,7 @@ namespace YARG.Core.Chart
         None = 0,
 
         Glissando = 1 << 0,
+        GlissandoStart = 1 << 1,
+        GlissandoEnd = 1 << 2,
     }
 }

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -150,14 +150,19 @@ namespace YARG.Core.Engine.Keys
                 StartSustain(note);
             }
 
-            if (note.IsGlissandoStart)
+            if (note.IsGlissando)
             {
-                IsGlissandoActive = true;
-            }
+                UpdateLaneAutohitExpireTime();
 
-            if (note.IsGlissandoEnd)
-            {
-                IsGlissandoActive = false;
+                if (note.IsGlissandoStart)
+                {
+                    IsGlissandoActive = true;
+                }
+
+                if (note.IsGlissandoEnd)
+                {
+                    IsGlissandoActive = false;
+                }
             }
 
             OnNoteHit?.Invoke(NoteIndex, note);
@@ -177,6 +182,14 @@ namespace YARG.Core.Engine.Keys
 
             // Can't miss a note during BRE phrase
             if (IsCodaActive && note.IsBigRockEnding)
+            {
+                note.SetHitState(true, false);
+                base.HitNote(note);
+                return;
+            }
+
+            // Autohit glissando notes as long as the player keeps providing inputs
+            if (note.IsGlissando && note.Time < LaneAutohitExpireTime)
             {
                 note.SetHitState(true, false);
                 base.HitNote(note);

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -13,6 +13,8 @@ namespace YARG.Core.Engine.Keys
         protected ProKeysNote? FatFingerNote;
         protected int? FatFingerKey;
 
+        protected bool IsGlissandoActive = false;
+
         protected override double[] KeyPressTimes { get; } = new double[(int) ProKeysAction.Key25 + 1];
 
         public EngineTimer GetFatFingerTimer() => FatFingerTimer;
@@ -148,6 +150,16 @@ namespace YARG.Core.Engine.Keys
                 StartSustain(note);
             }
 
+            if (note.IsGlissandoStart)
+            {
+                IsGlissandoActive = true;
+            }
+
+            if (note.IsGlissandoEnd)
+            {
+                IsGlissandoActive = false;
+            }
+
             OnNoteHit?.Invoke(NoteIndex, note);
             base.HitNote(note);
         }
@@ -200,6 +212,16 @@ namespace YARG.Core.Engine.Keys
             else if (note.IsSoloStart)
             {
                 StartSolo();
+            }
+
+            if (note.IsGlissandoStart)
+            {
+                IsGlissandoActive = true;
+            }
+
+            if (note.IsGlissandoEnd)
+            {
+                IsGlissandoActive = false;
             }
 
             // If no notes within a chord were hit, combo is 0

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
@@ -131,6 +131,7 @@ namespace YARG.Core.Engine.Keys.Engines
             // Can't overhit during a glissando
             if (IsGlissandoActive)
             {
+                UpdateLaneAutohitExpireTime(); // Lane autohitting applies to glissando notes
                 return;
             }
 

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
@@ -126,6 +126,29 @@ namespace YARG.Core.Engine.Keys.Engines
             UpdateSustains();
         }
 
+        protected override void Overhit(int key)
+        {
+            // Can't overhit during a glissando
+            if (IsGlissandoActive)
+            {
+                return;
+            }
+
+            // Can't overhit within the lane proximity leniency window before the beginning of a glissando
+            if (NoteIndex < Notes.Count && Notes[NoteIndex].IsGlissandoStart && Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow)
+            {
+                return;
+            }
+
+            // Can't overhit within the lane proximity leniency window after the end of a glissando
+            if (NoteIndex > 0 && Notes[NoteIndex - 1].IsGlissandoEnd && CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow)
+            {
+                return;
+            }
+
+            base.Overhit(key);
+        }
+
         protected override void CheckForNoteHit()
         {
             var parentNote = Notes[NoteIndex];
@@ -316,8 +339,7 @@ namespace YARG.Core.Engine.Keys.Engines
             }
 
             // Glissando hit logic
-            // Forces the first glissando to be hit correctly, then the rest can be hit "loosely"
-            if (note.PreviousNote is not null && note.IsGlissando && note.PreviousNote.IsGlissando)
+            if (note.IsGlissando)
             {
                 var keyDiff = KeyMask ^ PreviousKeyMask;
                 var keysPressed = keyDiff & KeyMask;


### PR DESCRIPTION
Implements a few behavioral improvements and bug fixes for Pro Keys glissando logic:

* Previously, we were forcing the player to hit the first note of the gliss correctly before kicking in the gliss behavior. This is born out of a misunderstanding of HMX charting practices - HMX often (but not always) _explicitly_ omits the first note of a gliss from the actual gliss phrase to require players to hit it correctly, but this is not an intrinsic behavior of glisses, and the result was that we would effectively require the first _two_ notes of a gliss to be hit correctly. We now interpret all notes within the gliss phrase as being part of the gliss, and it's up to the charter whether to require the first note or not
* We now clip any sustains within a glissando, like we do for other types of lanes
* It is no longer possible to overhit during a gliss. This is the case in RB3 and is consistent with the general intent for glissandos to be relaxed and imprecise; the player shouldn't need to hit _exactly_ the right number of notes (the number of notes charted in a typical glissando is hardly accurate anyway)
* Glissandos now use the new `LaneProximityProtectionWindow` engine parameter to offer overhit protection shortly before and after the gliss, keeping them loose (although if the charter omits the first note from the gliss, that will cut off the frontend protection window, so the gliss keeps its strict first-note requirement)
* On the backend, these changes required introducing `GlissandoStart` and `GlissandoEnd` values for `ProKeysNoteFlags`

Note that this does _not_ implement the autohit window behavior that other lanes use; this means that the player still has to provide (at least) as many key presses are there in the glissando, with no cap for high-speed glissandos. I didn't feel like the autohit behavior was necessary because glissandos are typically limited in length by the width of the highway range, and because counting _every single key press_ as a valid glissando input means that the ceiling for human input speeds is astronomical anyway