### PR TITLE
Fix proximal lane forgiveness mask logic, disallow chords in trills

### DIFF
--- a/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
@@ -1,6 +1,7 @@
 ﻿using Melanchall.DryWetMidi.Core;
 using NUnit.Framework;
 using YARG.Core.Chart;
+using YARG.Core.Engine;
 using YARG.Core.Engine.Drums;
 using YARG.Core.Engine.Drums.Engines;
 using YARG.Core.Game;
@@ -203,6 +204,28 @@ public class DrumEngineTester : EngineTester
         }
     }
 
+    [Test]
+    public void MatchingPadBeforeDrumLaneStart_DoesNotOverhit()
+    {
+        var (engine, notes) = CreateLaneProximityEngine(FourLaneDrumPad.YellowDrum);
+
+        HitPad(engine, notes.Notes[0].Time, DrumsAction.RedDrum);
+        HitPad(engine, notes.Notes[1].Time - 0.2, DrumsAction.YellowDrum);
+
+        Assert.That(engine.EngineStats.Overhits, Is.Zero);
+    }
+
+    [Test]
+    public void MismatchedPadBeforeDrumLaneStart_RecordsOverhit()
+    {
+        var (engine, notes) = CreateLaneProximityEngine(FourLaneDrumPad.YellowDrum);
+
+        HitPad(engine, notes.Notes[0].Time, DrumsAction.RedDrum);
+        HitPad(engine, notes.Notes[1].Time - 0.2, DrumsAction.BlueDrum);
+
+        Assert.That(engine.EngineStats.Overhits, Is.EqualTo(1));
+    }
+
     private (YargDrumsEngine Engine, InstrumentDifficulty<DrumNote> Notes) CreateEngine(bool isBot)
     {
         var chartPath = Path.Combine(ChartDirectory!, "drawntotheflame.mid");
@@ -211,6 +234,44 @@ public class DrumEngineTester : EngineTester
         var notes = chart.ProDrums.GetDifficulty(Difficulty.Expert);
         var engine = new YargDrumsEngine(notes, chart.SyncTrack, _engineParams, isBot, false);
         return (engine, notes);
+    }
+
+    private static (YargDrumsEngine Engine, InstrumentDifficulty<DrumNote> Notes) CreateLaneProximityEngine(
+        FourLaneDrumPad lanePad)
+    {
+        var firstNote = new DrumNote(FourLaneDrumPad.RedDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.None, 0.0, 0);
+        var laneStart = new DrumNote(lanePad, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.Tremolo | NoteFlags.LaneStart, 1.0, 480);
+        var laneEnd = new DrumNote(lanePad, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.Tremolo | NoteFlags.LaneEnd, 1.2, 576);
+
+        firstNote.NextNote = laneStart;
+        laneStart.PreviousNote = firstNote;
+        laneStart.NextNote = laneEnd;
+        laneEnd.PreviousNote = laneStart;
+
+        var notes = new InstrumentDifficulty<DrumNote>(Instrument.ProDrums, Difficulty.Expert,
+            [firstNote, laneStart, laneEnd], new(), new());
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+        var engineParams = new DrumsEngineParameters(
+            new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            DrumsEngineParameters.DrumMode.ProFourLane,
+            false,
+            true);
+
+        return (new YargDrumsEngine(notes, syncTrack, engineParams, false, false), notes);
+    }
+
+    private static void HitPad(YargDrumsEngine engine, double time, DrumsAction action)
+    {
+        var input = GameInput.Create(time, action, 1.0f);
+        engine.QueueInput(ref input);
+        engine.Update(time);
     }
 
     private static void RunEngineToEnd(YargDrumsEngine engine, InstrumentDifficulty<DrumNote> notes)

--- a/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
@@ -205,9 +205,9 @@ public class DrumEngineTester : EngineTester
     }
 
     [Test]
-    public void MatchingPadBeforeDrumLaneStart_DoesNotOverhit()
+    public void MatchingPadBeforeSingleDrumLaneStart_DoesNotOverhit()
     {
-        var (engine, notes) = CreateLaneProximityEngine(FourLaneDrumPad.YellowDrum);
+        var (engine, notes) = CreateSingleLaneProximityEngine(FourLaneDrumPad.YellowDrum);
 
         HitPad(engine, notes.Notes[0].Time, DrumsAction.RedDrum);
         HitPad(engine, notes.Notes[1].Time - 0.2, DrumsAction.YellowDrum);
@@ -216,12 +216,45 @@ public class DrumEngineTester : EngineTester
     }
 
     [Test]
-    public void MismatchedPadBeforeDrumLaneStart_RecordsOverhit()
+    public void MismatchedPadBeforeSingleDrumLaneStart_RecordsOverhit()
     {
-        var (engine, notes) = CreateLaneProximityEngine(FourLaneDrumPad.YellowDrum);
+        var (engine, notes) = CreateSingleLaneProximityEngine(FourLaneDrumPad.YellowDrum);
 
         HitPad(engine, notes.Notes[0].Time, DrumsAction.RedDrum);
         HitPad(engine, notes.Notes[1].Time - 0.2, DrumsAction.BlueDrum);
+
+        Assert.That(engine.EngineStats.Overhits, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void MatchingLeftPadBeforeDoubleDrumLaneStart_DoesNotOverhit()
+    {
+        var (engine, notes) = CreateDoubleLaneProximityEngine(FourLaneDrumPad.YellowCymbal, FourLaneDrumPad.GreenCymbal);
+
+        HitPad(engine, notes.Notes[0].Time, DrumsAction.RedDrum);
+        HitPad(engine, notes.Notes[1].Time - 0.2, DrumsAction.YellowCymbal);
+
+        Assert.That(engine.EngineStats.Overhits, Is.Zero);
+    }
+
+    [Test]
+    public void MatchingRightPadBeforeDoubleDrumLaneStart_DoesNotOverhit()
+    {
+        var (engine, notes) = CreateDoubleLaneProximityEngine(FourLaneDrumPad.YellowCymbal, FourLaneDrumPad.GreenCymbal);
+
+        HitPad(engine, notes.Notes[0].Time, DrumsAction.RedDrum);
+        HitPad(engine, notes.Notes[1].Time - 0.2, DrumsAction.GreenCymbal);
+
+        Assert.That(engine.EngineStats.Overhits, Is.Zero);
+    }
+
+    [Test]
+    public void MismatchedPadBeforeDoubleDrumLaneStart_RecordsOverhit()
+    {
+        var (engine, notes) = CreateDoubleLaneProximityEngine(FourLaneDrumPad.YellowCymbal, FourLaneDrumPad.GreenCymbal);
+
+        HitPad(engine, notes.Notes[0].Time, DrumsAction.RedDrum);
+        HitPad(engine, notes.Notes[1].Time - 0.2, DrumsAction.BlueCymbal);
 
         Assert.That(engine.EngineStats.Overhits, Is.EqualTo(1));
     }
@@ -236,7 +269,7 @@ public class DrumEngineTester : EngineTester
         return (engine, notes);
     }
 
-    private static (YargDrumsEngine Engine, InstrumentDifficulty<DrumNote> Notes) CreateLaneProximityEngine(
+    private static (YargDrumsEngine Engine, InstrumentDifficulty<DrumNote> Notes) CreateSingleLaneProximityEngine(
         FourLaneDrumPad lanePad)
     {
         var firstNote = new DrumNote(FourLaneDrumPad.RedDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
@@ -266,6 +299,38 @@ public class DrumEngineTester : EngineTester
 
         return (new YargDrumsEngine(notes, syncTrack, engineParams, false, false), notes);
     }
+
+    private static (YargDrumsEngine Engine, InstrumentDifficulty<DrumNote> Notes) CreateDoubleLaneProximityEngine(
+        FourLaneDrumPad firstPad, FourLaneDrumPad secondPad)
+    {
+        var firstNote = new DrumNote(FourLaneDrumPad.RedDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.None, 0.0, 0);
+        var laneStart = new DrumNote(firstPad, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.Trill | NoteFlags.LaneStart, 1.0, 480);
+        var laneEnd = new DrumNote(secondPad, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.Trill | NoteFlags.LaneEnd, 1.2, 576);
+
+        firstNote.NextNote = laneStart;
+        laneStart.PreviousNote = firstNote;
+        laneStart.NextNote = laneEnd;
+        laneEnd.PreviousNote = laneStart;
+
+        var notes = new InstrumentDifficulty<DrumNote>(Instrument.ProDrums, Difficulty.Expert,
+            [firstNote, laneStart, laneEnd], new(), new());
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+        var engineParams = new DrumsEngineParameters(
+            new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            DrumsEngineParameters.DrumMode.ProFourLane,
+            false,
+            true);
+
+        return (new YargDrumsEngine(notes, syncTrack, engineParams, false, false), notes);
+    }
+
 
     private static void HitPad(YargDrumsEngine engine, double time, DrumsAction action)
     {

--- a/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
@@ -1,0 +1,106 @@
+using NUnit.Framework;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Guitar;
+using YARG.Core.Engine.Guitar.Engines;
+using YARG.Core.Input;
+
+namespace YARG.Core.UnitTests.Engine;
+
+public class GuitarEngineTester : EngineTester
+{
+    [Test]
+    public void IncludedFretBeforeChordTrillStart_IsForgivenByGuitarGhostLeniency()
+    {
+        var (engine, notes) = CreateTrillProximityEngine();
+
+        Assert.That(engine.IsGhostInputForgivenByTrill((int) GuitarAction.RedFret, notes.Notes[1].Time - 0.2, 1),
+            Is.True);
+    }
+
+    [Test]
+    public void ExcludedFretBeforeChordTrillStart_IsNotForgivenByGuitarGhostLeniency()
+    {
+        var (engine, notes) = CreateTrillProximityEngine();
+
+        Assert.That(engine.IsGhostInputForgivenByTrill((int) GuitarAction.OrangeFret, notes.Notes[1].Time - 0.2, 1),
+            Is.False);
+    }
+
+    private static (TestFiveFretGuitarEngine Engine, InstrumentDifficulty<GuitarNote> Notes) CreateTrillProximityEngine()
+    {
+        var firstNote = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 0.0, 0);
+        var laneStart = CreateNote(FiveFretGuitarFret.Yellow, NoteFlags.Trill | NoteFlags.LaneStart, 1.0, 480);
+        var laneEnd = CreateNote(FiveFretGuitarFret.Red, NoteFlags.Trill | NoteFlags.LaneEnd, 1.2, 576);
+        laneEnd.AddChildNote(CreateNote(FiveFretGuitarFret.Blue, NoteFlags.Trill | NoteFlags.LaneEnd, 1.2, 576));
+
+        LinkNotes(firstNote, laneStart, laneEnd);
+
+        var notes = new InstrumentDifficulty<GuitarNote>(Instrument.FiveFretGuitar, Difficulty.Expert,
+            [firstNote, laneStart, laneEnd], new(), new());
+        var engineParams = new GuitarEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.1,
+            0.1,
+            0.1,
+            false,
+            true,
+            false,
+            false,
+            true);
+
+        return (new TestFiveFretGuitarEngine(notes, CreateSyncTrack(), engineParams), notes);
+    }
+
+    private sealed class TestFiveFretGuitarEngine(
+        InstrumentDifficulty<GuitarNote> chart,
+        SyncTrack syncTrack,
+        GuitarEngineParameters engineParameters)
+        : YargFiveFretGuitarEngine(chart, syncTrack, engineParameters, false)
+    {
+        public bool IsGhostInputForgivenByTrill(int inputNote, double currentTime, int noteIndex)
+        {
+            CurrentTime = currentTime;
+            NoteIndex = noteIndex;
+            return IsGhostInTrillLeniencyWindow(inputNote);
+        }
+    }
+
+    private static GuitarNote CreateNote(FiveFretGuitarFret fret, NoteFlags flags, double time, uint tick)
+    {
+        return new GuitarNote(fret, GuitarNoteType.Strum, GuitarNoteFlags.None, flags, time, 0, tick, 0);
+    }
+
+    private static void LinkNotes(params GuitarNote[] notes)
+    {
+        for (int i = 0; i < notes.Length; i++)
+        {
+            if (i > 0)
+            {
+                notes[i].PreviousNote = notes[i - 1];
+            }
+
+            if (i < notes.Length - 1)
+            {
+                notes[i].NextNote = notes[i + 1];
+            }
+        }
+    }
+
+    private static SyncTrack CreateSyncTrack()
+    {
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+        return syncTrack;
+    }
+
+    private static HitWindowSettings CreateHitWindowSettings()
+    {
+        return new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25);
+    }
+}

--- a/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using YARG.Core.Chart;
 using YARG.Core.Engine;
 using YARG.Core.Engine.Guitar;
@@ -10,7 +10,16 @@ namespace YARG.Core.UnitTests.Engine;
 public class GuitarEngineTester : EngineTester
 {
     [Test]
-    public void IncludedFretBeforeChordTrillStart_IsForgivenByGuitarGhostLeniency()
+    public void TopFretBeforeTrillStart_IsForgivenByGuitarGhostLeniency()
+    {
+        var (engine, notes) = CreateTrillProximityEngine();
+
+        Assert.That(engine.IsGhostInputForgivenByTrill((int) GuitarAction.YellowFret, notes.Notes[1].Time - 0.2, 1),
+            Is.True);
+    }
+
+    [Test]
+    public void BottomFretBeforeTrillStart_IsForgivenByGuitarGhostLeniency()
     {
         var (engine, notes) = CreateTrillProximityEngine();
 
@@ -32,7 +41,6 @@ public class GuitarEngineTester : EngineTester
         var firstNote = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 0.0, 0);
         var laneStart = CreateNote(FiveFretGuitarFret.Yellow, NoteFlags.Trill | NoteFlags.LaneStart, 1.0, 480);
         var laneEnd = CreateNote(FiveFretGuitarFret.Red, NoteFlags.Trill | NoteFlags.LaneEnd, 1.2, 576);
-        laneEnd.AddChildNote(CreateNote(FiveFretGuitarFret.Blue, NoteFlags.Trill | NoteFlags.LaneEnd, 1.2, 576));
 
         LinkNotes(firstNote, laneStart, laneEnd);
 

--- a/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
@@ -1,4 +1,4 @@
-using NUnit.Framework;
+﻿using NUnit.Framework;
 using YARG.Core.Chart;
 using YARG.Core.Engine;
 using YARG.Core.Engine.Keys;
@@ -10,9 +10,9 @@ namespace YARG.Core.UnitTests.Engine;
 public class KeysEngineTester : EngineTester
 {
     [Test]
-    public void MatchingKeyBeforeChordLaneStart_DoesNotOverhit()
+    public void MatchingKeyBeforeChordTremoloLaneStart_DoesNotOverhit()
     {
-        var (engine, notes) = CreateLaneProximityEngine();
+        var (engine, notes) = CreateChordTremoloLaneProximityEngine();
 
         PressKey(engine, notes.Notes[0].Time, ProKeysAction.GreenKey);
         ReleaseKey(engine, 0.1, ProKeysAction.GreenKey);
@@ -22,9 +22,9 @@ public class KeysEngineTester : EngineTester
     }
 
     [Test]
-    public void MismatchedKeyBeforeChordLaneStart_RecordsOverhit()
+    public void MismatchedKeyBeforeChordTremoloLaneStart_RecordsOverhit()
     {
-        var (engine, notes) = CreateLaneProximityEngine();
+        var (engine, notes) = CreateChordTremoloLaneProximityEngine();
 
         int? overhitKey = null;
         engine.OnOverhit += key => overhitKey = key;
@@ -40,13 +40,78 @@ public class KeysEngineTester : EngineTester
         }
     }
 
-    private static (YargFiveLaneKeysEngine Engine, InstrumentDifficulty<GuitarNote> Notes) CreateLaneProximityEngine()
+    [Test]
+    public void MatchingTopKeyBeforeTrillLaneStart_DoesNotOverhit()
+    {
+        var (engine, notes) = CreateTrillLaneProximityEngine();
+
+        PressKey(engine, notes.Notes[0].Time, ProKeysAction.GreenKey);
+        ReleaseKey(engine, 0.1, ProKeysAction.GreenKey);
+        PressKey(engine, notes.Notes[1].Time - 0.2, ProKeysAction.OrangeKey);
+
+        Assert.That(engine.EngineStats.Overhits, Is.Zero);
+    }
+
+    [Test]
+    public void MatchingBottomKeyBeforeTrillLaneStart_DoesNotOverhit()
+    {
+        var (engine, notes) = CreateTrillLaneProximityEngine();
+
+        PressKey(engine, notes.Notes[0].Time, ProKeysAction.GreenKey);
+        ReleaseKey(engine, 0.1, ProKeysAction.GreenKey);
+        PressKey(engine, notes.Notes[1].Time - 0.2, ProKeysAction.GreenKey);
+
+        Assert.That(engine.EngineStats.Overhits, Is.Zero);
+    }
+
+    [Test]
+    public void MismatchedKeyBeforeTrillLaneStart_DoesNotOverhit()
+    {
+        var (engine, notes) = CreateTrillLaneProximityEngine();
+
+        int? overhitKey = null;
+        engine.OnOverhit += key => overhitKey = key;
+
+        PressKey(engine, notes.Notes[0].Time, ProKeysAction.GreenKey);
+        ReleaseKey(engine, 0.1, ProKeysAction.GreenKey);
+        PressKey(engine, notes.Notes[1].Time - 0.2, ProKeysAction.YellowKey);
+
+        Assert.That(engine.EngineStats.Overhits, Is.EqualTo(1));
+        Assert.That(overhitKey, Is.EqualTo((int) FiveLaneKeysEngine.FiveLaneKeysAction.YellowKey));
+    }
+
+    private static (YargFiveLaneKeysEngine Engine, InstrumentDifficulty<GuitarNote> Notes) CreateChordTremoloLaneProximityEngine()
     {
         var firstNote = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 0.0, 0);
         var laneStart = CreateNote(FiveFretGuitarFret.Green, NoteFlags.Tremolo | NoteFlags.LaneStart, 1.0, 480);
         laneStart.AddChildNote(CreateNote(FiveFretGuitarFret.Red, NoteFlags.Tremolo | NoteFlags.LaneStart, 1.0, 480));
         var laneEnd = CreateNote(FiveFretGuitarFret.Green, NoteFlags.Tremolo | NoteFlags.LaneEnd, 1.2, 576);
         laneEnd.AddChildNote(CreateNote(FiveFretGuitarFret.Red, NoteFlags.Tremolo | NoteFlags.LaneEnd, 1.2, 576));
+
+        LinkNotes(firstNote, laneStart, laneEnd);
+
+        var notes = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert,
+            [firstNote, laneStart, laneEnd], new(), new());
+        var engineParams = new KeysEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.05,
+            0,
+            false,
+            true);
+
+        return (new YargFiveLaneKeysEngine(notes, CreateSyncTrack(), engineParams, false), notes);
+    }
+
+    private static (YargFiveLaneKeysEngine Engine, InstrumentDifficulty<GuitarNote> Notes) CreateTrillLaneProximityEngine()
+    {
+        var firstNote = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 0.0, 0);
+        var laneStart = CreateNote(FiveFretGuitarFret.Green, NoteFlags.Trill | NoteFlags.LaneStart, 1.0, 480);
+        var laneEnd = CreateNote(FiveFretGuitarFret.Orange, NoteFlags.Trill | NoteFlags.LaneEnd, 1.2, 576);
 
         LinkNotes(firstNote, laneStart, laneEnd);
 

--- a/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
@@ -1,0 +1,118 @@
+using NUnit.Framework;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Keys;
+using YARG.Core.Engine.Keys.Engines;
+using YARG.Core.Input;
+
+namespace YARG.Core.UnitTests.Engine;
+
+public class KeysEngineTester : EngineTester
+{
+    [Test]
+    public void MatchingKeyBeforeChordLaneStart_DoesNotOverhit()
+    {
+        var (engine, notes) = CreateLaneProximityEngine();
+
+        PressKey(engine, notes.Notes[0].Time, ProKeysAction.GreenKey);
+        ReleaseKey(engine, 0.1, ProKeysAction.GreenKey);
+        PressKey(engine, notes.Notes[1].Time - 0.2, ProKeysAction.GreenKey);
+
+        Assert.That(engine.EngineStats.Overhits, Is.Zero);
+    }
+
+    [Test]
+    public void MismatchedKeyBeforeChordLaneStart_RecordsOverhit()
+    {
+        var (engine, notes) = CreateLaneProximityEngine();
+
+        int? overhitKey = null;
+        engine.OnOverhit += key => overhitKey = key;
+
+        PressKey(engine, notes.Notes[0].Time, ProKeysAction.GreenKey);
+        ReleaseKey(engine, 0.1, ProKeysAction.GreenKey);
+        PressKey(engine, notes.Notes[1].Time - 0.2, ProKeysAction.BlueKey);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engine.EngineStats.Overhits, Is.EqualTo(1));
+            Assert.That(overhitKey, Is.EqualTo((int) FiveLaneKeysEngine.FiveLaneKeysAction.BlueKey));
+        }
+    }
+
+    private static (YargFiveLaneKeysEngine Engine, InstrumentDifficulty<GuitarNote> Notes) CreateLaneProximityEngine()
+    {
+        var firstNote = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 0.0, 0);
+        var laneStart = CreateNote(FiveFretGuitarFret.Green, NoteFlags.Tremolo | NoteFlags.LaneStart, 1.0, 480);
+        laneStart.AddChildNote(CreateNote(FiveFretGuitarFret.Red, NoteFlags.Tremolo | NoteFlags.LaneStart, 1.0, 480));
+        var laneEnd = CreateNote(FiveFretGuitarFret.Green, NoteFlags.Tremolo | NoteFlags.LaneEnd, 1.2, 576);
+        laneEnd.AddChildNote(CreateNote(FiveFretGuitarFret.Red, NoteFlags.Tremolo | NoteFlags.LaneEnd, 1.2, 576));
+
+        LinkNotes(firstNote, laneStart, laneEnd);
+
+        var notes = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert,
+            [firstNote, laneStart, laneEnd], new(), new());
+        var engineParams = new KeysEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.05,
+            0,
+            false,
+            true);
+
+        return (new YargFiveLaneKeysEngine(notes, CreateSyncTrack(), engineParams, false), notes);
+    }
+
+    private static GuitarNote CreateNote(FiveFretGuitarFret fret, NoteFlags flags, double time, uint tick)
+    {
+        return new GuitarNote(fret, GuitarNoteType.Strum, GuitarNoteFlags.None, flags, time, 0, tick, 0);
+    }
+
+    private static void LinkNotes(params GuitarNote[] notes)
+    {
+        for (int i = 0; i < notes.Length; i++)
+        {
+            if (i > 0)
+            {
+                notes[i].PreviousNote = notes[i - 1];
+            }
+
+            if (i < notes.Length - 1)
+            {
+                notes[i].NextNote = notes[i + 1];
+            }
+        }
+    }
+
+    private static SyncTrack CreateSyncTrack()
+    {
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+        return syncTrack;
+    }
+
+    private static HitWindowSettings CreateHitWindowSettings()
+    {
+        return new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25);
+    }
+
+    private static void PressKey(YargFiveLaneKeysEngine engine, double time, ProKeysAction action)
+    {
+        QueueInput(engine, GameInput.Create(time, action, true));
+    }
+
+    private static void ReleaseKey(YargFiveLaneKeysEngine engine, double time, ProKeysAction action)
+    {
+        QueueInput(engine, GameInput.Create(time, action, false));
+    }
+
+    private static void QueueInput(YargFiveLaneKeysEngine engine, GameInput input)
+    {
+        engine.QueueInput(ref input);
+        engine.Update(input.Time);
+    }
+}

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -78,12 +78,49 @@ namespace YARG.Core.Chart
             return new(instrument, difficulties, GetAnimationTrack(instrument));
         }
 
+        // "Hand chords" are ineligible for drum trills, but chords consisting of one hand gem and a kick are eligible
+        private static bool IsEligibleForDrumTrill(MoonNote moonNote)
+        {
+            var numberOfHandGems = 0;
+            var currentNote = moonNote;
+
+            while (currentNote is not null && currentNote.tick == moonNote.tick)
+            {
+                if (currentNote.drumPad is not DrumPad.Kick)
+                {
+                    numberOfHandGems++;
+                    if (numberOfHandGems > 1)
+                    {
+                        return false;
+                    }
+                }
+                currentNote = currentNote.previous;
+            }
+
+            currentNote = moonNote.next;
+
+            while (currentNote is not null && currentNote.tick == moonNote.tick)
+            {
+                if (currentNote.drumPad is not DrumPad.Kick)
+                {
+                    numberOfHandGems++;
+                    if (numberOfHandGems > 1)
+                    {
+                        return false;
+                    }
+                }
+                currentNote = currentNote.next;
+            }
+
+            return true;
+        }
+
         private DrumNote CreateFourLaneDrumNote(MoonNote moonNote, Dictionary<MoonPhrase.Type, MoonPhrase> currentPhrases, List<DrumNote> notes)
         {
             var pad = GetFourLaneDrumPad(moonNote);
             var noteType = GetDrumNoteType(moonNote);
 
-            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases, IsEligibleForDrumTrill);
             generalFlags = ModifyDrumLaneFlags(moonNote, currentPhrases, generalFlags, notes);
 
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
@@ -100,7 +137,7 @@ namespace YARG.Core.Chart
             var pad = GetFiveLaneDrumPad(moonNote);
             var noteType = GetDrumNoteType(moonNote);
 
-            var generalFlags = GetGeneralFlags(moonNote, currentPhrases);
+            var generalFlags = GetGeneralFlags(moonNote, currentPhrases, IsEligibleForDrumTrill);
             generalFlags = ModifyDrumLaneFlags(moonNote, currentPhrases, generalFlags, notes);
 
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -272,6 +272,18 @@ namespace YARG.Core.Chart
 
         private NoteFlags GetGeneralFlags(MoonNote moonNote, CurrentPhrases currentPhrases)
         {
+            // In most cases, eligibility for trills simply means not being a chord
+            // Drums needs its own check to make exceptions for kicks
+            static bool DefaultIsEligibleForTrill(MoonNote moonNote)
+            {
+                return !moonNote.isChord;
+            }
+
+            return GetGeneralFlags(moonNote, currentPhrases, DefaultIsEligibleForTrill);
+        }
+
+        private NoteFlags GetGeneralFlags(MoonNote moonNote, CurrentPhrases currentPhrases, Func<MoonNote,bool> isEligibleForTrill)
+        {
             var flags = NoteFlags.None;
 
             var previous = moonNote.PreviousSeperateMoonNote;
@@ -312,25 +324,27 @@ namespace YARG.Core.Chart
             // Trill
             if (currentPhrases.TryGetValue(MoonPhrase.Type.TrillLane, out var trill) && IsEventInPhrase(moonNote, trill, inclusiveEnd: true))
             {
-                var trillContainsPrevious = previous is not null && IsEventInPhrase(previous, trill, inclusiveEnd: true);
-                var trillContainsNext = next is not null && IsEventInPhrase(next, trill, inclusiveEnd: true);
+                var isLaneStart = previous is null || !IsEventInPhrase(previous, trill, inclusiveEnd: true);
+                var isLaneEnd = next is null || !IsEventInPhrase(next, trill, inclusiveEnd: true);
 
-                // Chords are not allowed in trills; if this trill contains one, reject it altogether
-                var trillContainsChord = (moonNote.isChord) || (trillContainsPrevious && previous.isChord) || (trillContainsNext && next.isChord);
+                var trillIsValid = (isEligibleForTrill(moonNote)) && // This lane note is eligible
+                    (isLaneStart || isEligibleForTrill(previous)) && // The previous lane note, if any, is also eligible
+                    (isLaneEnd || isEligibleForTrill(next)); // The next lane note, if any, is also eligible
 
-                if (!trillContainsChord)
+                // If we find something ineligible inside the trill, then there's no trill at all
+                if (trillIsValid)
                 {
                     // Sustains are not allowed in lanes, so make sure the note has zero length
                     moonNote.length = 0;
 
                     flags |= NoteFlags.Trill;
 
-                    if (!trillContainsPrevious)
+                    if (isLaneStart)
                     {
                         flags |= NoteFlags.LaneStart;
                     }
 
-                    if (!trillContainsNext)
+                    if (isLaneEnd)
                     {
                         flags |= NoteFlags.LaneEnd;
                     }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -274,12 +274,12 @@ namespace YARG.Core.Chart
         {
             // In most cases, eligibility for trills simply means not being a chord
             // Drums needs its own check to make exceptions for kicks
-            static bool DefaultIsEligibleForTrill(MoonNote moonNote)
+            static bool DefaultTrillEligibilityCheck(MoonNote moonNote)
             {
                 return !moonNote.isChord;
             }
 
-            return GetGeneralFlags(moonNote, currentPhrases, DefaultIsEligibleForTrill);
+            return GetGeneralFlags(moonNote, currentPhrases, DefaultTrillEligibilityCheck);
         }
 
         private NoteFlags GetGeneralFlags(MoonNote moonNote, CurrentPhrases currentPhrases, Func<MoonNote,bool> isEligibleForTrill)

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -312,19 +312,28 @@ namespace YARG.Core.Chart
             // Trill
             if (currentPhrases.TryGetValue(MoonPhrase.Type.TrillLane, out var trill) && IsEventInPhrase(moonNote, trill, inclusiveEnd: true))
             {
-                // Sustains are not allowed in lanes, so make sure the note has zero length
-                moonNote.length = 0;
+                var trillContainsPrevious = previous is not null && IsEventInPhrase(previous, trill, inclusiveEnd: true);
+                var trillContainsNext = next is not null && IsEventInPhrase(next, trill, inclusiveEnd: true);
 
-                flags |= NoteFlags.Trill;
+                // Chords are not allowed in trills; if this trill contains one, reject it altogether
+                var trillContainsChord = (moonNote.isChord) || (trillContainsPrevious && previous.isChord) || (trillContainsNext && next.isChord);
 
-                if (previous == null || !IsEventInPhrase(previous, trill, inclusiveEnd: true))
+                if (!trillContainsChord)
                 {
-                    flags |= NoteFlags.LaneStart;
-                }
+                    // Sustains are not allowed in lanes, so make sure the note has zero length
+                    moonNote.length = 0;
 
-                if (next == null || !IsEventInPhrase(next, trill, inclusiveEnd: true))
-                {
-                    flags |= NoteFlags.LaneEnd;
+                    flags |= NoteFlags.Trill;
+
+                    if (!trillContainsPrevious)
+                    {
+                        flags |= NoteFlags.LaneStart;
+                    }
+
+                    if (!trillContainsNext)
+                    {
+                        flags |= NoteFlags.LaneEnd;
+                    }
                 }
             }
 

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -669,7 +669,7 @@ namespace YARG.Core.Engine
                 NoteIndex < Notes.Count && // There is a next note
                 Notes[NoteIndex].IsLaneStart && // That note is a lane start
                 Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane is starting soon
-                LaneIncludesNote(inputNote, Notes[NoteIndex]) // That lane would accept this input
+                ProximalLaneForgivesInput(inputNote, Notes[NoteIndex]) // That lane forgives this input
             )
             {
                 return true;
@@ -679,32 +679,8 @@ namespace YARG.Core.Engine
                 NoteIndex > 0 && // There is a previous note
                 Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
                 CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That lane ended recently
-                LaneIncludesNote(inputNote, Notes[NoteIndex - 1]) // That lane would accept this input
+                ProximalLaneForgivesInput(inputNote, Notes[NoteIndex - 1]) // That lane forgives this input
             );
-        }
-
-        protected bool LaneIncludesNote(int inputNote, TNoteType laneNote)
-        {
-            var inputMask = 1 << inputNote;
-
-            var requiredLaneNote = laneNote.LaneNote;
-
-            int otherNoteInTrill;
-
-            if (laneNote.IsTremolo)
-            {
-                otherNoteInTrill = -1;
-            }
-            else if (laneNote.IsLaneEnd)
-            {
-                otherNoteInTrill = laneNote.PreviousNote.LaneNote;
-            }
-            else
-            {
-                otherNoteInTrill = laneNote.NextNote.LaneNote;
-            }
-
-            return inputMask == requiredLaneNote || (otherNoteInTrill != -1 && inputMask == otherNoteInTrill);
         }
 
         protected void UpdateLaneAutohitExpireTime()
@@ -1491,6 +1467,48 @@ namespace YARG.Core.Engine
             }
 
             return msbIndex;
+        }
+
+        protected abstract bool ProximalLaneForgivesInput(int inputNote, TNoteType laneNote);
+
+        protected static bool LaneIncludesInputMask(int inputNote, TNoteType laneNote)
+        {
+            var inputMask = 1 << inputNote;
+            var (requiredLaneNote, otherNoteInTrill) = GetLaneNotes(laneNote);
+
+            if ((inputMask & requiredLaneNote) != 0)
+            {
+                return true;
+            }
+
+            if (otherNoteInTrill != -1 && ((inputMask & otherNoteInTrill) != 0))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        protected static (int requiredLaneNote, int otherNoteInTrill) GetLaneNotes(TNoteType laneNote)
+        {
+            var requiredLaneNote = laneNote.LaneNote;
+
+            int otherNoteInTrill;
+
+            if (laneNote.IsTremolo)
+            {
+                otherNoteInTrill = -1;
+            }
+            else if (laneNote.IsLaneEnd)
+            {
+                otherNoteInTrill = laneNote.PreviousNote.LaneNote;
+            }
+            else
+            {
+                otherNoteInTrill = laneNote.NextNote.LaneNote;
+            }
+
+            return (requiredLaneNote, otherNoteInTrill);
         }
     }
 }

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -1471,7 +1471,7 @@ namespace YARG.Core.Engine
 
         protected abstract bool ProximalLaneForgivesInput(int inputNote, TNoteType laneNote);
 
-        protected static bool LaneIncludesInputMask(int inputNote, TNoteType laneNote)
+        protected static bool LaneIncludesInputNote(int inputNote, TNoteType laneNote)
         {
             var inputMask = 1 << inputNote;
             var (requiredLaneNote, otherNoteInTrill) = GetLaneNotes(laneNote);

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -558,5 +558,11 @@ namespace YARG.Core.Engine.Drums
         }
 
         protected override bool CanSustainHold(DrumNote note) => throw new InvalidOperationException();
+
+        protected override bool ProximalLaneForgivesInput(int inputNote, DrumNote laneNote)
+        {
+            var (requiredLaneNote, otherNoteInTrill) = GetLaneNotes(laneNote);
+            return inputNote == requiredLaneNote || (otherNoteInTrill != -1 && otherNoteInTrill == inputNote);
+        }
     }
 }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
@@ -636,7 +636,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 Notes[NoteIndex].IsLaneStart && // That note is a lane start
                 Notes[NoteIndex].IsTrill && // That lane is a trill
                 Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That trill is starting soon
-                LaneIncludesInputMask(inputNote, Notes[NoteIndex]) // That lane would accept this input
+                LaneIncludesInputNote(inputNote, Notes[NoteIndex]) // That trill includes the fretted note
             )
             {
                 return true;
@@ -647,7 +647,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
                 Notes[NoteIndex - 1].IsTrill && // That lane was a trill
                 CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That trill ended recently
-                LaneIncludesInputMask(inputNote, Notes[NoteIndex - 1]) // That lane would have accepted this input
+                LaneIncludesInputNote(inputNote, Notes[NoteIndex - 1]) // That trill included the fretted note
             );
         }
     }

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
@@ -636,7 +636,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 Notes[NoteIndex].IsLaneStart && // That note is a lane start
                 Notes[NoteIndex].IsTrill && // That lane is a trill
                 Notes[NoteIndex].Time - CurrentTime < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That trill is starting soon
-                LaneIncludesNote(inputNote, Notes[NoteIndex]) // That lane would accept this input
+                LaneIncludesInputMask(inputNote, Notes[NoteIndex]) // That lane would accept this input
             )
             {
                 return true;
@@ -647,7 +647,7 @@ namespace YARG.Core.Engine.Guitar.Engines
                 Notes[NoteIndex - 1].IsLaneEnd && // That note was a lane end
                 Notes[NoteIndex - 1].IsTrill && // That lane was a trill
                 CurrentTime - Notes[NoteIndex - 1].Time < EngineParameters.HitWindow.LaneProximityProtectionWindow && // That trill ended recently
-                LaneIncludesNote(inputNote, Notes[NoteIndex - 1]) // That lane would have accepted this input
+                LaneIncludesInputMask(inputNote, Notes[NoteIndex - 1]) // That lane would have accepted this input
             );
         }
     }

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -565,5 +565,11 @@ namespace YARG.Core.Engine.Guitar
                 _ => false,
             };
         }
+
+        protected override bool ProximalLaneForgivesInput(int inputNote, GuitarNote laneNote)
+        {
+            // The guitar engine doesn't require accurate fretting for lane proximity leniency
+            return true;
+        }
     }
 }

--- a/YARG.Core/Engine/Keys/KeysEngine.cs
+++ b/YARG.Core/Engine/Keys/KeysEngine.cs
@@ -203,7 +203,7 @@ namespace YARG.Core.Engine.Keys
 
         protected override bool ProximalLaneForgivesInput(int inputNote, TNoteType laneNote)
         {
-            return LaneIncludesInputMask(inputNote, laneNote);
+            return LaneIncludesInputNote(inputNote, laneNote);
         }
     }
 }

--- a/YARG.Core/Engine/Keys/KeysEngine.cs
+++ b/YARG.Core/Engine/Keys/KeysEngine.cs
@@ -200,5 +200,10 @@ namespace YARG.Core.Engine.Keys
         }
 
         protected abstract bool IsKeyInTime(TNoteType note, double frontEnd);
+
+        protected override bool ProximalLaneForgivesInput(int inputNote, TNoteType laneNote)
+        {
+            return LaneIncludesInputMask(inputNote, laneNote);
+        }
     }
 }

--- a/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargVocalsEngine.cs
@@ -272,5 +272,7 @@ namespace YARG.Core.Engine.Vocals.Engines
         }
 
         protected override bool CanNoteBeHit(VocalNote note) => throw new NotImplementedException();
+
+        protected override bool ProximalLaneForgivesInput(int inputNote, VocalNote laneNote) => throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Fixes a few bugs with lane proximity overhit protection, rooted in the differences between instruments that operate over masks vs. those that operate over literal note values.

This also adds new logic to `MoonSongLoader` which rejects any trill marker that contains a chord. Chords in trills are not supported by any other game and don't function correctly in YARG. I'm interested in adding proper support for them in the future, but I'm considering that outside of my goals for simple lane feature parity in 0.15.

Credit to @jstnlef for a lot of the unit testing work!