### PR TITLE
Fix lyric parsing on the same tick as phrase start/end (+tests)

### DIFF
--- a/YARG.Core.UnitTests/Parsing/MoonSongLoader/MoonSongLoaderTests.Lyrics.cs
+++ b/YARG.Core.UnitTests/Parsing/MoonSongLoader/MoonSongLoaderTests.Lyrics.cs
@@ -135,5 +135,85 @@ namespace YARG.Core.UnitTests.Parsing
                     $"Lyric phrase {i} does not match!");
             }
         }
+
+        [Test]
+        public void LyricPhrases_ParseIntoSectionsCorrectlyOnSameTickAsPhraseStart()
+        {
+            var song = CreateSong();
+            /*
+                  1354 = E "phrase_start"
+                  1392 = E "lyric shouldBeInPhrase1"
+                  2035 = E "lyric shouldBeInPhrase2"
+                  2035 = E "phrase_start"
+                  2035 = E "lyric shouldAlsoBeInPhrase2
+                  2688 = E "phrase_end"
+             */
+            // Phrase 1
+            song.events.Add(new("phrase_start", 1));
+            song.events.Add(new("lyric shouldBeInPhrase1", 2));
+            // Before the phrase start in the list, but on the same tick, so should still be in the next phrase.
+            song.events.Add(new("lyric shouldBeInPhrase2", 3));
+            // Phrase 2
+            song.events.Add(new("phrase_start", 3));
+            song.events.Add(new("lyric shouldAlsoBeInPhrase2", 3));
+            song.events.Add(new("phrase_end", 4));
+
+            var lyrics = new MoonSongLoader(song, ParseSettings.Default).LoadLyrics();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(lyrics.Phrases, Has.Count.EqualTo(2));
+
+                Assert.That(lyrics.Phrases[0].Lyrics, Has.Count.EqualTo(1));
+                Assert.That(lyrics.Phrases[0].Lyrics[0].Text, Is.EqualTo("shouldBeInPhrase1"));
+
+                Assert.That(lyrics.Phrases[1].Lyrics, Has.Count.EqualTo(2));
+                Assert.That(lyrics.Phrases[1].Lyrics[0].Text, Is.EqualTo("shouldBeInPhrase2"));
+                Assert.That(lyrics.Phrases[1].Lyrics[1].Text, Is.EqualTo("shouldAlsoBeInPhrase2"));
+            }
+        }
+
+        [Test]
+        public void LyricPhrases_ParseIntoSectionsCorrectlyOnSameTickAsPhraseEnd()
+        {
+            var song = CreateSong();
+            /*
+              1354 = E "phrase_start"
+              1392 = E "lyric phrase1"
+              2035 = E "lyric phrase1Again"
+              2035 = E "phrase_end"
+              2039 = E "lyric ignored"
+              2097 = E "phrase_start"
+              2097 = E "lyric phrase2"
+              2592 = E "lyric phrase2again"
+              2688 = E "phrase_end"
+             */
+
+            // Phrase 1
+            song.events.Add(new("phrase_start", 1));
+            song.events.Add(new("lyric phrase1", 2));
+            song.events.Add(new("lyric phrase1Again", 3));
+            song.events.Add(new("phrase_end", 3));
+            // Event in between phrases, should be ignored
+            song.events.Add(new("lyric ignored", 4));
+            // Phrase 2
+            song.events.Add(new("phrase_start", 5));
+            song.events.Add(new("lyric phrase2", 5));
+            song.events.Add(new("lyric phrase2again", 6));
+            song.events.Add(new("phrase_end", 7));
+
+            var lyrics = new MoonSongLoader(song, ParseSettings.Default).LoadLyrics();
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(lyrics.Phrases, Has.Count.EqualTo(2));
+
+                Assert.That(lyrics.Phrases[0].Lyrics, Has.Count.EqualTo(2));
+                Assert.That(lyrics.Phrases[0].Lyrics[0].Text, Is.EqualTo("phrase1"));
+                Assert.That(lyrics.Phrases[0].Lyrics[1].Text, Is.EqualTo("phrase1Again"));
+
+                Assert.That(lyrics.Phrases[1].Lyrics, Has.Count.EqualTo(2));
+                Assert.That(lyrics.Phrases[1].Lyrics[0].Text, Is.EqualTo("phrase2"));
+                Assert.That(lyrics.Phrases[1].Lyrics[1].Text, Is.EqualTo("phrase2again"));
+            }
+        }
     }
 }

--- a/YARG.Core/Parsing/TextEvents.Phrases.cs
+++ b/YARG.Core/Parsing/TextEvents.Phrases.cs
@@ -78,7 +78,6 @@ namespace YARG.Core.Parsing
                     ProcessPhraseEvents(converter, ref state);
                     state.currentTick = tick;
                     state.start = state.end = false;
-                    state.pendingEvents.Clear();
                 }
 
                 // Determine what events are present on the current tick
@@ -115,6 +114,23 @@ namespace YARG.Core.Parsing
 
         private static void ProcessPhraseEvents(ITextPhraseConverter converter, ref TextConversionState state)
         {
+            // If this is not a start tick...
+            if (!state.start)
+            {
+                // If we are not in any phrase...
+                if (state.startTick == null)
+                {
+                    // Clear all pending events (they must be between phrases)
+                    state.pendingEvents.Clear();
+                }
+                // If we are in a phrase...
+                else
+                {
+                    // Add the events to the phrase.
+                    FlushPendingEvents(converter, ref state);
+                }
+            }
+
             // Phrase starts or ends on this tick
             if (state.start ^ state.end)
             {
@@ -136,21 +152,18 @@ namespace YARG.Core.Parsing
                 if (state.startTick == null)
                 {
                     // Phrase starts and ends on this tick
-                    // Process pending events first, they are part of this phrase
-                    FlushPendingEvents(converter, ref state);
                     converter.AddPhrase(state.currentTick, state.currentTick);
                 }
                 else
                 {
                     // Phrase ends on this tick and a new one starts
-                    // Process phrase end first, pending events are part of the next phrase
                     converter.AddPhrase(state.startTick.Value, state.currentTick);
                     state.startTick = state.currentTick;
                 }
             }
 
-            // Only dequeue pending events if we're within a phrase
-            if (state.startTick != null)
+            // If a phrase starts here, we still want to flush the events, just after the phrase has begun.
+            if (state.startTick != null && state.start)
                 FlushPendingEvents(converter, ref state);
         }
 
@@ -160,6 +173,7 @@ namespace YARG.Core.Parsing
             {
                 converter.AddPhraseEvent(pending, state.currentTick);
             }
+            state.pendingEvents.Clear();
         }
         #endregion
     }


### PR DESCRIPTION
This matches the behavior from CH. I also wrote some tests for this, though I haven't tested this with MIDI files.

The behavior that should be expected for some event is:
1. On the same tick as a phrase_start, it should go into that phrase.
2. Otherwise, if it's on the same tick as a phrase_end, it should go into that phrase.
3. If it's outside of a phrase, ignore the event.
4. If it's in a phrase, put the event in the phrase.

Also, changed `FlushPendingEvents` to actually *flush* the events instead of just adding them.