### PR TITLE
Vocals practice mode fixes

### DIFF
--- a/YARG.Core.UnitTests/Chart/VocalsPartTests.cs
+++ b/YARG.Core.UnitTests/Chart/VocalsPartTests.cs
@@ -45,6 +45,50 @@ public class VocalsTrackTests
     }
 
     [Test]
+    public void CloneInTickRangeKeepsPhrasesOverlappingStart()
+    {
+        var track = new VocalsTrack(Instrument.Vocals, [
+            new VocalsPart(false,
+                CreateVocalPhrases((90u, 20u), (95u, 5u), (100u, 10u)),
+                CreateVocalPhrases((80u, 30u), (95u, 5u), (125u, 10u)),
+                CreatePhrases((75u, 30u), (95u, 5u), (150u, 10u)),
+                CreateTextEvents(90, 95, 100, 125))
+        ], []);
+
+        var trimmed = track.CloneInTickRange(100, 200).Parts[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(trimmed.NotePhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 90, 100 }));
+            Assert.That(trimmed.StaticLyricPhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 80, 125 }));
+            Assert.That(trimmed.OtherPhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 75, 150 }));
+            Assert.That(trimmed.TextEvents.Select(e => e.Tick), Is.EqualTo(new uint[] { 100, 125 }));
+        }
+    }
+
+    [Test]
+    public void CloneInTickRangeExcludesPhrasesTouchingRangeBoundaryWithoutOverlap()
+    {
+        var track = new VocalsTrack(Instrument.Vocals, [
+            new VocalsPart(false,
+                CreateVocalPhrases((90u, 10u), (200u, 10u)),
+                CreateVocalPhrases((90u, 10u), (200u, 10u)),
+                CreatePhrases((90u, 10u), (200u, 10u)),
+                CreateTextEvents(90, 200))
+        ], []);
+
+        var trimmed = track.CloneInTickRange(100, 200).Parts[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(trimmed.NotePhrases, Is.Empty);
+            Assert.That(trimmed.StaticLyricPhrases, Is.Empty);
+            Assert.That(trimmed.OtherPhrases, Is.Empty);
+            Assert.That(trimmed.TextEvents, Is.Empty);
+        }
+    }
+
+    [Test]
     public void CloneInTickRangeDoesNotModifyOriginalPart()
     {
         var track = CreateVocalsTrack();
@@ -84,16 +128,34 @@ public class VocalsTrackTests
 
     private static List<VocalsPhrase> CreateVocalPhrases(params uint[] ticks)
     {
-        return ticks.Select(tick =>
+        return CreateVocalPhrases(ticks.Select(tick => (tick, 10u)));
+    }
+
+    private static List<VocalsPhrase> CreateVocalPhrases(params (uint Tick, uint TickLength)[] phrases)
+    {
+        return CreateVocalPhrases((IEnumerable<(uint Tick, uint TickLength)>) phrases);
+    }
+
+    private static List<VocalsPhrase> CreateVocalPhrases(IEnumerable<(uint Tick, uint TickLength)> phrases)
+    {
+        return phrases.Select(phrase =>
         {
-            var parentNote = new VocalNote(NoteFlags.None, false, tick / 100.0, 0.1, tick, 10);
-            return new VocalsPhrase(tick / 100.0, 0.1, tick, 10, parentNote, []);
+            var parentNote = new VocalNote(NoteFlags.None, false,
+                phrase.Tick / 100.0, phrase.TickLength / 100.0, phrase.Tick, phrase.TickLength);
+            return new VocalsPhrase(phrase.Tick / 100.0, phrase.TickLength / 100.0,
+                phrase.Tick, phrase.TickLength, parentNote, []);
         }).ToList();
     }
 
     private static List<Phrase> CreatePhrases(params uint[] ticks)
     {
         return ticks.Select(tick => new Phrase(PhraseType.StarPower, tick / 100.0, 0.1, tick, 10)).ToList();
+    }
+
+    private static List<Phrase> CreatePhrases(params (uint Tick, uint TickLength)[] phrases)
+    {
+        return phrases.Select(phrase => new Phrase(PhraseType.StarPower,
+            phrase.Tick / 100.0, phrase.TickLength / 100.0, phrase.Tick, phrase.TickLength)).ToList();
     }
 
     private static List<TextEvent> CreateTextEvents(params uint[] ticks)

--- a/YARG.Core.UnitTests/Chart/VocalsPartTests.cs
+++ b/YARG.Core.UnitTests/Chart/VocalsPartTests.cs
@@ -45,36 +45,36 @@ public class VocalsTrackTests
     }
 
     [Test]
-    public void CloneInTickRangeKeepsPhrasesOverlappingStart()
+    public void CloneInTickRangeKeepsVocalPhrasesWithChildEventsAtStart()
     {
         var track = new VocalsTrack(Instrument.Vocals, [
             new VocalsPart(false,
-                CreateVocalPhrases((90u, 20u), (95u, 5u), (100u, 10u)),
-                CreateVocalPhrases((80u, 30u), (95u, 5u), (125u, 10u)),
-                CreatePhrases((75u, 30u), (95u, 5u), (150u, 10u)),
-                CreateTextEvents(90, 95, 100, 125))
+                [CreateVocalPhraseWithChildEvents(90, 100)],
+                [CreateVocalPhraseWithChildEvents(90, 100)],
+                [],
+                [])
         ], []);
 
         var trimmed = track.CloneInTickRange(100, 200).Parts[0];
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(trimmed.NotePhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 90, 100 }));
-            Assert.That(trimmed.StaticLyricPhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 80, 125 }));
-            Assert.That(trimmed.OtherPhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 75, 150 }));
-            Assert.That(trimmed.TextEvents.Select(e => e.Tick), Is.EqualTo(new uint[] { 100, 125 }));
+            Assert.That(trimmed.NotePhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 90 }));
+            Assert.That(trimmed.StaticLyricPhrases.Select(e => e.Tick), Is.EqualTo(new uint[] { 90 }));
+            Assert.That(trimmed.NotePhrases[0].PhraseParentNote.ChildNotes.Select(e => e.Tick), Is.EqualTo(new uint[] { 100 }));
+            Assert.That(trimmed.NotePhrases[0].Lyrics.Select(e => e.Tick), Is.EqualTo(new uint[] { 100 }));
         }
     }
 
     [Test]
-    public void CloneInTickRangeExcludesPhrasesTouchingRangeBoundaryWithoutOverlap()
+    public void CloneInTickRangeExcludesVocalPhrasesWithChildEventsOutsideRange()
     {
         var track = new VocalsTrack(Instrument.Vocals, [
             new VocalsPart(false,
-                CreateVocalPhrases((90u, 10u), (200u, 10u)),
-                CreateVocalPhrases((90u, 10u), (200u, 10u)),
-                CreatePhrases((90u, 10u), (200u, 10u)),
-                CreateTextEvents(90, 200))
+                [CreateVocalPhraseWithChildEvents(80, 200), CreateVocalPhraseWithChildEvents(70, 90, 100), CreateVocalPhraseWithChildEvents(90, 191)],
+                [CreateVocalPhraseWithChildEvents(80, 200), CreateVocalPhraseWithChildEvents(70, 90, 100), CreateVocalPhraseWithChildEvents(90, 191)],
+                [],
+                [])
         ], []);
 
         var trimmed = track.CloneInTickRange(100, 200).Parts[0];
@@ -83,8 +83,6 @@ public class VocalsTrackTests
         {
             Assert.That(trimmed.NotePhrases, Is.Empty);
             Assert.That(trimmed.StaticLyricPhrases, Is.Empty);
-            Assert.That(trimmed.OtherPhrases, Is.Empty);
-            Assert.That(trimmed.TextEvents, Is.Empty);
         }
     }
 
@@ -128,34 +126,30 @@ public class VocalsTrackTests
 
     private static List<VocalsPhrase> CreateVocalPhrases(params uint[] ticks)
     {
-        return CreateVocalPhrases(ticks.Select(tick => (tick, 10u)));
-    }
-
-    private static List<VocalsPhrase> CreateVocalPhrases(params (uint Tick, uint TickLength)[] phrases)
-    {
-        return CreateVocalPhrases((IEnumerable<(uint Tick, uint TickLength)>) phrases);
-    }
-
-    private static List<VocalsPhrase> CreateVocalPhrases(IEnumerable<(uint Tick, uint TickLength)> phrases)
-    {
-        return phrases.Select(phrase =>
+        return ticks.Select(tick =>
         {
-            var parentNote = new VocalNote(NoteFlags.None, false,
-                phrase.Tick / 100.0, phrase.TickLength / 100.0, phrase.Tick, phrase.TickLength);
-            return new VocalsPhrase(phrase.Tick / 100.0, phrase.TickLength / 100.0,
-                phrase.Tick, phrase.TickLength, parentNote, []);
+            var parentNote = new VocalNote(NoteFlags.None, false, tick / 100.0, 0.1, tick, 10);
+            return new VocalsPhrase(tick / 100.0, 0.1, tick, 10, parentNote, []);
         }).ToList();
+    }
+
+    private static VocalsPhrase CreateVocalPhraseWithChildEvents(uint phraseTick, params uint[] childTicks)
+    {
+        var tickLength = childTicks[^1] - phraseTick + 10;
+        var parentNote = new VocalNote(NoteFlags.None, false, phraseTick / 100.0, tickLength / 100.0, phraseTick, tickLength);
+
+        foreach (var childTick in childTicks)
+        {
+            parentNote.AddChildNote(new VocalNote(60, 0, VocalNoteType.Lyric, childTick / 100.0, 0.1, childTick, 10));
+        }
+
+        return new VocalsPhrase(phraseTick / 100.0, tickLength / 100.0, phraseTick, tickLength, parentNote,
+            childTicks.Select(childTick => new LyricEvent(LyricSymbolFlags.None, childTick.ToString(), childTick / 100.0, childTick)).ToList());
     }
 
     private static List<Phrase> CreatePhrases(params uint[] ticks)
     {
         return ticks.Select(tick => new Phrase(PhraseType.StarPower, tick / 100.0, 0.1, tick, 10)).ToList();
-    }
-
-    private static List<Phrase> CreatePhrases(params (uint Tick, uint TickLength)[] phrases)
-    {
-        return phrases.Select(phrase => new Phrase(PhraseType.StarPower,
-            phrase.Tick / 100.0, phrase.TickLength / 100.0, phrase.Tick, phrase.TickLength)).ToList();
     }
 
     private static List<TextEvent> CreateTextEvents(params uint[] ticks)

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
@@ -135,10 +135,15 @@ namespace YARG.Core.Chart
 
         public void TrimToTickRange(uint tickStart, uint tickEnd)
         {
-            NotePhrases.RemoveAll(n => n.Tick < tickStart || n.Tick >= tickEnd);
-            StaticLyricPhrases.RemoveAll(n => n.Tick < tickStart || n.Tick >= tickEnd);
-            OtherPhrases.RemoveAll(n => n.Tick < tickStart || n.Tick >= tickEnd);
+            NotePhrases.RemoveAll(n => !OverlapsTickRange(n, tickStart, tickEnd));
+            StaticLyricPhrases.RemoveAll(n => !OverlapsTickRange(n, tickStart, tickEnd));
+            OtherPhrases.RemoveAll(n => !OverlapsTickRange(n, tickStart, tickEnd));
             TextEvents.RemoveAll(n => n.Tick < tickStart || n.Tick >= tickEnd);
+        }
+
+        private static bool OverlapsTickRange(ChartEvent chartEvent, uint tickStart, uint tickEnd)
+        {
+            return chartEvent.TickEnd > tickStart && chartEvent.Tick < tickEnd;
         }
     }
 }

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
@@ -135,15 +135,40 @@ namespace YARG.Core.Chart
 
         public void TrimToTickRange(uint tickStart, uint tickEnd)
         {
-            NotePhrases.RemoveAll(n => !OverlapsTickRange(n, tickStart, tickEnd));
-            StaticLyricPhrases.RemoveAll(n => !OverlapsTickRange(n, tickStart, tickEnd));
-            OtherPhrases.RemoveAll(n => !OverlapsTickRange(n, tickStart, tickEnd));
-            TextEvents.RemoveAll(n => n.Tick < tickStart || n.Tick >= tickEnd);
+            NotePhrases.RemoveAll(phrase => !IsVocalPhraseInTickRange(phrase, tickStart, tickEnd));
+            StaticLyricPhrases.RemoveAll(phrase => !IsVocalPhraseInTickRange(phrase, tickStart, tickEnd));
+            OtherPhrases.RemoveAll(phrase => !IsTickInRange(phrase.Tick, tickStart, tickEnd));
+            TextEvents.RemoveAll(text => !IsTickInRange(text.Tick, tickStart, tickEnd));
         }
 
-        private static bool OverlapsTickRange(ChartEvent chartEvent, uint tickStart, uint tickEnd)
+        private static bool IsVocalPhraseInTickRange(VocalsPhrase phrase, uint tickStart, uint tickEnd)
         {
-            return chartEvent.TickEnd > tickStart && chartEvent.Tick < tickEnd;
+            if (IsTickInRange(phrase.Tick, tickStart, tickEnd))
+            {
+                return true;
+            }
+
+            if (phrase.PhraseParentNote.ChildNotes.Count == 0 && phrase.Lyrics.Count == 0)
+            {
+                return false;
+            }
+
+            if (phrase.PhraseParentNote.ChildNotes.Any(note => !IsNoteInRange(note, tickStart, tickEnd)))
+            {
+                return false;
+            }
+
+            return phrase.Lyrics.All(lyric => IsTickInRange(lyric.Tick, tickStart, tickEnd));
+        }
+
+        private static bool IsNoteInRange(VocalNote note, uint tickStart, uint tickEnd)
+        {
+            return note.Tick >= tickStart && note.TotalTickEnd <= tickEnd;
+        }
+
+        private static bool IsTickInRange(uint tick, uint tickStart, uint tickEnd)
+        {
+            return tick >= tickStart && tick < tickEnd;
         }
     }
 }


### PR DESCRIPTION
Fixes practice-mode vocal phrase filtering so a vocal phrase that starts before the selected practice section can still be included when its actual lyric/note content is fully inside the section. This addresses cases like “Bohemian Rhapsody,” where the phrase marker starts before the intro section tick but the first lyric starts exactly on it.