### PR TITLE
Implement postproc lane parsing

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using MoonscraperChartEditor.Song;
 using MoonscraperChartEditor.Song.IO;
+using YARG.Core.Extensions;
+using YARG.Core.Logging;
 using YARG.Core.Parsing;
 using static MoonscraperChartEditor.Song.MoonNote;
 
@@ -36,12 +38,12 @@ namespace YARG.Core.Chart
 
             var difficulties = new Dictionary<Difficulty, InstrumentDifficulty<DrumNote>>()
             {
-                { Difficulty.Beginner, LoadDifficulty(instrument, Difficulty.Beginner, beginnerNoteDelegate, HandleTextEvent) },
-                { Difficulty.Easy, LoadDifficulty(instrument, Difficulty.Easy, createNote, HandleTextEvent) },
-                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote, HandleTextEvent) },
-                { Difficulty.Hard, LoadDifficulty(instrument, Difficulty.Hard, createNote, HandleTextEvent) },
-                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote, HandleTextEvent) },
-                { Difficulty.ExpertPlus, LoadDifficulty(instrument, Difficulty.ExpertPlus, createNote, HandleTextEvent) },
+                { Difficulty.Beginner, LoadDifficulty(instrument, Difficulty.Beginner, beginnerNoteDelegate, HandleTextEvent) }, // No lanes on Beginner, so no final pass
+                { Difficulty.Easy, LoadDifficulty(instrument, Difficulty.Easy, createNote, HandleTextEvent, finalPassDelegate: DrumsFinalPass) }, // Drum lanes on Easy are possible in .chart, so we do need the final pass
+                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote, HandleTextEvent, finalPassDelegate: DrumsFinalPass) }, // Drum lanes on Medium are possible in .chart, so we do need the final pass
+                { Difficulty.Hard, LoadDifficulty(instrument, Difficulty.Hard, createNote, HandleTextEvent, finalPassDelegate: DrumsFinalPass) },
+                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote, HandleTextEvent, finalPassDelegate: DrumsFinalPass) },
+                { Difficulty.ExpertPlus, LoadDifficulty(instrument, Difficulty.ExpertPlus, createNote, HandleTextEvent, finalPassDelegate: DrumsFinalPass) },
             };
 
             foreach (var difficulty in difficulties)
@@ -121,7 +123,6 @@ namespace YARG.Core.Chart
             var noteType = GetDrumNoteType(moonNote);
 
             var generalFlags = GetGeneralFlags(moonNote, currentPhrases, IsEligibleForDrumTrill);
-            generalFlags = ModifyDrumLaneFlags(moonNote, currentPhrases, generalFlags, notes);
 
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
 
@@ -138,7 +139,6 @@ namespace YARG.Core.Chart
             var noteType = GetDrumNoteType(moonNote);
 
             var generalFlags = GetGeneralFlags(moonNote, currentPhrases, IsEligibleForDrumTrill);
-            generalFlags = ModifyDrumLaneFlags(moonNote, currentPhrases, generalFlags, notes);
 
             var drumFlags = GetDrumNoteFlags(moonNote, currentPhrases);
 
@@ -437,130 +437,396 @@ namespace YARG.Core.Chart
             return new(instrument, difficulty, notes, phrases, textEvents);
         }
 
-        private NoteFlags ModifyDrumLaneFlags(MoonNote moonNote, Dictionary<MoonPhrase.Type, MoonPhrase> currentPhrases,
-            NoteFlags flags, List<DrumNote> notes)
+        private static void DrumsFinalPass(InstrumentDifficulty<DrumNote> chart)
         {
-            MoonPhrase? lanePhrase = null;
-            bool isTrill = false;
+            var noteIndex = 0;
 
-            if ((flags & NoteFlags.Tremolo) != 0)
+            // All we're here to do is assemble lane phrases, so if there aren't any notes or phrases, then we have nothing to do
+            if (chart.Phrases.Count == 0 || chart.Notes.Count == 0)
             {
-                currentPhrases.TryGetValue(MoonPhrase.Type.TremoloLane, out lanePhrase);
+                return;
             }
-            else if ((flags & NoteFlags.Trill) != 0)
+           
+            foreach (var phrase in chart.Phrases)
             {
-                currentPhrases.TryGetValue(MoonPhrase.Type.TrillLane, out lanePhrase);
-                isTrill = true;
-            }
-
-            if (lanePhrase == null)
-            {
-                return flags;
-            }
-
-            if (_validLaneNotes == null || lanePhrase.tick != _lastLanePhraseTick)
-            {
-                _lastLanePhraseTick = lanePhrase.tick;
-                _validLaneNotes = GetValidLaneNotes(moonNote, lanePhrase, isTrill);
-            }
-
-            if (!_validLaneNotes.Contains(moonNote.rawNote))
-            {
-                // Fix up lane end since we're going to nuke it
-                if ((flags & NoteFlags.LaneEnd) != 0 && notes.Count > 0)
+                if (phrase.Type is not (PhraseType.TremoloLane or PhraseType.TrillLane))
                 {
-                    foreach (var child in notes[^1].AllNotes)
+                    continue;
+                }
+
+                var notesInPhrase = GetNotesInPhrase(phrase, chart.Notes, noteIndex, out noteIndex);
+
+                var fourLane = chart.Instrument is Instrument.FourLaneDrums or Instrument.ProDrums;
+
+                List<DrumNote> laneNotes;
+
+                switch (phrase.Type)
+                {
+                    case PhraseType.TremoloLane:
+                        laneNotes = GetDrumTremoloNotes(notesInPhrase, fourLane);
+                        break;
+                    case PhraseType.TrillLane:
+                        laneNotes = GetDrumTrillNotes(notesInPhrase, fourLane);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Unreachable.");
+                }
+
+                if (laneNotes.Count > 0)
+                {
+                    laneNotes[0].ActivateFlag(NoteFlags.LaneStart);
+                    laneNotes[^1].ActivateFlag(NoteFlags.LaneEnd);
+                }
+            }
+        }
+
+        // Takes all notes that are supposedly inside a drum tremolo phrase and validates them.
+        // Activates the Tremolo flag for all notes in the phrase that constitute a valid tremolo
+        //   -For a well-formed chart, this will be all of them
+        //   -If the chart is malformed, the tremolo might terminate earlier than the supposed end of the phrase or be invalidated altogether
+        // Returns the list of all marked notes. GuitarFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with trills)
+        private static List<DrumNote> GetDrumTremoloNotes(List<DrumNote> notesInPhrase, bool fourLane)
+        {
+            List<DrumNote> tremoloNotes = new();
+
+            // First we need to know which pad is getting the tremolo. If the tremolo turns out to be invalid, this will be null
+            var tremoloPad = GetDrumTremoloPad(notesInPhrase, fourLane);
+
+            if (tremoloPad is not null)
+            {
+                // If this is a 4L format, we'll need to watch out for a same-color counterpart (tom vs. cymbal) and either prematurely terminate
+                // the tremolo or invalidate it altogether
+                int? counterpart = fourLane ? (int?) ((FourLaneDrumPad) tremoloPad).OtherPadOfSameColor() : null;
+
+                for (var i = 0; i < notesInPhrase.Count; i++)
+                {
+                    var note = notesInPhrase[i];
+
+                    foreach (var child in note.AllNotes)
                     {
-                        if (child.IsLane)
+                        if (counterpart is not null && child.Pad == counterpart)
                         {
-                            child.ActivateFlag(NoteFlags.LaneEnd);
+                            // Uh-oh, we hit the tremolo pad's same-color counterpart. Terminate early
+                            return tremoloNotes;
+                        }
+
+                        if (child.Pad == tremoloPad)
+                        {
+                            child.ActivateFlag(NoteFlags.Tremolo);
+                            tremoloNotes.Add(child);
                         }
                     }
                 }
-
-                flags &= ~NoteFlags.Tremolo;
-                flags &= ~NoteFlags.Trill;
-                flags &= ~NoteFlags.LaneStart;
-                flags &= ~NoteFlags.LaneEnd;
             }
 
-            return flags;
+            return tremoloNotes;
+        }
 
-            static List<int> GetValidLaneNotes(MoonNote moonNote, MoonPhrase lanePhrase, bool isTrill)
+
+        // If a tremolo phrase starts on a single non-kick pad (optionally paired with a kick), then it's a tremolo for that pad as long as that pad reoccurs at least once in the phrase.
+        // It's okay if other notes of different colors happen later in the phrase, whether they're chorded with the laned pad or not
+        // If the other pad of the same color (tom vs. cymbal) occurs, the tremolo is terminated at that point. It's still a valid tremolo up to that point as long as it contains at least 2 valid notes
+        // If the starting note never reoccurs for the duration of the tremolo, the tremolo isn't valid
+        //
+        // If a tremolo phrase starts on a chord (ignoring kicks), it can only be a lane for one pad in the chord
+        // Of the pads in the starting chord, the one that gets laned is whichever one reoccurs first
+        // If multiple pads from the starting chord reoccur simultaneously, that doesn't count; keep looking for the first unambiguous reoccurence
+        // If no starting chord pad ever reoccurs unambiguously in the tremolo, the tremolo isn't valid
+        //
+        // If a tremolo phrase starts on a lone kick, it isn't valid
+        private static int? GetDrumTremoloPad(
+            List<DrumNote> notesInPhrase,
+            bool fourLane // If this is a 4L format, then we need to run some extra checks regarding same-color counterparts
+        )
+        {
+            var kick = fourLane ? (int) FourLaneDrumPad.Kick : (int) FiveLaneDrumPad.Kick;
+
+            // A tremolo must encompass at least two hits to be valid
+            if (notesInPhrase.Count < 2)
             {
-                // Iterate forward every note in this phrase to find the notes that appear the most
-                // Assumes that this will only run when the first note in a phrase is provided
-                Dictionary<int,int> noteTotals = new();
+                return null;
+            }
 
-                // Stop searching if the current note value has this much of a lead over the others
-                const int CLINCH_THRESHOLD = 5;
-                int highestTotal = 0;
-
-                for (var noteRef = moonNote; noteRef != null && IsEventInPhrase(noteRef, lanePhrase, inclusiveEnd: true); noteRef = noteRef.next)
+            // Get a list of pads that this tremolo might be
+            List<int> candidatePads = new();
+            foreach (var child in notesInPhrase[0].AllNotes)
+            {
+                if (child.Pad != kick) // Kicks can't form tremolo lanes
                 {
-                    if (noteRef.drumPad == MoonNote.DrumPad.Kick)
-                    {
-                        // Don't allow kick lanes
-                        continue;
-                    }
+                    candidatePads.Add(child.Pad);
+                }
+            }
 
-                    int thisNote = noteRef.rawNote;
+            // If there is only one candidate pad, then all we need to do is verify that that pad reoccurs at least once during the lane, and we're all good
+            if (candidatePads.Count == 1)
+            {
+                var otherPadOfSameColor = fourLane ? ((FourLaneDrumPad) candidatePads[0]).OtherPadOfSameColor() : null;
 
-                    int thisTotal;
-                    if (noteTotals.ContainsKey(thisNote))
+                // Check all subsequent notes for a reoccurence of the candidate pad
+                for (var i = 1; i < notesInPhrase.Count; i++)
+                {
+                    foreach (var child in notesInPhrase[i].AllNotes)
                     {
-                        thisTotal = ++noteTotals[thisNote];
-                    }
-                    else
-                    {
-                        thisTotal = noteTotals[thisNote] = 1;
-                    }
-
-                    if (thisTotal <= highestTotal)
-                    {
-                        continue;
-                    }
-
-                    highestTotal = thisTotal;
-
-                    if (thisTotal >= CLINCH_THRESHOLD)
-                    {
-                        bool stopSearching = true;
-                        foreach(var (otherNote, otherTotal) in noteTotals)
+                        if (otherPadOfSameColor is not null && (int)otherPadOfSameColor == child.Pad)
                         {
-                            if (otherNote == thisNote)
-                            {
-                                continue;
-                            }
-
-                            if (thisTotal - otherTotal < CLINCH_THRESHOLD)
-                            {
-                                stopSearching = false;
-                                break;
-                            }
+                            // The other pad of the same color reoccurred before the candidate did, so this is not a valid tremolo
+                            return null;
                         }
 
-                        if (stopSearching)
+                        if (candidatePads[0] == child.Pad)
                         {
-                            // Safe to say this is the only laned note a tremolo phrase
+                            // The pad reoccurred, so this is a valid tremolo of that pad
+                            return candidatePads[0];
+                        }
+                    }
+
+                    return null; // The pad never reoccurred, so this is not a valid tremolo
+                }
+            }
+
+            // If there are multiple candidate pads, then we want to give the tremolo to the first one of them to reoccur
+            // If a pad's same-pad-of-other-color happens before this is determined, that pad is out of the running
+            else if (candidatePads.Count > 1)
+            {
+                // Check all subsequent notes for a reoccurence of exactly one candidate pad
+                for (var i = 1; i < notesInPhrase.Count; i++)
+                {
+                    List<int> repeatedCandidatePads = new();
+                    foreach (var child in notesInPhrase[i].AllNotes)
+                    {
+                        if (candidatePads.Contains(child.Pad))
+                        {
+                            repeatedCandidatePads.Add(child.Pad);
+                        }
+                        else if (fourLane)
+                        {
+                            var otherPadOfSameColor = ((FourLaneDrumPad) child.Pad).OtherPadOfSameColor();
+                            if (otherPadOfSameColor is not null)
+                            {
+                                // Remove same-color counterparts from the running
+                                // For example, if Ycym is one of our candidates, but we just found a Ytom, then we know that Ycym isn't
+                                // going to be the lane
+                                candidatePads.Remove((int)otherPadOfSameColor);
+                            }
+                        }
+                    }
+
+                    if (repeatedCandidatePads.Count == 1)
+                    {
+                        // A candidate pad has reoccurred without any other candidate pads on the same tick; that's the tremolo
+                        return repeatedCandidatePads[0];
+                    }
+                }
+
+                return null; // No single candidate pad ever reoccurred, so this is not a valid tremolo
+            }
+
+            return null; // There were no candidate pads, presumably because this tremolo started on a lone kick. Not a valid tremolo
+        }
+
+
+        // A drum trill must alternate strictly between two single pads of different colors, ignoring kicks. See the comment on GetDrumTrillPads
+        // for more information on what constitutes a valid trill.
+        //
+        // Assuming a trill is valid, then it lasts until the end of the phrase marker, until a non-trill pad (besides kicks) occurs, or
+        // until the trill repeats the same pad twice instead of strictly alternating, whichever comes first.
+        //
+        // Drum trills do not support "gravity blast"-style unlaned notes (besides kicks) in the way that drum tremolos do. Any unlaned non-kick note
+        // terminates the trill immediately, regardless of whether it's chorded with a lane note.
+        private static List<DrumNote> GetDrumTrillNotes(List<DrumNote> notesInPhrase, bool fourLane)
+        {
+            var kick = fourLane ? (int) FourLaneDrumPad.Kick : (int) FiveLaneDrumPad.Kick;
+
+            List<DrumNote> trillNotes = new();
+            var trillPads = GetDrumTrillPads(notesInPhrase, fourLane);
+
+            if (trillPads is not null)
+            {
+                var trillPad1 = trillPads.Value.pad1;
+                var trillPad2 = trillPads.Value.pad2;
+
+                foreach (var note in notesInPhrase)
+                {
+                    foreach (var child in note.AllNotes)
+                    {
+                        if (child.Pad == kick)
+                        {
+                            // Ignore kicks
+                            continue;
+                        }
+
+                        if (child.Pad != trillPad1 && child.Pad != trillPad2)
+                        {
+                            // This is not a valid part of the trill, so we're terminating early
+                            return trillNotes;
+                        }
+
+                        if (trillNotes.Count > 0 && child.Pad == trillNotes[^1].Pad)
+                        {
+                            // Repeating the same trill note twice is invalid, so we're terminating early
+                            return trillNotes;
+                        }
+                    }
+
+                    // We didn't terminate early, so this hit is part of the trill. We're going to add it to the trill notes,
+                    // although there could still be a kick here, so we need to iterate again (over a maximum of 2 notes) to
+                    // avoid flagging it if so
+                    foreach (var child in note.AllNotes)
+                    {
+                        if (child.Pad != kick)
+                        {
+                            child.ActivateFlag(NoteFlags.Trill);
+                            trillNotes.Add(child);
                             break;
                         }
                     }
                 }
+            }
 
-                int validNoteTotal = isTrill ? highestTotal - 2 : highestTotal;
-                List<int> validTremoloNotes = new();
+            return trillNotes;
+        }
 
-                foreach (var (note, total) in noteTotals)
+
+        // A drum trill phrase is defined by exactly two alternating pads. Those pads must be different colors (e.g. no Gtom+Gcym trills)
+        //
+        // The first hit of the trill phrase must be a single pad (optionally paired with a kick, but it cannot be a lone kick)
+        //
+        // The second non-kick hit of the trill phrase must be a different single pad of a different color (it can be paired with
+        // a kick, and there can also be kicks between the first and second trill notes)
+        //
+        // The third non-kick hit of the trill must be the same single pad as the first (again, optionally paired with a kick, and
+        // there can be interposed kicks as well)
+        //
+        // If all of those conditions are not met, then this trill is valid for those pads. Otherwise, the trill is not valid.
+        private static (int pad1, int pad2)? GetDrumTrillPads(List<DrumNote> notesInPhrase, bool fourLane)
+        {
+            var kick = fourLane ? (int) FourLaneDrumPad.Kick : (int) FiveLaneDrumPad.Kick;
+
+            // A tremolo must encompass at least three hits to be legitimate
+            if (notesInPhrase.Count < 3)
+            {
+                return null;
+            }
+
+            int? pad1 = null;
+
+            // The first note of the phrase must have exactly one non-kick gem (optionally paired with a kick)
+            foreach (var child in notesInPhrase[0].AllNotes)
+            {
+                if (child.Pad == kick)
                 {
-                    if (total >= validNoteTotal)
+                    continue;
+                }
+
+                if (pad1 is not null)
+                {
+                    // We already found a non-kick pad, so this is a hand chord; not a valid trill
+                    return null;
+                }
+
+                pad1 = child.Pad;
+            }
+
+            if (pad1 is null)
+            {
+                // We didn't find a valid first pad (presumably because the phrase started on a lone kick), so this is not a valid trill
+                return null;
+            }
+
+            // So far so good; time to find the second pad
+            int? pad2 = null;
+
+            var noteRef = notesInPhrase[1]; // It's probably here, but this might be a lone kick, in which case we need to keep going forward
+
+            // Iterate until we find something other than a lone kick
+            while (noteRef is not null && pad2 is null)
+            {
+                if (noteRef.NextNote is null)
+                {
+                    // We still need a third note for the trill to be legitimate, so if there's no next note, we're already done
+                    return null;
+                }
+
+                if (!noteRef.IsChord && noteRef.Pad == kick)
+                {
+                    // If this is a lone kick, move on
+                    noteRef = noteRef.NextNote;
+                    continue;
+                }
+
+                // We found our first hit that isn't a lone kick; this is where we're going to need to find our second trill pad
+                // If it's not here, this isn't a valid trill
+                foreach (var child in noteRef.AllNotes)
+                {
+                    if (child.Pad == kick)
                     {
-                        validTremoloNotes.Add(note);
+                        continue;
+                    }
+
+                    if (pad2 is not null)
+                    {
+                        // We already found a non-kick pad, so this is a hand chord; not a valid trill
+                        return null;
+                    }
+
+                    if (child.Pad == pad1)
+                    {
+                        // The phrase starts with two of the same pad in a row; not a valid trill
+                        return null;
+                    }
+
+                    if (fourLane && child.Pad == (int?) ((FourLaneDrumPad) pad1).OtherPadOfSameColor())
+                    {
+                        // The phrase starts with a tom and cymbal of the same color back-to-back (in either order); not a valid trill
+                        return null;
+                    }
+
+                    pad2 = child.Pad;
+                }
+            }
+
+            if (pad2 is null)
+            {
+                // We didn't find a valid second pad (presumably because the phrasae was nothing but kicks after the first hit), so this is not a valid trill
+                return null;
+            }
+
+            // We have two valid trill notes. We just need to make sure that the next non-lone-kick hit matches the first, and we have our pads
+            noteRef = noteRef!.NextNote;
+            while (noteRef is not null)
+            {
+                if (!noteRef.IsChord && noteRef.Pad == kick)
+                {
+                    // If this is a lone kick, move on
+                    noteRef = noteRef.NextNote;
+                    continue;
+                }
+
+                // We found our first hit that isn't a lone kick; this is where we're going to need to find our second trill pad
+                foreach (var child in noteRef.AllNotes)
+                {
+                    if (child.Pad == kick)
+                    {
+                        continue;
+                    }
+
+                    if (child.Pad != pad1)
+                    {
+                        // We found a non-kick pad that doesn't match the first; not a valid trill
+                        return null;
                     }
                 }
 
-                return validTremoloNotes;
+                // If we made it here, we know we have a valid third hit
+                //   -If there were another non-kick pad, we would have returned null in the previous if statement
+                //   -If there were only a kick pad, we would have continued the while loop in the first if statement
+                //   -Thus, the only possibilities are a lone pad that matches pad1, or that plus a kick
+                return (pad1.Value, pad2.Value);
             }
+
+            // If we're here, we never found a valid third hit (presumably because the phrase was nothing but kicks after the second pad);
+            // not a valid trill
+            return null;
         }
     }
 }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -13,9 +13,6 @@ namespace YARG.Core.Chart
     {
         private bool _discoFlip = false;
 
-        private uint _lastLanePhraseTick;
-        private List<int>? _validLaneNotes = null;
-
         // Used to wipe lane markers from Beginner
         private const NoteFlags NO_LANE_FLAGS = ~(NoteFlags.LaneStart | NoteFlags.LaneEnd | NoteFlags.Tremolo | NoteFlags.Trill);
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -484,7 +484,7 @@ namespace YARG.Core.Chart
         // Activates the Tremolo flag for all notes in the phrase that constitute a valid tremolo
         //   -For a well-formed chart, this will be all of them
         //   -If the chart is malformed, the tremolo might terminate earlier than the supposed end of the phrase or be invalidated altogether
-        // Returns the list of all marked notes. GuitarFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with trills)
+        // Returns the list of all marked notes. DrumsFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with trills)
         private static List<DrumNote> GetDrumTremoloNotes(List<DrumNote> notesInPhrase, bool fourLane)
         {
             List<DrumNote> tremoloNotes = new();
@@ -557,7 +557,9 @@ namespace YARG.Core.Chart
                 }
             }
 
-            // If there is only one candidate pad, then all we need to do is verify that that pad reoccurs at least once during the lane, and we're all good
+            // If there is only one candidate pad, then all we need to do is verify these two things:
+            //   -The pad reoccurs at least once in the phrase
+            //   -If the pad has a same-color counterpart, that counterpart does not occur earlier than the first reocurrence of the candidate pad
             if (candidatePads.Count == 1)
             {
                 var otherPadOfSameColor = fourLane ? ((FourLaneDrumPad) candidatePads[0]).OtherPadOfSameColor() : null;
@@ -579,9 +581,9 @@ namespace YARG.Core.Chart
                             return candidatePads[0];
                         }
                     }
-
-                    return null; // The pad never reoccurred, so this is not a valid tremolo
                 }
+
+                return null; // The pad never reoccurred, so this is not a valid tremolo
             }
 
             // If there are multiple candidate pads, then we want to give the tremolo to the first one of them to reoccur
@@ -792,13 +794,13 @@ namespace YARG.Core.Chart
             }
 
             // We have two valid trill notes. We just need to make sure that the next non-lone-kick hit matches the first, and we have our pads
-            noteRef = noteRef!.NextNote;
-            while (noteRef is not null)
+            for (var i = 2; i < notesInPhrase.Count; i++)
             {
+                noteRef = notesInPhrase[i];
+
                 if (!noteRef.IsChord && noteRef.Pad == kick)
                 {
-                    // If this is a lone kick, move on
-                    noteRef = noteRef.NextNote;
+                    // This is a lone kick; move on
                     continue;
                 }
 
@@ -812,20 +814,20 @@ namespace YARG.Core.Chart
 
                     if (child.Pad != pad1)
                     {
-                        // We found a non-kick pad that doesn't match the first; not a valid trill
+                        // We found a non-kick pad that doesn't match pad1; not a valid trill
                         return null;
                     }
                 }
 
                 // If we made it here, we know we have a valid third hit
-                //   -If there were another non-kick pad, we would have returned null in the previous if statement
+                //   -If there were a non-kick pad that didn't match pad1, we would have returned null in the previous if statement
                 //   -If there were only a kick pad, we would have continued the while loop in the first if statement
                 //   -Thus, the only possibilities are a lone pad that matches pad1, or that plus a kick
                 return (pad1.Value, pad2.Value);
             }
 
-            // If we're here, we never found a valid third hit (presumably because the phrase was nothing but kicks after the second pad);
-            // not a valid trill
+            // If we're here, we never found a valid third hit (presumably because the phrase was nothing but kicks after the second
+            // pad); // not a valid trill
             return null;
         }
     }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -22,11 +22,11 @@ namespace YARG.Core.Chart
         {
             var difficulties = new Dictionary<Difficulty, InstrumentDifficulty<GuitarNote>>()
             {
-                { Difficulty.Beginner, LoadDifficulty<GuitarNote>(instrument, Difficulty.Beginner, CreateFiveFretBeginnerNote, null, ValidateGuitarPhrase) },
-                { Difficulty.Easy, LoadDifficulty(instrument, Difficulty.Easy, createNote, null, ValidateGuitarPhrase) },
-                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote, null, ValidateGuitarPhrase) },
-                { Difficulty.Hard, LoadDifficulty(instrument, Difficulty.Hard, createNote, null, ValidateGuitarPhrase) },
-                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote, null, ValidateGuitarPhrase) },
+                { Difficulty.Beginner, LoadDifficulty<GuitarNote>(instrument, Difficulty.Beginner, CreateFiveFretBeginnerNote, null, ValidateGuitarPhrase, null) }, // No lanes on Beginner, so no final pass
+                { Difficulty.Easy, LoadDifficulty(instrument, Difficulty.Easy, createNote, null, ValidateGuitarPhrase, null) }, // No lanes on Easy, so no final pass
+                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote, null, ValidateGuitarPhrase, null) }, // No lanes on Medium, so no final pass
+                { Difficulty.Hard, LoadDifficulty(instrument, Difficulty.Hard, createNote, null, ValidateGuitarPhrase, GuitarFinalPass) },
+                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote, null, ValidateGuitarPhrase, GuitarFinalPass) },
             };
 
             var track = new InstrumentTrack<GuitarNote>(instrument, difficulties, GetAnimationTrack(instrument));
@@ -220,6 +220,180 @@ namespace YARG.Core.Chart
             }
 
             return false;
+        }
+
+        private static void GuitarFinalPass(InstrumentDifficulty<GuitarNote> chart)
+        {
+            var noteIndex = 0;
+
+            // All we're here to do is assemble lane phrases, so if there aren't any notes or phrases, then we have nothing to do
+            if (chart.Phrases.Count == 0 || chart.Notes.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var phrase in chart.Phrases)
+            {
+                if (phrase.Type is not (PhraseType.TremoloLane or PhraseType.TrillLane))
+                {
+                    continue;
+                }
+
+                var notesInPhrase = GetNotesInPhrase(phrase, chart.Notes, noteIndex, out noteIndex);
+
+                List<GuitarNote> laneNotes;
+
+                switch (phrase.Type)
+                {
+                    case PhraseType.TremoloLane:
+                        laneNotes = GetGuitarTremoloNotes(notesInPhrase);
+                        break;
+                    case PhraseType.TrillLane:
+                        laneNotes = GetGuitarTrillNotes(notesInPhrase);
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException("Unreachable.");
+                }
+
+                if (laneNotes.Count > 0)
+                {
+                    foreach (var startChild in laneNotes[0].AllNotes)
+                    {
+                        startChild.ActivateFlag(NoteFlags.LaneStart);
+                    }
+
+                    foreach (var endChild in laneNotes[^1].AllNotes)
+                    {
+                        endChild.ActivateFlag(NoteFlags.LaneEnd);
+                    }
+                }
+            }
+        }
+
+        // Takes all notes that are supposedly inside a guitar tremolo phrase and validates them.
+        // Activates the Tremolo flag for all notes in the phrase that constitute a valid tremolo
+        //   -For a well-formed chart, this will be all of them
+        //   -If the chart is malformed, the tremolo might terminate earlier than the supposed end of the phrase or be invalidated altogether
+        // Returns the list of all marked notes. GuitarFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with trills)
+        //
+        // A guitar tremolo must consist of exactly one notemask, repeated at least twice
+        // If the tremolo's notemask changes on the second note, it's not a valid tremolo
+        // If the notemask changes later in the tremolo, the tremolo is terminated there
+        private static List<GuitarNote> GetGuitarTremoloNotes(List<GuitarNote> notesInPhrase)
+        {
+            static void AddToTremolo(GuitarNote note, List<GuitarNote> tremolo)
+            {
+                foreach (var child in note.AllNotes)
+                {
+                    child.ActivateFlag(NoteFlags.Tremolo);
+                }
+
+                tremolo.Add(note);
+            }
+
+
+            List<GuitarNote> tremoloNotes = new();
+
+            if (notesInPhrase.Count < 2 || notesInPhrase[0].NoteMask != notesInPhrase[1].NoteMask)
+            {
+                // This tremolo doesn't start with two matching masks, so it's invalid. Return an empty list (no tremolo)
+                return tremoloNotes;
+            }
+
+            // The first two notes are now pre-cleared, so no need to check their masks again
+            AddToTremolo(notesInPhrase[0], tremoloNotes);
+            AddToTremolo(notesInPhrase[1], tremoloNotes);
+
+            // Go through all further notes in the phrase and add them to the tremolo as long as the mask doesn't change
+            
+            for (var i = 2; i < notesInPhrase.Count; i++)
+            {
+                var note = notesInPhrase[i];
+
+                if (notesInPhrase[i].NoteMask != notesInPhrase[0].NoteMask)
+                {
+                    // We found a mask that doesn't fit the tremolo; terminate early
+                    break;
+                }
+
+                AddToTremolo(note, tremoloNotes);
+            }
+
+            return tremoloNotes;
+        }
+
+        // Takes all notes that are supposedly inside a guitar trill phrase and validates them
+        // Activates the Trill flag for all notes in the phrase that constitute a valid trill
+        //   -For a well-formed chart, this will be all of them
+        //   -If the chart is malformed, the trill might terminate earlier than the supposed end of the phrase or be invalidated altogether
+        // Returns the list of all marked notes. GuitarFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with tremolos)
+        //
+        // A guitar trill must begin with two different single notes - if they match or either is a chord, the trill is invalid
+        // The third note of the trill must match the first - if not, the trill is invalid
+        // From there, the trill is valid as long as it continues alternating those two notes
+        // If it repeats the same note twice, the trill terminates
+        // If anything other than the two established notes occurs, the trill terminates
+        private static List<GuitarNote> GetGuitarTrillNotes(List<GuitarNote> notesInPhrase)
+        {
+            List<GuitarNote> trillNotes = new();
+
+            if (notesInPhrase.Count < 3)
+            {
+                // Need at least three notes to constitute a trill; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            if (notesInPhrase[0].IsChord || notesInPhrase[1].IsChord)
+            {
+                // Trills can't contain chords; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            if (notesInPhrase[0].NoteMask == notesInPhrase[1].NoteMask)
+            {
+                // Trills must be two different notes; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            if (notesInPhrase[0].NoteMask != notesInPhrase[2].NoteMask)
+            {
+                // The third note must match the first; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            // We now know that we have a valid trill, and we've pre-approved the first three notes. Flag them and add them to the list
+            notesInPhrase[0].ActivateFlag(NoteFlags.Trill);
+            notesInPhrase[1].ActivateFlag(NoteFlags.Trill);
+            notesInPhrase[2].ActivateFlag(NoteFlags.Trill);
+            trillNotes.Add(notesInPhrase[0]);
+            trillNotes.Add(notesInPhrase[1]);
+            trillNotes.Add(notesInPhrase[2]);
+
+            // The trill will continue for as long as it keeps alternating these two masks
+            var mask1 = notesInPhrase[0].NoteMask;
+            var mask2 = notesInPhrase[1].NoteMask;
+
+            for (var i = 3; i < notesInPhrase.Count; i++)
+            {
+                var note = notesInPhrase[i];
+                var previousNote = notesInPhrase[i - 1];
+
+                if (
+                    (note.NoteMask == mask1 && previousNote.NoteMask == mask2) ||
+                    (note.NoteMask == mask2 && previousNote.NoteMask == mask1)
+                )
+                {
+                    note.ActivateFlag(NoteFlags.Trill);
+                    trillNotes.Add(note);
+                }
+                else
+                {
+                    // We've stopped properly alternating; terminate the trill
+                    break;
+                }
+            }
+
+            return trillNotes;
         }
     }
 }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -13,7 +13,7 @@ namespace YARG.Core.Chart
             return instrument.ToNativeGameMode() switch
             {
                 GameMode.FiveFretGuitar => LoadGuitarTrack(instrument, CreateFiveFretGuitarNote),
-                GameMode.SixFretGuitar  => LoadGuitarTrack(instrument, CreateSixFretGuitarNote),
+                GameMode.SixFretGuitar => LoadGuitarTrack(instrument, CreateSixFretGuitarNote),
                 _ => throw new ArgumentException($"Instrument {instrument} is not a guitar instrument!")
             };
         }
@@ -74,11 +74,11 @@ namespace YARG.Core.Chart
         {
             return moonNote.guitarFret switch
             {
-                MoonNote.GuitarFret.Open   => FiveFretGuitarFret.Open,
-                MoonNote.GuitarFret.Green  => FiveFretGuitarFret.Green,
-                MoonNote.GuitarFret.Red    => FiveFretGuitarFret.Red,
+                MoonNote.GuitarFret.Open => FiveFretGuitarFret.Open,
+                MoonNote.GuitarFret.Green => FiveFretGuitarFret.Green,
+                MoonNote.GuitarFret.Red => FiveFretGuitarFret.Red,
                 MoonNote.GuitarFret.Yellow => FiveFretGuitarFret.Yellow,
-                MoonNote.GuitarFret.Blue   => FiveFretGuitarFret.Blue,
+                MoonNote.GuitarFret.Blue => FiveFretGuitarFret.Blue,
                 MoonNote.GuitarFret.Orange => FiveFretGuitarFret.Orange,
                 _ => throw new InvalidOperationException($"Invalid Moonscraper guitar fret {moonNote.guitarFret}!")
             };
@@ -88,7 +88,7 @@ namespace YARG.Core.Chart
         {
             return moonNote.ghliveGuitarFret switch
             {
-                MoonNote.GHLiveGuitarFret.Open   => SixFretGuitarFret.Open,
+                MoonNote.GHLiveGuitarFret.Open => SixFretGuitarFret.Open,
                 MoonNote.GHLiveGuitarFret.Black1 => SixFretGuitarFret.Black1,
                 MoonNote.GHLiveGuitarFret.Black2 => SixFretGuitarFret.Black2,
                 MoonNote.GHLiveGuitarFret.Black3 => SixFretGuitarFret.Black3,
@@ -124,8 +124,8 @@ namespace YARG.Core.Chart
             return type switch
             {
                 MoonNote.MoonNoteType.Strum => GuitarNoteType.Strum,
-                MoonNote.MoonNoteType.Hopo  => GuitarNoteType.Hopo,
-                MoonNote.MoonNoteType.Tap   => GuitarNoteType.Tap,
+                MoonNote.MoonNoteType.Hopo => GuitarNoteType.Hopo,
+                MoonNote.MoonNoteType.Tap => GuitarNoteType.Tap,
                 _ => throw new InvalidOperationException($"Unhandled Moonscraper note type {type}!")
             };
         }
@@ -156,7 +156,7 @@ namespace YARG.Core.Chart
                 uint largestLength = 0;
 
                 // Must find the longest length of previous note (disjoint chords)
-                while(prevNote is not null && prevNote.previous?.tick == prevNote.tick)
+                while (prevNote is not null && prevNote.previous?.tick == prevNote.tick)
                 {
                     largestLength = Math.Max(largestLength, prevNote.length);
                     prevNote = prevNote.previous;
@@ -252,7 +252,7 @@ namespace YARG.Core.Chart
                         laneNotes = GetGuitarTrillNotes(notesInPhrase);
                         break;
                     default:
-                        throw new ArgumentOutOfRangeException("Unreachable.");
+                        throw new ArgumentOutOfRangeException(nameof(phrase.Type), phrase.Type, "Invalid phrase type for Guitar lane");
                 }
 
                 if (laneNotes.Count > 0)
@@ -317,7 +317,7 @@ namespace YARG.Core.Chart
             AddToTremolo(notesInPhrase[1], tremoloNotes);
 
             // Go through all further notes in the phrase and add them to the tremolo as long as the mask doesn't change
-            
+
             for (var i = 2; i < notesInPhrase.Count; i++)
             {
                 var note = notesInPhrase[i];
@@ -382,18 +382,13 @@ namespace YARG.Core.Chart
             trillNotes.Add(notesInPhrase[2]);
 
             // The trill will continue for as long as it keeps alternating these two masks
-            var mask1 = notesInPhrase[0].NoteMask;
-            var mask2 = notesInPhrase[1].NoteMask;
+            var mask = notesInPhrase[0].NoteMask;
+            var otherMask = notesInPhrase[1].NoteMask;
 
             for (var i = 3; i < notesInPhrase.Count; i++)
             {
                 var note = notesInPhrase[i];
-                var previousNote = notesInPhrase[i - 1];
-
-                if (
-                    (note.NoteMask == mask1 && previousNote.NoteMask == mask2) ||
-                    (note.NoteMask == mask2 && previousNote.NoteMask == mask1)
-                )
+                if (note.NoteMask == otherMask)
                 {
                     note.ActivateFlag(NoteFlags.Trill);
                     trillNotes.Add(note);
@@ -403,6 +398,7 @@ namespace YARG.Core.Chart
                     // We've stopped properly alternating; terminate the trill
                     break;
                 }
+                (mask, otherMask) = (otherMask, mask);
             }
 
             return trillNotes;

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -257,11 +257,23 @@ namespace YARG.Core.Chart
 
                 if (laneNotes.Count > 0)
                 {
+                    // Apply lane start flag to entire starting note
                     foreach (var startChild in laneNotes[0].AllNotes)
                     {
                         startChild.ActivateFlag(NoteFlags.LaneStart);
                     }
 
+                    // Cut sustains for all but the last note
+                    foreach (var laneNote in laneNotes.GetRange(0, laneNotes.Count - 1))
+                    {
+                        foreach (var child in laneNote.AllNotes)
+                        {
+                            child.TickLength = 0;
+                            child.TimeLength = 0;
+                        }
+                    }
+
+                    // Apply lane end flag to entire ending note
                     foreach (var endChild in laneNotes[^1].AllNotes)
                     {
                         endChild.ActivateFlag(NoteFlags.LaneEnd);

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
@@ -93,7 +93,17 @@ namespace YARG.Core.Chart
                 {
                     // Unlike for guitar, we don't need to iterate through all children here since we're only handling trills. If there were child notes to
                     // iterate through, then we wouldn't have validated these as trill notes in the first place because trills don't support chords
+
+                    // Apply lane start flag
                     laneNotes[0].ActivateFlag(NoteFlags.LaneStart);
+
+                    // Cut sustains for all but the last note
+                    foreach (var laneNote in laneNotes.GetRange(0, laneNotes.Count - 1)) {
+                        laneNote.TickLength = 0;
+                        laneNote.TimeLength = 0;
+                    }
+
+                    // Apply lane end flag
                     laneNotes[^1].ActivateFlag(NoteFlags.LaneEnd);
                 }
             }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
@@ -18,10 +18,10 @@ namespace YARG.Core.Chart
 
             var difficulties = new Dictionary<Difficulty, InstrumentDifficulty<ProKeysNote>>
             {
-                { Difficulty.Easy,   LoadDifficulty(instrument, Difficulty.Easy, createNote) },
-                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote) },
-                { Difficulty.Hard,   LoadDifficulty(instrument, Difficulty.Hard, createNote) },
-                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote) },
+                { Difficulty.Easy,   LoadDifficulty(instrument, Difficulty.Easy, createNote, finalPassDelegate: ProKeysFinalPass) },
+                { Difficulty.Medium, LoadDifficulty(instrument, Difficulty.Medium, createNote, finalPassDelegate: ProKeysFinalPass) },
+                { Difficulty.Hard,   LoadDifficulty(instrument, Difficulty.Hard, createNote, finalPassDelegate: ProKeysFinalPass) },
+                { Difficulty.Expert, LoadDifficulty(instrument, Difficulty.Expert, createNote, finalPassDelegate: ProKeysFinalPass) },
             };
             return new(instrument, difficulties);
         }
@@ -65,6 +65,112 @@ namespace YARG.Core.Chart
             }
 
             return flags;
+        }
+
+        private static void ProKeysFinalPass(InstrumentDifficulty<ProKeysNote> chart)
+        {
+            var noteIndex = 0;
+
+            // All we're here to do is assemble lane phrases, so if there aren't any notes or phrases, then we have nothing to do
+            if (chart.Phrases.Count == 0 || chart.Notes.Count == 0)
+            {
+                return;
+            }
+
+            foreach (var phrase in chart.Phrases)
+            {
+                // Pro Keys does not support tremolos. Glissando phrases are handled earlier, since they don't require complex adjacent-note validation logic
+                if (phrase.Type is not PhraseType.TrillLane)
+                {
+                    continue;
+                }
+
+                var notesInPhrase = GetNotesInPhrase(phrase, chart.Notes, noteIndex, out noteIndex);
+
+                var laneNotes = GetProKeysTrillNotes(notesInPhrase);
+
+                if (laneNotes.Count > 0)
+                {
+                    // Unlike for guitar, we don't need to iterate through all children here since we're only handling trills. If there were child notes to
+                    // iterate through, then we wouldn't have validated these as trill notes in the first place because trills don't support chords
+                    laneNotes[0].ActivateFlag(NoteFlags.LaneStart);
+                    laneNotes[^1].ActivateFlag(NoteFlags.LaneEnd);
+                }
+            }
+        }
+
+        // Takes all notes that are supposedly inside a Pro Keys trill phrase and validates them
+        // Activates the Trill flag for all notes in the phrase that constitute a valid trill
+        //   -For a well-formed chart, this will be all of them
+        //   -If the chart is malformed, the trill might terminate earlier than the supposed end of the phrase or be invalidated altogether
+        // Returns the list of all marked notes. GuitarFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with tremolos)
+        //
+        // A guitar trill must begin with two different single notes - if they match or either is a chord, the trill is invalid
+        // The third note of the trill must match the first - if not, the trill is invalid
+        // From there, the trill is valid as long as it continues alternating those two notes
+        // If it repeats the same note twice, the trill terminates
+        // If anything other than the two established notes occurs, the trill terminates
+        private static List<ProKeysNote> GetProKeysTrillNotes(List<ProKeysNote> notesInPhrase)
+        {
+            List<ProKeysNote> trillNotes = new();
+
+            if (notesInPhrase.Count < 3)
+            {
+                // Need at least three notes to constitute a trill; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            if (notesInPhrase[0].IsChord || notesInPhrase[1].IsChord)
+            {
+                // Trills can't contain chords; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            if (notesInPhrase[0].NoteMask == notesInPhrase[1].NoteMask)
+            {
+                // Trills must be two different notes; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            if (notesInPhrase[0].NoteMask != notesInPhrase[2].NoteMask)
+            {
+                // The third note must match the first; this is invalid. Return empty (no trill)
+                return trillNotes;
+            }
+
+            // We now know that we have a valid trill, and we've pre-approved the first three notes. Flag them and add them to the list
+            notesInPhrase[0].ActivateFlag(NoteFlags.Trill);
+            notesInPhrase[1].ActivateFlag(NoteFlags.Trill);
+            notesInPhrase[2].ActivateFlag(NoteFlags.Trill);
+            trillNotes.Add(notesInPhrase[0]);
+            trillNotes.Add(notesInPhrase[1]);
+            trillNotes.Add(notesInPhrase[2]);
+
+            // The trill will continue for as long as it keeps alternating these two masks
+            var mask1 = notesInPhrase[0].NoteMask;
+            var mask2 = notesInPhrase[1].NoteMask;
+
+            for (var i = 3; i < notesInPhrase.Count; i++)
+            {
+                var note = notesInPhrase[i];
+                var previousNote = notesInPhrase[i - 1];
+
+                if (
+                    (note.NoteMask == mask1 && previousNote.NoteMask == mask2) ||
+                    (note.NoteMask == mask2 && previousNote.NoteMask == mask1)
+                )
+                {
+                    note.ActivateFlag(NoteFlags.Trill);
+                    trillNotes.Add(note);
+                }
+                else
+                {
+                    // We've stopped properly alternating; terminate the trill
+                    break;
+                }
+            }
+
+            return trillNotes;
         }
     }
 }

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
@@ -98,7 +98,8 @@ namespace YARG.Core.Chart
                     laneNotes[0].ActivateFlag(NoteFlags.LaneStart);
 
                     // Cut sustains for all but the last note
-                    foreach (var laneNote in laneNotes.GetRange(0, laneNotes.Count - 1)) {
+                    foreach (var laneNote in laneNotes.GetRange(0, laneNotes.Count - 1))
+                    {
                         laneNote.TickLength = 0;
                         laneNote.TimeLength = 0;
                     }
@@ -113,7 +114,7 @@ namespace YARG.Core.Chart
         // Activates the Trill flag for all notes in the phrase that constitute a valid trill
         //   -For a well-formed chart, this will be all of them
         //   -If the chart is malformed, the trill might terminate earlier than the supposed end of the phrase or be invalidated altogether
-        // Returns the list of all marked notes. GuitarFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with tremolos)
+        // Returns the list of all marked notes. ProKeysFinalPass will assign the LaneStart and LaneEnd flags (shared behavior with tremolos)
         //
         // A guitar trill must begin with two different single notes - if they match or either is a chord, the trill is invalid
         // The third note of the trill must match the first - if not, the trill is invalid
@@ -157,18 +158,12 @@ namespace YARG.Core.Chart
             trillNotes.Add(notesInPhrase[2]);
 
             // The trill will continue for as long as it keeps alternating these two masks
-            var mask1 = notesInPhrase[0].NoteMask;
-            var mask2 = notesInPhrase[1].NoteMask;
-
+            var mask = notesInPhrase[0].NoteMask;
+            var otherMask = notesInPhrase[1].NoteMask;
             for (var i = 3; i < notesInPhrase.Count; i++)
             {
                 var note = notesInPhrase[i];
-                var previousNote = notesInPhrase[i - 1];
-
-                if (
-                    (note.NoteMask == mask1 && previousNote.NoteMask == mask2) ||
-                    (note.NoteMask == mask2 && previousNote.NoteMask == mask1)
-                )
+                if (note.NoteMask == otherMask)
                 {
                     note.ActivateFlag(NoteFlags.Trill);
                     trillNotes.Add(note);
@@ -178,6 +173,7 @@ namespace YARG.Core.Chart
                     // We've stopped properly alternating; terminate the trill
                     break;
                 }
+                (mask, otherMask) = (otherMask, mask);
             }
 
             return trillNotes;

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -21,6 +21,7 @@ namespace YARG.Core.Chart
             where TNote : Note<TNote>;
         private delegate void ProcessTextDelegate(MoonText text);
         private delegate Phrase? ValidatePhraseDelegate(Phrase phrase, List<Phrase> phrases);
+        private delegate void FinalPassDelegate<TNote>(InstrumentDifficulty<TNote> chart) where TNote : Note<TNote>;
 
         private MoonSong _moonSong;
         private ParseSettings _settings;
@@ -38,6 +39,13 @@ namespace YARG.Core.Chart
 
         private readonly double _codaTime;
         private readonly List<(uint start,uint end)> _codaTicks;
+
+        private enum LaneParsingState
+        {
+            None,
+            Tremolo,
+            Trill
+        }
 
         public MoonSongLoader(MoonSong song, in ParseSettings settings)
         {
@@ -129,9 +137,13 @@ namespace YARG.Core.Chart
             return _moonSong.syncTrack;
         }
 
-        private InstrumentDifficulty<TNote> LoadDifficulty<TNote>(Instrument instrument, Difficulty difficulty,
-            CreateNoteDelegate<TNote> createNote, ProcessTextDelegate? processText = null,
-            ValidatePhraseDelegate? validatePhrase = null)
+        private InstrumentDifficulty<TNote> LoadDifficulty<TNote>(
+            Instrument instrument,
+            Difficulty difficulty,
+            CreateNoteDelegate<TNote> createNote,
+            ProcessTextDelegate? processText = null,
+            ValidatePhraseDelegate? validatePhrase = null,
+            FinalPassDelegate<TNote>? finalPassDelegate = null)
             where TNote : Note<TNote>
         {
             _currentMode = instrument.ToNativeGameMode();
@@ -146,7 +158,15 @@ namespace YARG.Core.Chart
             var notes = GetNotes(moonChart, difficulty, createNote, processText);
             var phrases = GetPhrases(moonChart, validatePhrase);
             var textEvents = GetTextEvents(moonChart);
-            return new(instrument, difficulty, notes, phrases, textEvents);
+
+            var chart = new InstrumentDifficulty<TNote>(instrument, difficulty, notes, phrases, textEvents);
+
+            if (finalPassDelegate is not null)
+            {
+                finalPassDelegate(chart);
+            }
+
+            return chart;
         }
 
         private List<TNote> GetNotes<TNote>(MoonChart moonChart, Difficulty difficulty,
@@ -321,55 +341,6 @@ namespace YARG.Core.Chart
                 }
             }
 
-            // Trill
-            if (currentPhrases.TryGetValue(MoonPhrase.Type.TrillLane, out var trill) && IsEventInPhrase(moonNote, trill, inclusiveEnd: true))
-            {
-                var isLaneStart = previous is null || !IsEventInPhrase(previous, trill, inclusiveEnd: true);
-                var isLaneEnd = next is null || !IsEventInPhrase(next, trill, inclusiveEnd: true);
-
-                var trillIsValid = (isEligibleForTrill(moonNote)) && // This lane note is eligible
-                    (isLaneStart || isEligibleForTrill(previous)) && // The previous lane note, if any, is also eligible
-                    (isLaneEnd || isEligibleForTrill(next)); // The next lane note, if any, is also eligible
-
-                // If we find something ineligible inside the trill, then there's no trill at all
-                if (trillIsValid)
-                {
-                    // Sustains are not allowed in lanes, so make sure the note has zero length
-                    moonNote.length = 0;
-
-                    flags |= NoteFlags.Trill;
-
-                    if (isLaneStart)
-                    {
-                        flags |= NoteFlags.LaneStart;
-                    }
-
-                    if (isLaneEnd)
-                    {
-                        flags |= NoteFlags.LaneEnd;
-                    }
-                }
-            }
-
-            // Tremolo
-            if (currentPhrases.TryGetValue(MoonPhrase.Type.TremoloLane, out var tremolo) && IsEventInPhrase(moonNote, tremolo, inclusiveEnd: true))
-            {
-                // Sustains are not allowed in lanes, so make sure the note has zero length
-                moonNote.length = 0;
-
-                flags |= NoteFlags.Tremolo;
-
-                if (previous == null || !IsEventInPhrase(previous, tremolo, inclusiveEnd: true))
-                {
-                    flags |= NoteFlags.LaneStart;
-                }
-
-                if (next == null || !IsEventInPhrase(next, tremolo, inclusiveEnd: true))
-                {
-                    flags |= NoteFlags.LaneEnd;
-                }
-            }
-
             // Big Rock Ending
             if (currentPhrases.TryGetValue(MoonPhrase.Type.BigRockEnding, out var bigRockEnding) &&
                 IsEventInPhrase(moonNote, bigRockEnding))
@@ -383,6 +354,8 @@ namespace YARG.Core.Chart
             {
                 flags |= NoteFlags.CodaEnd;
             }
+
+            // Trill and tremolo lanes are handled in the finalPassDelegate, since they're easiest to parse with Notes instead of MoonNotes
 
             return flags;
         }
@@ -578,5 +551,32 @@ namespace YARG.Core.Chart
             Difficulty.ExpertPlus => MoonSong.Difficulty.Expert,
             _ => throw new InvalidOperationException($"Invalid difficulty {difficulty}!")
         };
+
+        private static List<TNote> GetNotesInPhrase<TNote>(Phrase phrase, List<TNote> allNotes, int startingIndex, out int nextIndex) where TNote : Note<TNote>
+        {
+            List<TNote> notesInPhrase = new();
+
+            nextIndex = startingIndex;
+
+            for (var i = startingIndex; i < allNotes.Count; i++)
+            {
+                var note = allNotes[i];
+
+                if (note.Tick < phrase.Tick)
+                {
+                    continue;
+                }
+
+                if (note.Tick > phrase.TickEnd)
+                {
+                    break;
+                }
+
+                nextIndex = i + 1; // This is where the next GetNotesInPhrase call will start iterating from, so we don't waste time rescanning earlier notes again
+                notesInPhrase.Add(note);
+            }
+
+            return notesInPhrase;
+        }
     }
 }

--- a/YARG.Core/Extensions/NoteExtensions.cs
+++ b/YARG.Core/Extensions/NoteExtensions.cs
@@ -56,5 +56,22 @@ namespace YARG.Core.Extensions
                 _ => throw new ArgumentOutOfRangeException()
             };
         }
+
+        public static FourLaneDrumPad? OtherPadOfSameColor(this FourLaneDrumPad pad)
+        {
+            return pad switch
+            {
+                FourLaneDrumPad.YellowCymbal => FourLaneDrumPad.YellowDrum,
+                FourLaneDrumPad.YellowDrum => FourLaneDrumPad.YellowCymbal,
+
+                FourLaneDrumPad.BlueCymbal => FourLaneDrumPad.BlueDrum,
+                FourLaneDrumPad.BlueDrum => FourLaneDrumPad.BlueCymbal,
+
+                FourLaneDrumPad.GreenCymbal => FourLaneDrumPad.GreenDrum,
+                FourLaneDrumPad.GreenDrum => FourLaneDrumPad.GreenCymbal,
+
+                _ => null
+            };
+        }
     }
 }


### PR DESCRIPTION
Completely reimplements how we parse trill and tremolo lanes. The previous logic operated on `MoonNote` data, which made it very difficult to properly validate and sanitize lanes, since they depend heavily on relationships between notes and the `MoonNote` parser has no sense of state.

`MoonSongLoader::LoadDifficulty` now takes one additional delegate, `FinalPassDelegate`. This delegate operates on an entire `InstrumentDifficulty<TNote>` - the thing we previously would have returned - and allows for final-pass logic that depends on fully-constructed `Note` and `Phrase` data rather than `MoonNote` data or incomplete `Note` lists. It's currently used only for lane parsing, but in theory it could be used for anything else that similarly benefits from preprocessed data.

We now heavily validate and sanitize lanes as we parse them. If a lane is malformed, we terminate it at the first invalid note, or reject the lane entirely if it's invalidated before the lane can be established (before 2 valid tremolo notes or 3 valid trill notes).

Guitar and ProKeys effectively share the same logic for trills, but because `NoteMask` is independently defined in each of their note classes rather than being inherited from `Note`, I still had to do a bit of code duplication. We can probably get clever with some kind of `GetNoteMaskDelegate` or something if you want - this is just a first draft.

The Drums loader has very different rules for lane validation, especially for tremolos. I've heavily commented all of the new logic, so hopefully it's easy enough to follow. Again, this is a first draft, and I'm sure there are some places where we could clean up the flow/readability of things.