### PR TITLE
Clip extended sustains on Beginner

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -55,7 +55,22 @@ namespace YARG.Core.Chart
             var guitarFlags = GuitarNoteFlags.None;
 
             double time = _moonSong.TickToTime(moonNote.tick);
-            return new GuitarNote(fret, noteType, guitarFlags, generalFlags, time, GetLengthInTime(moonNote), moonNote.tick, moonNote.length);
+
+            uint tickLength;
+
+            // If Easy contains extended sustains, we'll want to clip them so we don't have wildcards on top of wildcard sustains
+            if (moonNote.NextSeperateMoonNote is not null && moonNote.NextSeperateMoonNote.tick < moonNote.tick + moonNote.length)
+            {
+                tickLength = moonNote.NextSeperateMoonNote.tick - moonNote.tick;
+            }
+            else
+            {
+                tickLength = moonNote.length;
+            }
+
+            var timeLength = GetLengthInTime(time, moonNote.tick, tickLength);
+
+            return new GuitarNote(fret, noteType, guitarFlags, generalFlags, time, timeLength, moonNote.tick, tickLength);
         }
 
         private GuitarNote CreateSixFretGuitarNote(MoonNote moonNote, Dictionary<MoonPhrase.Type, MoonPhrase> currentPhrases,


### PR DESCRIPTION
If a guitar chart contains extended sustains on Easy (which it shouldn't, but charters be crazy), then the Beginner chart ends up with overlapping Wildcard sustains that unavoidably drop when the next note is strummed. This change cuts any wildcard sustain at the start of the next note if it detects an overlap.

I didn't bother creating any kind of sustain gap - this scenario is already against charting conventions in the first place, and all I care about is making it playable, not pretty.

This affects only the Guitar loader because PK has no Beginner, Drums has no sustains, and 5LK uses the guitar loader.