### PR TITLE
Fix PK->5LK action conversion

### DIFF
--- a/YARG.Core/Engine/Keys/FiveLaneKeys/YargFiveLaneKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/FiveLaneKeys/YargFiveLaneKeysEngine.cs
@@ -488,17 +488,18 @@ namespace YARG.Core.Engine.Keys.Engines
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool IsFiveLaneKeysAction(ProKeysAction action)
         {
-            return (ALLOWED_FIVE_LANE_KEYS_ACTIONS & (1 << (int) action)) != 0;
+            return (ALLOWED_FIVE_LANE_KEYS_ACTIONS & (1L << (int) action)) != 0;
         }
 
-        private const int ALLOWED_FIVE_LANE_KEYS_ACTIONS =
-            1 << (int) ProKeysAction.GreenKey |
-            1 << (int) ProKeysAction.RedKey |
-            1 << (int) ProKeysAction.YellowKey |
-            1 << (int) ProKeysAction.BlueKey |
-            1 << (int) ProKeysAction.OrangeKey |
-            1 << (int) ProKeysAction.OpenNote |
-            1 << (int) ProKeysAction.StarPower |
-            1 << (int) ProKeysAction.TouchEffects;
+        // ProKeysAction.OrangeKey is 32, which causes issues if we use a plain 32-bit int for the mask
+        private const long ALLOWED_FIVE_LANE_KEYS_ACTIONS =
+            1L << (int) ProKeysAction.GreenKey |
+            1L << (int) ProKeysAction.RedKey |
+            1L << (int) ProKeysAction.YellowKey |
+            1L << (int) ProKeysAction.BlueKey |
+            1L << (int) ProKeysAction.OrangeKey |
+            1L << (int) ProKeysAction.OpenNote |
+            1L << (int) ProKeysAction.StarPower |
+            1L << (int) ProKeysAction.TouchEffects;
     }
 }


### PR DESCRIPTION
Congratulations @wyrdough , you correctly predicted this was going to be an issue like a year ago lol

We use a `const int` mask of `ProKeysActions` that are applicable to 5LK to filter out irrelevant inputs in the 5LK engine. But because `ProKeysAction.OrangeKey` is `32`, we end up accepting Low C PK inputs (`0`), which then throw exceptions later when we find out that we got an inapplicable action through to the 5LK input handler.

Changed the `int` to `long` to avoid the overflow