### PR TITLE
Add OnStarPowerGain event for gain SFX

### DIFF
--- a/YARG.Core/Audio/AudioEnums.cs
+++ b/YARG.Core/Audio/AudioEnums.cs
@@ -22,7 +22,7 @@
     {
         NoteMiss,
         StarPowerAward,
-        StarPowerGain,
+        StarPowerReady,
         StarPowerDeploy,
         StarPowerDeployCrowd,
         StarPowerRelease,

--- a/YARG.Core/Audio/AudioHelpers.cs
+++ b/YARG.Core/Audio/AudioHelpers.cs
@@ -94,7 +94,7 @@ namespace YARG.Core.Audio
         {
             new Sample<SfxSample>(SfxSample.NoteMiss, "note_miss", 0.55f),
             new Sample<SfxSample>(SfxSample.StarPowerAward, "starpower_award", 0.5f),
-            new Sample<SfxSample>(SfxSample.StarPowerGain, "starpower_gain", 0.5f),
+            new Sample<SfxSample>(SfxSample.StarPowerGain, "starpower_gain", 0.85f),
             new Sample<SfxSample>(SfxSample.StarPowerDeploy, "starpower_deploy", 0.4f),
             new Sample<SfxSample>(SfxSample.StarPowerDeployCrowd, "overdrive_deploy_crowd", 0.4f),
             new Sample<SfxSample>(SfxSample.StarPowerRelease, "starpower_release", 0.5f),

--- a/YARG.Core/Audio/AudioHelpers.cs
+++ b/YARG.Core/Audio/AudioHelpers.cs
@@ -94,7 +94,7 @@ namespace YARG.Core.Audio
         {
             new Sample<SfxSample>(SfxSample.NoteMiss, "note_miss", 0.55f),
             new Sample<SfxSample>(SfxSample.StarPowerAward, "starpower_award", 0.5f),
-            new Sample<SfxSample>(SfxSample.StarPowerGain, "starpower_gain", 0.85f),
+            new Sample<SfxSample>(SfxSample.StarPowerReady, "starpower_ready", 0.85f),
             new Sample<SfxSample>(SfxSample.StarPowerDeploy, "starpower_deploy", 0.4f),
             new Sample<SfxSample>(SfxSample.StarPowerDeployCrowd, "overdrive_deploy_crowd", 0.4f),
             new Sample<SfxSample>(SfxSample.StarPowerRelease, "starpower_release", 0.5f),

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -884,6 +884,11 @@ namespace YARG.Core.Engine
             {
                 var whammyTicks = CalculateStarPowerGain(CurrentTick, Math.Max(LastTick, FirstWhammyTick), ref WhammyTicksRemainder);
 
+                if (!BaseStats.IsStarPowerActive && BaseStats.StarPowerTickAmount < TicksPerHalfSpBar && BaseStats.StarPowerTickAmount + whammyTicks >= TicksPerHalfSpBar)
+                {
+                    OnStarPowerGain?.Invoke();
+                }
+
                 // Don't cap until drain has been calculated
                 BaseStats.StarPowerTickAmount += whammyTicks;
 

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -886,7 +886,7 @@ namespace YARG.Core.Engine
 
                 if (!BaseStats.IsStarPowerActive && BaseStats.StarPowerTickAmount < TicksPerHalfSpBar && BaseStats.StarPowerTickAmount + whammyTicks >= TicksPerHalfSpBar)
                 {
-                    OnStarPowerGain?.Invoke();
+                    OnStarPowerReady?.Invoke();
                 }
 
                 // Don't cap until drain has been calculated

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -20,7 +20,7 @@ namespace YARG.Core.Engine
         protected const int SUSTAIN_BURST_FRACTION = 4;
 
         public delegate void StarPowerStatusEvent(bool active);
-        public delegate void StarPowerGainEvent();
+        public delegate void StarPowerReadyEvent();
         public delegate void SoloStartEvent(SoloSection soloSection);
         public delegate void SoloEndEvent(SoloSection soloSection);
         public delegate void CodaStartEvent(CodaSection codaSection);
@@ -30,7 +30,7 @@ namespace YARG.Core.Engine
 
         public delegate void UnisonBonusAwardedEvent();
         public StarPowerStatusEvent? OnStarPowerStatus;
-        public StarPowerGainEvent?   OnStarPowerGain;
+        public StarPowerReadyEvent?   OnStarPowerReady;
         public SoloStartEvent?       OnSoloStart;
         public SoloEndEvent?         OnSoloEnd;
         public CodaStartEvent?       OnCodaStart;
@@ -511,7 +511,7 @@ namespace YARG.Core.Engine
             var prevTicks = BaseStats.StarPowerTickAmount;
             if (!BaseStats.IsStarPowerActive && prevTicks < TicksPerHalfSpBar && prevTicks + ticks >= TicksPerHalfSpBar)
             {
-                OnStarPowerGain?.Invoke();
+                OnStarPowerReady?.Invoke();
             }
             BaseStats.StarPowerTickAmount += ticks;
 

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -20,6 +20,7 @@ namespace YARG.Core.Engine
         protected const int SUSTAIN_BURST_FRACTION = 4;
 
         public delegate void StarPowerStatusEvent(bool active);
+        public delegate void StarPowerGainEvent();
         public delegate void SoloStartEvent(SoloSection soloSection);
         public delegate void SoloEndEvent(SoloSection soloSection);
         public delegate void CodaStartEvent(CodaSection codaSection);
@@ -29,6 +30,7 @@ namespace YARG.Core.Engine
 
         public delegate void UnisonBonusAwardedEvent();
         public StarPowerStatusEvent? OnStarPowerStatus;
+        public StarPowerGainEvent?   OnStarPowerGain;
         public SoloStartEvent?       OnSoloStart;
         public SoloEndEvent?         OnSoloEnd;
         public CodaStartEvent?       OnCodaStart;
@@ -507,6 +509,10 @@ namespace YARG.Core.Engine
         protected void GainStarPower(uint ticks)
         {
             var prevTicks = BaseStats.StarPowerTickAmount;
+            if (!BaseStats.IsStarPowerActive && prevTicks < TicksPerHalfSpBar && prevTicks + ticks >= TicksPerHalfSpBar)
+            {
+                OnStarPowerGain?.Invoke();
+            }
             BaseStats.StarPowerTickAmount += ticks;
 
             // Limit amount of ticks to a full bar.


### PR DESCRIPTION
Previously, this was being handled in YARG separately in the vocals and track players for notifications. Since I needed it for SFX anyway, and that seemed at odds with the other star power events, I made it an event instead.