### PR TITLE
Make Harmony part selection sticky with fallback.

### DIFF
--- a/YARG.Core.UnitTests/Game/YargProfileHarmonyIndexTests.cs
+++ b/YARG.Core.UnitTests/Game/YargProfileHarmonyIndexTests.cs
@@ -1,0 +1,69 @@
+using NUnit.Framework;
+using YARG.Core.Game;
+
+namespace YARG.Core.UnitTests.Game;
+
+public class YargProfileHarmonyIndexTests
+{
+    private static YargProfile MakeHarmonyProfile(byte harmonyIndex)
+    {
+        var profile = new YargProfile
+        {
+            CurrentInstrument = Instrument.Harmony,
+        };
+        profile.HarmonyIndex = harmonyIndex;
+        return profile;
+    }
+
+    [Test]
+    public void ResolveClampsToHighestAvailablePart()
+    {
+        var profile = MakeHarmonyProfile(2); // HARM3
+
+        profile.ResolveHarmonyIndex(2); // two-part song
+
+        Assert.That(profile.HarmonyIndex, Is.EqualTo(1)); // HARM2
+    }
+
+    [Test]
+    public void ResolveRestoresExplicitSelectionOnLargerSong()
+    {
+        var profile = MakeHarmonyProfile(2); // explicitly picked HARM3
+
+        profile.ResolveHarmonyIndex(2); // looked at a two-part song
+        profile.ResolveHarmonyIndex(3); // back to a three-part song
+
+        Assert.That(profile.HarmonyIndex, Is.EqualTo(2)); // HARM3 remembered
+    }
+
+    [Test]
+    public void ExplicitSelectionReplacesPreviousPreference()
+    {
+        var profile = MakeHarmonyProfile(2);
+
+        profile.ResolveHarmonyIndex(2);
+        profile.HarmonyIndex = 0; // player explicitly picks HARM1
+        profile.ResolveHarmonyIndex(3);
+
+        Assert.That(profile.HarmonyIndex, Is.EqualTo(0)); // not bounced back to HARM3
+    }
+
+    [Test]
+    public void ResolveIgnoresNonPositivePartCount()
+    {
+        var profile = MakeHarmonyProfile(2);
+
+        profile.ResolveHarmonyIndex(0);
+
+        Assert.That(profile.HarmonyIndex, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void GetterStillGuardsNonHarmonyInstruments()
+    {
+        var profile = MakeHarmonyProfile(2);
+        profile.CurrentInstrument = Instrument.Vocals;
+
+        Assert.That(profile.HarmonyIndex, Is.EqualTo(0));
+    }
+}

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -90,12 +90,22 @@ namespace YARG.Core.Game
         /// </summary>
         public Difficulty DifficultyFallback;
 
+        /// <summary>
+        /// The harmony part the player last *explicitly* selected. Mirrors
+        /// <see cref="DifficultyFallback"/>: songs with fewer parts never overwrite it,
+        /// so the preference survives visiting a song where it isn't available.
+        /// Serialized as "HarmonyIndex" for compatibility with existing profiles.
+        /// </summary>
         [JsonProperty("HarmonyIndex")]
+        private byte _harmonyIndexFallback;
+
         private byte _harmonyIndex;
 
         /// <summary>
         /// The harmony index, used for determining what harmony part the player selected.
         /// Does nothing if <see cref="CurrentInstrument"/> is not a harmony.
+        /// Setting this counts as an explicit selection and updates the fallback;
+        /// use <see cref="ResolveHarmonyIndex"/> for per-song adjustment.
         /// </summary>
         [JsonIgnore]
         public byte HarmonyIndex
@@ -103,7 +113,26 @@ namespace YARG.Core.Game
             // Only expose harmony index when playing harmonies, ensures consistent behavior
             // while still allowing harmony index to persist between instrument switches
             get => CurrentInstrument == Instrument.Harmony ? _harmonyIndex : (byte) 0;
-            set => _harmonyIndex = value;
+            set => _harmonyIndex = _harmonyIndexFallback = value;
+        }
+
+        /// <summary>
+        /// Recomputes the effective harmony index for a song with
+        /// <paramref name="harmonyPartCount"/> parts from the player's last explicit
+        /// selection, clamping to the highest available part rather than resetting to
+        /// zero. The explicit selection itself is left untouched, so a song with fewer
+        /// parts doesn't erase the preference (same behavior as
+        /// <see cref="DifficultyFallback"/> for Expert+). Operates on the raw backing
+        /// field so it works regardless of <see cref="CurrentInstrument"/>.
+        /// </summary>
+        public void ResolveHarmonyIndex(int harmonyPartCount)
+        {
+            if (harmonyPartCount <= 0)
+                return;
+
+            _harmonyIndex = _harmonyIndexFallback < harmonyPartCount
+                ? _harmonyIndexFallback
+                : (byte) (harmonyPartCount - 1);
         }
 
         /// <summary>
@@ -172,7 +201,7 @@ namespace YARG.Core.Game
             CurrentInstrument = (Instrument) stream.ReadByte();
             CurrentDifficulty = (Difficulty) stream.ReadByte();
             CurrentModifiers = (Modifier) stream.Read<ulong>(Endianness.Little);
-            _harmonyIndex = stream.ReadByte();
+            _harmonyIndex = _harmonyIndexFallback = stream.ReadByte();
 
             NoteSpeed = stream.Read<float>(Endianness.Little);
             HighwayLength = stream.Read<float>(Endianness.Little);
@@ -420,6 +449,10 @@ namespace YARG.Core.Game
         [OnDeserialized]
         public void ValidateJsonDeserialization(StreamingContext context)
         {
+            // Seed the effective harmony index from the saved preference; it is
+            // re-resolved against each song's part count in difficulty select.
+            _harmonyIndex = _harmonyIndexFallback;
+
             ValidatePreferredInstrument();
         }
 


### PR DESCRIPTION
This is in support of this issue: https://discord.com/channels/1086048856678084609/1514622595297841202

### Summary

Makes the harmony part selection behave like `DifficultyFallback` does for Expert+: the player's last *explicit* selection is kept in a private fallback field (`_harmonyIndexFallback`, serialized as the existing `"HarmonyIndex"` profile property), and a new `ResolveHarmonyIndex(int harmonyPartCount)` method recomputes the effective `_harmonyIndex` per song — clamping to the highest available part when the song has fewer parts, and restoring the full selection when it has enough.

A resolve method is needed because the existing `HarmonyIndex` getter returns `0` whenever `CurrentInstrument != Harmony` (by design, since `VocalsPlayer` uses `HarmonyIndex` to index into `Parts[]` for both VOCALS and HARMONY players, and VOCALS always has one part at index 0). Any code that reads `HarmonyIndex` to validate the stored value will see `0` (always valid) when the instrument is not Harmony, and will never correct a stale out-of-range value. `ResolveHarmonyIndex` operates on the backing fields directly so the instrument guard is not a problem.

The `HarmonyIndex` setter now also writes the fallback — setting it counts as an explicit selection. Both deserialization paths (JSON profiles, binary/replay) seed both fields, so existing profiles and replays load unchanged.

### Why resolve clamps to `harmonyPartCount - 1`, not `0`

If a player had HARM3 selected and navigates to a two-part song, clamping to HARM2 (the highest available) is a better default than silently jumping them to HARM1. Their preference was for a Harmony part, not the lead vocals.

### Why a fallback, not just a clamp

A destructive clamp would erase the player's HARM3 selection the moment they *view* a two-part song in difficulty select; returning to a three-part song would leave them stuck on HARM2. Keeping the explicit selection and recomputing per song matches the established `DifficultyFallback` behavior for Expert+. (I encountered this behavior during testing.)

### Changes

| File | Change |
|------|--------|
| `YARG.Core/Game/YargProfile.cs` | Add `_harmonyIndexFallback` (serialized as `"HarmonyIndex"`), `ResolveHarmonyIndex(int)`; setter updates fallback; deserialization seeds both fields |
| `YARG.Core.UnitTests/Game/YargProfileHarmonyIndexTests.cs` | New tests for clamp, restore, explicit-selection, and getter-guard behavior |

### Notes

- No observable behavior change until `ResolveHarmonyIndex` is called (Unity PR);
  without resolve calls the two fields always hold the same value.
- Profile JSON property name (`"HarmonyIndex"`) and binary replay format are unchanged.
- Safe to merge before the Unity side PR (bug/bad-harmony-number), and required for it to work.
