### PR TITLE
Fix shared VocalNote instances between vocal players on the same part

### DIFF
--- a/YARG.Core.UnitTests/Chart/VocalsPartTests.cs
+++ b/YARG.Core.UnitTests/Chart/VocalsPartTests.cs
@@ -113,6 +113,56 @@ public class VocalsTrackTests
         Assert.That(trimmed.RangeShifts.Select(e => e.Tick), Is.EqualTo(new uint[] { 75, 125, 175 }));
     }
 
+    [Test]
+    public void CloneAsInstrumentDifficultyDoesNotShareNotesBetweenClones()
+    {
+        var part = CreatePartWithSungPhrase();
+
+        var first = part.CloneAsInstrumentDifficulty();
+        var second = part.CloneAsInstrumentDifficulty();
+
+        first.Notes[0].SetHitState(true, true);
+        first.Notes[0].SetMissState(true, true);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(second.Notes[0], Is.Not.SameAs(first.Notes[0]));
+            Assert.That(second.Notes[0].WasHit, Is.False);
+            Assert.That(second.Notes[0].WasMissed, Is.False);
+            Assert.That(part.NotePhrases[0].PhraseParentNote.WasHit, Is.False);
+            Assert.That(part.NotePhrases[0].PhraseParentNote.WasMissed, Is.False);
+        }
+    }
+
+    [Test]
+    public void CloneAsInstrumentDifficultyPreservesPitchSlideChildNotes()
+    {
+        var part = CreatePartWithSungPhrase();
+
+        var cloned = part.CloneAsInstrumentDifficulty();
+        var phrase = cloned.Notes[0];
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(phrase.ChildNotes, Has.Count.EqualTo(2));
+            Assert.That(phrase.ChildNotes[1].ChildNotes, Has.Count.EqualTo(1));
+            Assert.That(phrase.ChildNotes[1].ChildNotes[0].Pitch, Is.EqualTo(64));
+        }
+    }
+
+    private static VocalsPart CreatePartWithSungPhrase()
+    {
+        var parentNote = new VocalNote(NoteFlags.None, false, 1.0, 0.4, 100, 40);
+        parentNote.AddChildNote(new VocalNote(60, 0, VocalNoteType.Lyric, 1.0, 0.1, 100, 10));
+
+        var slideNote = new VocalNote(62, 0, VocalNoteType.Lyric, 1.2, 0.1, 120, 10);
+        parentNote.AddChildNote(slideNote);
+        slideNote.AddChildNote(new VocalNote(64, 0, VocalNoteType.Lyric, 1.3, 0.1, 130, 10));
+
+        var phrase = new VocalsPhrase(1.0, 0.4, 100, 40, parentNote, []);
+        return new VocalsPart(false, [phrase], [], [], []);
+    }
+
     private static VocalsTrack CreateVocalsTrack()
     {
         return new VocalsTrack(Instrument.Vocals, [

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs
@@ -119,7 +119,10 @@ namespace YARG.Core.Chart
 
         public InstrumentDifficulty<VocalNote> CloneAsInstrumentDifficulty()
         {
-            var vocalNotes = NotePhrases.Select(i => i.PhraseParentNote).ToList();
+            // Deep-clone the phrase notes: multiple players can sing the same part, and
+            // each engine mutates hit/miss state on its notes. Sharing instances would
+            // leak one player's hit/miss state into every other engine on this part.
+            var vocalNotes = NotePhrases.Select(i => i.PhraseParentNote.Clone()).ToList();
             var instrument = IsHarmony ? Instrument.Harmony : Instrument.Vocals;
 
             var diff = new InstrumentDifficulty<VocalNote>(instrument, Difficulty.Expert,


### PR DESCRIPTION
### Summary

`VocalsPart.CloneAsInstrumentDifficulty()` doesn't actually clone the notes — it builds the note list from the same `VocalNote` instances (`NotePhrases.Select(i => i.PhraseParentNote)`). Every caller gets a new `InstrumentDifficulty<VocalNote>` wrapper around shared mutable notes.

When two or more players sing the same part (two profiles on solo Vocals, or the same `HarmonyIndex`), each `VocalsEngine` mutates hit/miss state on those shared notes via `SetHitState`/`SetMissState`. One player's engine marking a note hit or missed changes what every other engine sees.

This PR deep-clones the phrase parent notes so each engine owns its note instances.

### Visible symptom

Percussion notes: `VocalsEngine.GetNextPercussionNote` skips notes with `WasHit || WasMissed` set. With two players on the same part, whichever engine resolves a percussion note first removes it from contention for the other player — the second player can never hit (or even see as hittable) a percussion note the first player already hit or missed.

The same shared state also affects anything else reading per-note hit/miss flags across engines; percussion is just where it's directly gameplay-visible.

### Root cause

```csharp
// VocalsPart.CloneAsInstrumentDifficulty — before:
var vocalNotes = NotePhrases.Select(i => i.PhraseParentNote).ToList();
```

The method name says clone, and `VocalsPhrase.Clone()` / `VocalsPart.Clone()` *do* deep-clone — this one path shares instances.

### Fix

```csharp
var vocalNotes = NotePhrases.Select(i => i.PhraseParentNote.Clone()).ToList();
```

One consideration verified: `Note<T>.Clone()` rebuilds children through `AddChildNote`, and `VocalNote.AddChildNote`'s non-lyric branch rejects child notes that have their own children. This could in principle drop pitch-slide child notes. It doesn't: sung phrases satisfy `IsLyricPhrase` (all children are `VocalNoteType.Lyric`), which takes the branch without that rejection, so slides survive the clone. A test pins this down so a future `AddChildNote` change can't silently make the clone lossy.

### Changes

| File | Change |
|------|--------|
| `YARG.Core/Chart/Tracks/Vocals/VocalsPart.cs` | Deep-clone `PhraseParentNote` in `CloneAsInstrumentDifficulty` |
| `YARG.Core.UnitTests/Chart/VocalsPartTests.cs` | New tests: clones don't share note instances (hit/miss isolation — fails without the fix); pitch-slide child notes survive cloning (preventive — see below) |

The two tests have different jobs. The isolation test demonstrates the bug and the fix (it fails on the old code). The pitch-slide test is *preventive*: it never failed, because before this change `CloneAsInstrumentDifficulty` didn't clone at all. The fix puts `VocalNote.Clone()` in the critical path of every vocals song load, which makes "cloning preserves the full note tree" a newly load-bearing invariant — and the mechanism keeping it true (`IsLyricPhrase` routing around `AddChildNote`'s reject-children-with-children branch) is indirect enough to break from changes that never touch `VocalsPart.cs`. The test enforces that invariant.

### Note on the isolation test's hit-and-missed state

`CloneAsInstrumentDifficultyDoesNotShareNotesBetweenClones` sets *both* `SetHitState(true, true)` and `SetMissState(true, true)` on the same note — a state real gameplay never produces (engines resolve a note as one or the other). This is deliberate: `WasHit`/`WasMissed` are independent booleans with no coherence enforced by `Note` itself, and the test dirties both in one go to prove neither flag leaks into the other clone. It also acts as a canary: if hit/miss state is ever refactored into a mutually exclusive representation (e.g. an enum), this test will fail and force a look at the isolation behavior under the new model.

### Other callers (all benefit or are unaffected)

- `VocalsEngine.cs:98` — bot/all-parts note aggregation; now operates on clones, which is strictly safer.
- `ReplayAnalyzer.cs:329` — per-player analysis; same isolation benefit when analyzing multi-vocal replays.

### Cost

One extra deep copy of the vocal note tree per player at song load / replay-analysis setup. Negligible next to chart parsing.

### Testing

- Core unit tests: full suite passes (408 passed, 2 skipped — the usual `FullScan`/`QuickScan` external-data skips). The isolation test fails without the fix.
- Unity manual test (**done, 2026-06-12**): 3 microphones + 2 bots on the same part in a song with vocal percussion — all 5 players hit percussion notes independently; previously only the first resolver per note could.
