### PR TITLE
Fix consecutive lane edge case

### DIFF
--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Drums.cs
@@ -443,15 +443,19 @@ namespace YARG.Core.Chart
             {
                 return;
             }
-           
-            foreach (var phrase in chart.Phrases)
+
+
+            for (var phraseIndex = 0; phraseIndex < chart.Phrases.Count; phraseIndex++)
             {
+                var phrase = chart.Phrases[phraseIndex];
+
                 if (phrase.Type is not (PhraseType.TremoloLane or PhraseType.TrillLane))
                 {
                     continue;
                 }
+                
 
-                var notesInPhrase = GetNotesInPhrase(phrase, chart.Notes, noteIndex, out noteIndex);
+                var notesInPhrase = GetNotesInLanePhrase(chart.Phrases, phraseIndex, chart.Notes, noteIndex, out noteIndex);
 
                 var fourLane = chart.Instrument is Instrument.FourLaneDrums or Instrument.ProDrums;
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Guitar.cs
@@ -247,14 +247,16 @@ namespace YARG.Core.Chart
                 return;
             }
 
-            foreach (var phrase in chart.Phrases)
+            for (var phraseIndex = 0; phraseIndex < chart.Phrases.Count; phraseIndex++)
             {
+                var phrase = chart.Phrases[phraseIndex];
+
                 if (phrase.Type is not (PhraseType.TremoloLane or PhraseType.TrillLane))
                 {
                     continue;
                 }
 
-                var notesInPhrase = GetNotesInPhrase(phrase, chart.Notes, noteIndex, out noteIndex);
+                var notesInPhrase = GetNotesInLanePhrase(chart.Phrases, phraseIndex, chart.Notes, noteIndex, out noteIndex);
 
                 List<GuitarNote> laneNotes;
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.ProKeys.cs
@@ -77,15 +77,17 @@ namespace YARG.Core.Chart
                 return;
             }
 
-            foreach (var phrase in chart.Phrases)
+            for (var phraseIndex = 0; phraseIndex < chart.Phrases.Count; phraseIndex++)
             {
+                var phrase = chart.Phrases[phraseIndex];
+
                 // Pro Keys does not support tremolos. Glissando phrases are handled earlier, since they don't require complex adjacent-note validation logic
                 if (phrase.Type is not PhraseType.TrillLane)
                 {
                     continue;
                 }
 
-                var notesInPhrase = GetNotesInPhrase(phrase, chart.Notes, noteIndex, out noteIndex);
+                var notesInPhrase = GetNotesInLanePhrase(chart.Phrases, phraseIndex, chart.Notes, noteIndex, out noteIndex);
 
                 var laneNotes = GetProKeysTrillNotes(notesInPhrase);
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.cs
@@ -552,8 +552,31 @@ namespace YARG.Core.Chart
             _ => throw new InvalidOperationException($"Invalid difficulty {difficulty}!")
         };
 
-        private static List<TNote> GetNotesInPhrase<TNote>(Phrase phrase, List<TNote> allNotes, int startingIndex, out int nextIndex) where TNote : Note<TNote>
+        private static List<TNote> GetNotesInLanePhrase<TNote>(List<Phrase> phrases, int phraseIndex, List<TNote> allNotes, int startingIndex, out int nextIndex) where TNote : Note<TNote>
         {
+            var phrase = phrases[phraseIndex];
+
+            var conterminousNextLaneExists = false;
+            // Find the next lane phrase, if any. If it exists and its start tick is the same as this phrase's end tick, then we'll treat this phrase as
+            // end-tick-exclusive to give the subsequent lane ownership of any note on that tick
+            for (var i = phraseIndex; i < phrases.Count; i++)
+            {
+                var laterPhrase = phrases[i];
+
+                if (laterPhrase.Tick > phrase.TickEnd)
+                {
+                    // We've moved on to phrases that don't abut this one; there is no conterminous next lane
+                    break;
+                }
+
+                if (laterPhrase.Tick == phrase.TickEnd && laterPhrase.Type is PhraseType.TremoloLane or PhraseType.TrillLane)
+                {
+                    conterminousNextLaneExists = true;
+                    break;
+                }
+            }
+
+
             List<TNote> notesInPhrase = new();
 
             nextIndex = startingIndex;
@@ -565,6 +588,12 @@ namespace YARG.Core.Chart
                 if (note.Tick < phrase.Tick)
                 {
                     continue;
+                }
+
+                if (conterminousNextLaneExists && note.Tick == phrase.TickEnd)
+                {
+                    // If there's a conterminous next lane, then this lane phrase excludes its last tick and gives it to that subsequent phrase instead
+                    break;
                 }
 
                 if (note.Tick > phrase.TickEnd)


### PR DESCRIPTION
The lane parsing logic currently incorrectly handles the edge case of two consecutive lanes that directly touch each other (lane 1's end tick is lane 2's start tick), like so:
<img width="1115" height="391" alt="image" src="https://github.com/user-attachments/assets/c0bc9bcb-19ae-400f-90b5-a0bd73ba2405" />

NaÏvely, the note on the border tick (highlighted in that screenshot) belongs to _both_ lanes, since lanes are inclusive of their end-ticks. However, the correct behavior is to give the latter phrase priority over the former in terms of "owning" that border note.

This change modifies the `GetNotesInPhrase` method (renamed to `GetNotesInLanePhrase` since it now concerns specifically lane-related logic) to check if a subsequent lane phrase exists which abuts the currently-evaluated phrase. If that is the case, it uses end-exclusive logic to leave the end-tick note for that subsequent phrase. Otherwise, it uses end-inclusive logic as usual.