### PR TITLE
Fix Big Rock Ending soft-lock and premature finale-chord bonus

### DIFF
--- a/YARG.Core.UnitTests/Engine/BreSoftlockTests.cs
+++ b/YARG.Core.UnitTests/Engine/BreSoftlockTests.cs
@@ -1,0 +1,222 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using YARG.Core.Chart;
+using YARG.Core.Engine.Drums;
+using YARG.Core.Engine.Drums.Engines;
+using YARG.Core.Game;
+using YARG.Core.Input;
+
+namespace YARG.Core.UnitTests.Engine;
+
+// Regression tests for the Big Rock Ending soft-lock: when a BRE fill contains
+// real gem notes and the player mashes out of order, the engine must not strand
+// NoteIndex on an already-resolved BRE note (which previously froze the engine so
+// that no further notes registered for the rest of the song).
+public class BreSoftlockTests : EngineTester
+{
+    private const int RES = 480;
+
+    private static DrumsEngineParameters Params() =>
+        EnginePreset.Default.Drums.Create(StarMultiplierThresholds, SoloBonusStarMultiplierThresholds,
+            DrumsEngineParameters.DrumMode.NonProFourLane);
+
+    // Builds: lead-in note, a BRE phrase densely packed with gems on rotating pads,
+    // a couple of finale notes after the fill, the last of which is the CodaEnd note.
+    private static (YargDrumsEngine engine, InstrumentDifficulty<DrumNote> notes, List<DrumNote> finale)
+        BuildGemFilledBre(int gemCount)
+    {
+        double TimeOf(uint tick) => tick / (double) RES * 0.5; // 120 bpm
+
+        var notes = new List<DrumNote>();
+
+        // lead-in
+        notes.Add(new DrumNote(FourLaneDrumPad.RedDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.None, TimeOf(0), 0));
+
+        // BRE fill gems, every 120 ticks (0.125s), rotating Red/Yellow/Blue/Green
+        var pads = new[] { FourLaneDrumPad.RedDrum, FourLaneDrumPad.YellowDrum, FourLaneDrumPad.BlueDrum, FourLaneDrumPad.GreenDrum };
+        uint breStart = 480;
+        uint t = breStart;
+        const uint gemSpacing = 40; // dense fill so several gems share a hit window
+        for (int i = 0; i < gemCount; i++)
+        {
+            notes.Add(new DrumNote(pads[i % pads.Length], DrumNoteType.Neutral, DrumNoteFlags.None,
+                NoteFlags.BigRockEnding, TimeOf(t), t));
+            t += gemSpacing;
+        }
+        uint breEnd = t + gemSpacing;
+
+        // finale: two normal notes after the fill, last one is CodaEnd
+        uint finaleA = breEnd + 240;
+        uint finaleB = finaleA + 240;
+        var fA = new DrumNote(FourLaneDrumPad.YellowDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.None, TimeOf(finaleA), finaleA);
+        var fB = new DrumNote(FourLaneDrumPad.BlueDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.CodaEnd, TimeOf(finaleB), finaleB);
+        notes.Add(fA);
+        notes.Add(fB);
+
+        // wire neighbour links
+        for (int i = 1; i < notes.Count; i++)
+        {
+            notes[i].PreviousNote = notes[i - 1];
+            notes[i - 1].NextNote = notes[i];
+        }
+
+        var phrases = new List<Phrase>
+        {
+            new(PhraseType.BigRockEnding, TimeOf(breStart), TimeOf(breEnd) - TimeOf(breStart), breStart, breEnd - breStart),
+        };
+
+        var diff = new InstrumentDifficulty<DrumNote>(Instrument.FourLaneDrums, Difficulty.Expert,
+            notes, phrases, new());
+
+        var syncTrack = new SyncTrack(RES);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new YargDrumsEngine(diff, syncTrack, Params(), isBot: false, isMidiDrumsInput: false);
+        return (engine, diff, new List<DrumNote> { fA, fB });
+    }
+
+    private static DrumsAction ActionFor(int pad) => (FourLaneDrumPad) pad switch
+    {
+        FourLaneDrumPad.Kick => DrumsAction.Kick,
+        FourLaneDrumPad.RedDrum => DrumsAction.RedDrum,
+        FourLaneDrumPad.YellowDrum => DrumsAction.YellowDrum,
+        FourLaneDrumPad.BlueDrum => DrumsAction.BlueDrum,
+        FourLaneDrumPad.GreenDrum => DrumsAction.GreenDrum,
+        _ => DrumsAction.RedDrum,
+    };
+
+    // Builds an empty-fill BRE followed by a finale that is a chord. The CodaEnd flag
+    // sits on a single sub-note of that chord (the kick), mirroring real charts.
+    private static (YargDrumsEngine engine, InstrumentDifficulty<DrumNote> notes, DrumNote finale)
+        BuildBreWithFinalChord()
+    {
+        double TimeOf(uint tick) => tick / (double) RES * 0.5; // 120 bpm
+
+        var leadIn = new DrumNote(FourLaneDrumPad.RedDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.None, TimeOf(0), 0);
+
+        // Final chord after the (empty) fill: kick carries CodaEnd, green does not.
+        uint finaleTick = 1680;
+        var finale = new DrumNote(FourLaneDrumPad.Kick, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.CodaEnd, TimeOf(finaleTick), finaleTick);
+        finale.AddChildNote(new DrumNote(FourLaneDrumPad.GreenDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.None, TimeOf(finaleTick), finaleTick));
+
+        leadIn.NextNote = finale;
+        finale.PreviousNote = leadIn;
+
+        uint breStart = 480, breEnd = 1440;
+        var phrases = new List<Phrase>
+        {
+            new(PhraseType.BigRockEnding, TimeOf(breStart), TimeOf(breEnd) - TimeOf(breStart), breStart, breEnd - breStart),
+        };
+
+        var diff = new InstrumentDifficulty<DrumNote>(Instrument.FourLaneDrums, Difficulty.Expert,
+            new List<DrumNote> { leadIn, finale }, phrases, new());
+
+        var syncTrack = new SyncTrack(RES);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new YargDrumsEngine(diff, syncTrack, Params(), isBot: false, isMidiDrumsInput: false);
+        return (engine, diff, finale);
+    }
+
+    // Runs the engine to the end, hitting only the listed pads on the finale chord.
+    private static bool? RunFinale(YargDrumsEngine engine, InstrumentDifficulty<DrumNote> notes,
+        DrumNote finale, params int[] padsToHit)
+    {
+        bool? successAtCodaEnd = null;
+        engine.OnCodaEnd += _ => successAtCodaEnd = engine.CodaSuccess; // mirrors the band handler
+
+        var fired = false;
+        double endTime = finale.Time + 2.0;
+        for (double time = 0; time <= endTime; time += 0.02)
+        {
+            if (!fired && time >= finale.Time)
+            {
+                fired = true;
+                foreach (var pad in padsToHit)
+                {
+                    var gi = GameInput.Create(time, ActionFor(pad), 1.0f);
+                    engine.QueueInput(ref gi);
+                }
+            }
+
+            engine.Update(time);
+        }
+
+        return successAtCodaEnd;
+    }
+
+    [Test]
+    public void HittingOnlyCodaEndSubNote_OfFinalChord_DoesNotBankBonus()
+    {
+        var (engine, notes, finale) = BuildBreWithFinalChord();
+
+        // Hit only the kick (the CodaEnd-flagged sub-note); leave the green unhit.
+        bool? success = RunFinale(engine, notes, finale, (int) FourLaneDrumPad.Kick);
+
+        Assert.That(success, Is.False,
+            "hitting only the CodaEnd sub-note must not count as completing the final chord");
+    }
+
+    [Test]
+    public void HittingFullFinalChord_BanksBonus()
+    {
+        var (engine, notes, finale) = BuildBreWithFinalChord();
+
+        bool? success = RunFinale(engine, notes, finale,
+            (int) FourLaneDrumPad.Kick, (int) FourLaneDrumPad.GreenDrum);
+
+        Assert.That(success, Is.True, "hitting the entire final chord should award the coda bonus");
+    }
+
+    [Test]
+    public void MashingGemFilledBre_OutOfOrder_DoesNotSoftlock()
+    {
+        var (engine, notes, finale) = BuildGemFilledBre(gemCount: 64);
+
+        double endTime = notes.Notes[^1].Time + 1.0;
+        var mash = new[] { DrumsAction.GreenDrum, DrumsAction.RedDrum, DrumsAction.BlueDrum, DrumsAction.YellowDrum };
+        int mp = 0;
+        var firedFinale = new HashSet<uint>();
+
+        for (double time = 0; time <= endTime; time += 0.02)
+        {
+            // Mash continuously across the fill (and a bit past it), out of order vs the gem layout.
+            if (time >= 0.5 && time <= notes.Notes[^1].Time)
+            {
+                var gi = GameInput.Create(time, mash[mp++ % mash.Length], 1.0f);
+                engine.QueueInput(ref gi);
+            }
+
+            // Player also tries to hit the finale notes at their times.
+            foreach (var f in finale)
+            {
+                if (!firedFinale.Contains(f.Tick) && System.Math.Abs(time - f.Time) < 0.02)
+                {
+                    firedFinale.Add(f.Tick);
+                    var gi = GameInput.Create(time, ActionFor(f.Pad), 1.0f);
+                    engine.QueueInput(ref gi);
+                }
+            }
+
+            engine.Update(time);
+        }
+
+        // The defining symptom of the soft-lock: post-fill notes left in limbo
+        // (neither hit nor missed) because NoteIndex never reached them.
+        int limbo = finale.Count(f => !f.WasHit && !f.WasMissed);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(limbo, Is.Zero, "finale notes were stranded in limbo (engine soft-locked during the BRE)");
+            Assert.That(engine.NoteIndex, Is.EqualTo(notes.Notes.Count),
+                "NoteIndex did not advance through the whole chart");
+        }
+    }
+}

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -496,8 +496,11 @@ namespace YARG.Core.Engine
 
         protected virtual void HitNote(TNoteType note)
         {
-            // If this is the last note in the chart and there was a successful coda, award coda bonus
-            if (CodaHasStarted && note.IsCodaEnd)
+            // The coda ends on the final note of the section. That note may be a chord, but the
+            // CodaEnd marker sits on a single sub-note, so only end the coda once the whole chord
+            // is resolved — otherwise hitting one sub-note (e.g. just the kick) ends the coda early
+            // and banks the bonus without the player completing the final chord.
+            if (CodaHasStarted && ChordHasCodaEnd(note) && note.ParentOrSelf.WasFullyHitOrMissed())
             {
                 EndCoda();
             }
@@ -574,7 +577,8 @@ namespace YARG.Core.Engine
                 Codas[CurrentCodaIndex].MissNote();
             }
 
-            if (CodaHasStarted && note.IsCodaEnd)
+            // Mirror HitNote: end the coda only once the whole final chord is resolved.
+            if (CodaHasStarted && ChordHasCodaEnd(note) && note.ParentOrSelf.WasFullyHitOrMissed())
             {
                 EndCoda();
             }
@@ -1131,6 +1135,21 @@ namespace YARG.Core.Engine
             IsCodaActive = true;
             CodaHasStarted = true;
             OnCodaStart?.Invoke(Codas[CurrentCodaIndex]);
+        }
+
+        // The CodaEnd marker is set on a single note; this reports whether that note's
+        // chord (parent + children) carries it, so the coda ends on the whole final chord.
+        private static bool ChordHasCodaEnd(TNoteType note)
+        {
+            foreach (var chordNote in note.ParentOrSelf.AllNotes)
+            {
+                if (chordNote.IsCodaEnd)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         protected void EndCoda()

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -140,9 +140,14 @@ namespace YARG.Core.Engine.Drums
 
             note.SetHitState(true, false);
 
-            // Cancel the rest of hit logic during BRE phrase
+            // Cancel the rest of hit logic during BRE phrase (no scoring/combo/star power),
+            // but still resolve any previous notes that were skipped. BRE gems can be hit
+            // out of order while mashing; without this the skipped gems stay unresolved and
+            // NoteIndex strands on an already-hit note, soft-locking the engine for the rest
+            // of the song.
             if (IsCodaActive && note.IsBigRockEnding)
             {
+                SkipPreviousNotes(note.ParentOrSelf);
                 base.HitNote(note);
                 return;
             }


### PR DESCRIPTION
# PR Draft: Fix drums Big Rock Ending soft-lock and premature finale-chord bonus

Single Core PR — no Unity changes required for the engine fixes.

**Target:** `YARC-Official/YARG.Core` ← `XaiaX/YARG.Core:bug/bre-gem-softlock`

---

## Summary

Two related defects in how the drums engine handles Big Rock Endings (codas), both reproducible on stock RB charts:

1. **Soft-lock when gems are charted under the BRE lanes.** On a BRE whose fill contains real gem notes (most BREs leave the fill empty, but some — e.g. "CfH (Live)" — chart the drums through it), mashing out of order strands `NoteIndex` on an already-hit note. The engine then freezes for the rest of the song: inputs still produce visual feedback (overhits) but no further notes register, and the coda/lanes never tear down.
2. **Finale chord bonus banked by hitting one sub-note.** The finale after a BRE may be a chord (e.g. kick + green), but the `CodaEnd` marker sits on a single sub-note. Hitting just that note (in observed cases always the kick) ended the coda and awarded the bonus without the player completing the chord.

Both are input-dependent.

---

## Bug 1 — Soft-lock with charted BRE gems

### Root cause

`DrumsEngine.HitNote`'s BRE branch returned **before** `SkipPreviousNotes`:

```csharp
note.SetHitState(true, false);
if (IsCodaActive && note.IsBigRockEnding)
{
    base.HitNote(note);   // <-- skips SkipPreviousNotes
    return;
}
bool skipped = SkipPreviousNotes(note.ParentOrSelf);
```

`SkipPreviousNotes` is the mechanism the normal hit path uses to resolve notes that were skipped by an out-of-order hit. During a BRE the player mashes freely, so gems are routinely hit out of order; with the resolve step skipped, those gems stay unresolved (neither hit nor missed). `NoteIndex` only advances past a fully-resolved note, and the hit/miss paths no-op on an already-resolved note, so once `NoteIndex` lands on a gem that was hit out of order, it can never advance. The coda's `IsCodaEnd` note becomes unreachable, so `CodaHasStarted` never clears and the section never ends. Most BREs have 0 notes in the lanes, so they don't exhibit this behavior, it only applies to BREs where the lanes cover charted/placeholder notes.

This is the same *class* as `Fix 5LK lane bug causing player to get stuck` (a note left in neither `WasHit` nor `WasMissed` stalls advancement), in a different code path.

### Fix

Call `SkipPreviousNotes` in the BRE branch as well, still skipping scoring / combo / star power:

```csharp
if (IsCodaActive && note.IsBigRockEnding)
{
    SkipPreviousNotes(note.ParentOrSelf);
    base.HitNote(note);
    return;
}
```

Skipped BRE gems are resolved (force-hit, since BRE notes can't be missed), so `NoteIndex` always advances.

---

## Bug 2 — Premature finale-chord bonus

### Root cause

The coda ended on the single `CodaEnd`-flagged sub-note, in both `BaseEngine.HitNote` and `MissNote`:

```csharp
if (CodaHasStarted && note.IsCodaEnd)
{
    EndCoda();
}
```

`EndCoda` fires `OnCodaEnd`, and the band handler captures `CodaSuccess` at that instant. When the finale is a chord with `CodaEnd` on one sub-note (the kick), hitting only that note ended the coda before the rest of the chord was judged — `CodaSuccess` was still `true`, so the bonus was banked. Hitting only the non-flagged notes (green/red) correctly failed.

### Fix

End the coda only once the whole chord containing the `CodaEnd` note is resolved:

```csharp
if (CodaHasStarted && ChordHasCodaEnd(note) && note.ParentOrSelf.WasFullyHitOrMissed())
{
    EndCoda();
}
```

with a small helper that reports whether a note's chord (parent + children) carries the marker. Now an incomplete final chord leaves the coda open; the unhit sub-note later misses, fails the section, and *then* the coda ends — no bonus. Completing the full chord awards it. Correct for single-note finales too (chord of one).

---

## Changes

| File | Change |
|------|--------|
| `YARG.Core/Engine/Drums/DrumsEngine.cs` | `HitNote` BRE branch now calls `SkipPreviousNotes` before `base.HitNote` |
| `YARG.Core/Engine/BaseEngine.Generic.cs` | `HitNote`/`MissNote` end the coda only when the full chord containing `CodaEnd` is resolved; add `ChordHasCodaEnd` helper |
| `YARG.Core.UnitTests/Engine/BreSoftlockTests.cs` | New: out-of-order gem-filled BRE (no soft-lock), kick-only finale (no bonus), full-chord finale (bonus) |

---

## Testing

- **Unit tests** (`BreSoftlockTests`): the soft-lock test was confirmed RED before the fix (`NoteIndex` stuck, finale notes in limbo); the kick-only-finale test was confirmed RED before bug 2's fix.
- **Full Core suite:** 411 passed, 2 skipped, 0 failures (no coda/other regressions).
- **Corpus sweep:** a headless harness drove the drums engine over 137 known BRE songs (28 of which chart gems under the lanes). Before: 8 different songs soft-locked under trivial mash patterns. After: **zero** soft-locks across 5 mash patterns. Finale-chord bonus verified on "DDDDC" (`Kick* + Green`) and "HS" (`Kick* + Red + Green`): kick-only and green-only fail, full chord awards.
- **In-game:** verified on CfH (soft-lock gone), DDDDC and HS (finale bonus correct).

## Notes

- Empty-fill BREs (109 of 137 songs) never enter the BRE hit branch, so their behavior is unchanged.
- A separate, **Unity-side** visual issue remains open and unrelated to this PR: a finale chord that lands exactly on the BRE phrase-end tick renders on the lane's trailing edge (the note is correct and must be hit to complete the BRE).
