### PR TITLE
fix(engine): suppress end-tick BRE finale through the whole coda

### DIFF
--- a/YARG.Core.UnitTests/Engine/BreSoftlockTests.cs
+++ b/YARG.Core.UnitTests/Engine/BreSoftlockTests.cs
@@ -7,6 +7,8 @@ using YARG.Core.Engine.Drums;
 using YARG.Core.Engine.Drums.Engines;
 using YARG.Core.Engine.Guitar;
 using YARG.Core.Engine.Guitar.Engines;
+using YARG.Core.Engine.Keys;
+using YARG.Core.Engine.Keys.Engines;
 using YARG.Core.Game;
 using YARG.Core.Input;
 
@@ -176,6 +178,303 @@ public class BreSoftlockTests : EngineTester
             (int) FourLaneDrumPad.Kick, (int) FourLaneDrumPad.GreenDrum);
 
         Assert.That(success, Is.True, "hitting the entire final chord should award the coda bonus");
+    }
+
+    // Builds a BRE whose finale chord is charted on the EXACT tick where the BRE phrase
+    // ends (phrase.TickEnd). Real parsing marks such a note IsBigRockEnding end-inclusively
+    // (MoonSongLoader), and the BRE lane visual hides any IsBigRockEnding note (TrackPlayer
+    // skips its spawn), so the player cannot see it. Unless they blindly hit it, the engine
+    // misses it — and the miss must not forfeit the BRE bonus.
+    //
+    // The bug: the suppression gate keys on IsCodaActive, but a note is *missed* at its
+    // back-end time (BitIncrement(note.Time + backEnd)), which is strictly after
+    // phrase.TimeEnd == CodaSection.EndTime, by which point IsCodaActive is already false
+    // (it deactivates at time >= EndTime). The miss therefore falls through to a normal
+    // miss, which calls CodaSection.MissNote() -> Success = false and banks nothing.
+    private static (YargDrumsEngine engine, InstrumentDifficulty<DrumNote> notes, DrumNote finale)
+        BuildBreWithEndTickFinalChord()
+    {
+        double TimeOf(uint tick) => tick / (double) RES * 0.5; // 120 bpm
+
+        var notes = new List<DrumNote>();
+
+        // Lead-in note (not part of the BRE). Missed, keeps combo at 0.
+        notes.Add(new DrumNote(FourLaneDrumPad.RedDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.None, TimeOf(0), 0));
+
+        // BRE fill gems, every 120 ticks. They are auto-resolved during the fill (the gate
+        // is active while IsCodaActive is true) and collect bonus as the player mashes.
+        var pads = new[] { FourLaneDrumPad.RedDrum, FourLaneDrumPad.YellowDrum, FourLaneDrumPad.BlueDrum, FourLaneDrumPad.GreenDrum };
+        uint breStart = 480;
+        uint breEnd = 1440;
+        int p = 0;
+        for (uint t = breStart; t < breEnd; t += 120)
+        {
+            notes.Add(new DrumNote(pads[p++ % pads.Length], DrumNoteType.Neutral, DrumNoteFlags.None,
+                NoteFlags.BigRockEnding, TimeOf(t), t));
+        }
+
+        // Finale chord charted EXACTLY on phrase.TickEnd (breEnd). Both notes are IsBigRockEnding
+        // (end-inclusive); the parent carries IsCodaEnd. Mirrors the [Yellow+Blue] finale of
+        // dirtydeeds_live (BRE phrase 288000..296160, finale at tick 296160).
+        var finale = new DrumNote(FourLaneDrumPad.YellowDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.BigRockEnding | NoteFlags.CodaEnd, TimeOf(breEnd), breEnd);
+        finale.AddChildNote(new DrumNote(FourLaneDrumPad.BlueDrum, DrumNoteType.Neutral, DrumNoteFlags.None,
+            NoteFlags.BigRockEnding, TimeOf(breEnd), breEnd));
+        notes.Add(finale);
+
+        // Wire neighbour links.
+        for (int i = 1; i < notes.Count; i++)
+        {
+            notes[i].PreviousNote = notes[i - 1];
+            notes[i - 1].NextNote = notes[i];
+        }
+
+        var phrases = new List<Phrase>
+        {
+            new(PhraseType.BigRockEnding, TimeOf(breStart), TimeOf(breEnd) - TimeOf(breStart), breStart, breEnd - breStart),
+        };
+
+        var diff = new InstrumentDifficulty<DrumNote>(Instrument.FourLaneDrums, Difficulty.Expert,
+            notes, phrases, new());
+
+        var syncTrack = new SyncTrack(RES);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new YargDrumsEngine(diff, syncTrack, Params(), isBot: false, isMidiDrumsInput: false);
+        return (engine, diff, finale);
+    }
+
+    [Test]
+    public void EndTickFinalChord_NotHit_StillAwardsBonus()
+    {
+        var (engine, notes, finale) = BuildBreWithEndTickFinalChord();
+
+        bool codaEnded = false;
+        bool? successAtCodaEnd = null;
+        engine.OnCodaEnd += _ =>
+        {
+            codaEnded = true;
+            // Read while CurrentCodaIndex still points at the just-ended coda: EndCoda fires
+            // OnCodaEnd before advancing the index. CodaSuccess is the faithful proxy for "the
+            // bonus would be banked" since the band-side AwardCodaBonus handler is absent in a
+            // headless engine.
+            successAtCodaEnd = engine.CodaSuccess;
+        };
+
+        // Mash the BRE fill so the coda collects a bonus, but never feed a hit to the
+        // end-tick finale (the player cannot see it).
+        var mash = new[] { DrumsAction.RedDrum, DrumsAction.YellowDrum, DrumsAction.BlueDrum, DrumsAction.GreenDrum };
+        int mp = 0;
+        double finaleTime = finale.Time;
+        double endTime = finaleTime + 2.0;
+        for (double time = 0; time <= endTime; time += 0.02)
+        {
+            if (time >= 0.5 && time < finaleTime)
+            {
+                var gi = GameInput.Create(time, mash[mp++ % mash.Length], 1.0f);
+                engine.QueueInput(ref gi);
+            }
+
+            engine.Update(time);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(codaEnded, Is.True,
+                "OnCodaEnd must fire to bank the BRE bonus (EndCoda -> OnCodaEnd -> AwardCodaBonus)");
+            Assert.That(successAtCodaEnd, Is.True,
+                "an end-tick finale the player cannot see must not forfeit the BRE bonus when missed");
+        }
+    }
+
+    // Shared runner: advances the engine to endTime with NO input. BRE fill gems auto-resolve via
+    // the suppression gate (they are missed at their back-end and converted to a hit while the coda
+    // is active), and the end-tick finale is left unhit — the exact reported scenario (the player
+    // cannot see it). Returns whether OnCodaEnd fired and the CodaSuccess captured at that moment
+    // (read before CurrentCodaIndex advances in EndCoda; CodaSuccess is the faithful proxy for "the
+    // bonus would be banked" since the band-side AwardCodaBonus handler is absent in a headless engine).
+    private static (bool codaEnded, bool? success) RunWithoutHittingFinale(BaseEngine engine, double endTime)
+    {
+        bool codaEnded = false;
+        bool? success = null;
+        engine.OnCodaEnd += _ =>
+        {
+            codaEnded = true;
+            success = engine.CodaSuccess;
+        };
+
+        for (double time = 0; time <= endTime; time += 0.02)
+        {
+            engine.Update(time);
+        }
+
+        return (codaEnded, success);
+    }
+
+    private static void AssertEndTickFinaleBonus(bool codaEnded, bool? success, string instrument)
+    {
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(codaEnded, Is.True,
+                $"{instrument}: OnCodaEnd must fire to bank the BRE bonus (EndCoda -> OnCodaEnd -> AwardCodaBonus)");
+            Assert.That(success, Is.True,
+                $"{instrument}: an end-tick finale the player cannot see must not forfeit the BRE bonus when missed");
+        }
+    }
+
+    // ----- Five-lane keys (true repro: MissNote gate was IsCodaActive) -----
+    private static KeysEngineParameters KeysParams() =>
+        new(new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4, 0, 0, StarMultiplierThresholds, SoloBonusStarMultiplierThresholds, 0.05, 0, false, true);
+
+    private static (YargFiveLaneKeysEngine engine, GuitarNote finale) BuildKeysEndTickFinaleBre()
+    {
+        double TimeOf(uint tick) => tick / (double) RES * 0.5;
+
+        var notes = new List<GuitarNote>();
+        notes.Add(GuitarGem(FiveFretGuitarFret.Green, NoteFlags.None, TimeOf(0), 0));
+
+        var frets = new[] { FiveFretGuitarFret.Green, FiveFretGuitarFret.Red, FiveFretGuitarFret.Yellow, FiveFretGuitarFret.Blue };
+        uint breStart = 480, breEnd = 1440;
+        int p = 0;
+        for (uint t = breStart; t < breEnd; t += 120)
+        {
+            notes.Add(GuitarGem(frets[p++ % frets.Length], NoteFlags.BigRockEnding, TimeOf(t), t));
+        }
+
+        var finale = GuitarGem(FiveFretGuitarFret.Yellow, NoteFlags.BigRockEnding | NoteFlags.CodaEnd, TimeOf(breEnd), breEnd);
+        finale.AddChildNote(GuitarGem(FiveFretGuitarFret.Blue, NoteFlags.BigRockEnding, TimeOf(breEnd), breEnd));
+        notes.Add(finale);
+
+        for (int i = 1; i < notes.Count; i++)
+        {
+            notes[i].PreviousNote = notes[i - 1];
+            notes[i - 1].NextNote = notes[i];
+        }
+
+        var phrases = new List<Phrase>
+        {
+            new(PhraseType.BigRockEnding, TimeOf(breStart), TimeOf(breEnd) - TimeOf(breStart), breStart, breEnd - breStart),
+        };
+
+        var diff = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert, notes, phrases, new());
+
+        var syncTrack = new SyncTrack(RES);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new YargFiveLaneKeysEngine(diff, syncTrack, KeysParams(), isBot: false);
+        return (engine, finale);
+    }
+
+    [Test]
+    public void FiveLaneKeys_EndTickFinalChord_NotHit_StillAwardsBonus()
+    {
+        var (engine, finale) = BuildKeysEndTickFinaleBre();
+        var (codaEnded, success) = RunWithoutHittingFinale(engine, finale.Time + 2.0);
+        AssertEndTickFinaleBonus(codaEnded, success, "Five-lane keys");
+    }
+
+    // ----- Pro keys (true repro: MissNote gate was IsCodaActive) -----
+    private static ProKeysNote ProKeysGem(int key, NoteFlags flags, double time, uint tick) =>
+        new(key, ProKeysNoteFlags.None, flags, time, 0, tick, 0);
+
+    private static (YargProKeysEngine engine, ProKeysNote finale) BuildProKeysEndTickFinaleBre()
+    {
+        double TimeOf(uint tick) => tick / (double) RES * 0.5;
+
+        var notes = new List<ProKeysNote>();
+        notes.Add(ProKeysGem(0, NoteFlags.None, TimeOf(0), 0));
+
+        int[] keys = { 0, 2, 4, 6 };
+        uint breStart = 480, breEnd = 1440;
+        int p = 0;
+        for (uint t = breStart; t < breEnd; t += 120)
+        {
+            notes.Add(ProKeysGem(keys[p++ % keys.Length], NoteFlags.BigRockEnding, TimeOf(t), t));
+        }
+
+        var finale = ProKeysGem(4, NoteFlags.BigRockEnding | NoteFlags.CodaEnd, TimeOf(breEnd), breEnd);
+        finale.AddChildNote(ProKeysGem(6, NoteFlags.BigRockEnding, TimeOf(breEnd), breEnd));
+        notes.Add(finale);
+
+        for (int i = 1; i < notes.Count; i++)
+        {
+            notes[i].PreviousNote = notes[i - 1];
+            notes[i - 1].NextNote = notes[i];
+        }
+
+        var phrases = new List<Phrase>
+        {
+            new(PhraseType.BigRockEnding, TimeOf(breStart), TimeOf(breEnd) - TimeOf(breStart), breStart, breEnd - breStart),
+        };
+
+        var diff = new InstrumentDifficulty<ProKeysNote>(Instrument.ProKeys, Difficulty.Expert, notes, phrases, new());
+
+        var syncTrack = new SyncTrack(RES);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new YargProKeysEngine(diff, syncTrack, KeysParams(), isBot: false);
+        return (engine, finale);
+    }
+
+    [Test]
+    public void ProKeys_EndTickFinalChord_NotHit_StillAwardsBonus()
+    {
+        var (engine, finale) = BuildProKeysEndTickFinaleBre();
+        var (codaEnded, success) = RunWithoutHittingFinale(engine, finale.Time + 2.0);
+        AssertEndTickFinaleBonus(codaEnded, success, "Pro keys");
+    }
+
+    // ----- Five-fret guitar (regression guard) -----
+    // GuitarEngine.MissNote already keyed on CodaHasStarted before this fix, so a guitar miss can't
+    // reproduce the bug. This passes on unmodified code AND after the fix, and exercises the HitNote
+    // gate change (which WAS IsCodaActive on guitar).
+    private static (YargFiveFretGuitarEngine engine, GuitarNote finale) BuildGuitarEndTickFinaleBre()
+    {
+        double TimeOf(uint tick) => tick / (double) GUITAR_RES * 0.5;
+
+        var notes = new List<GuitarNote>();
+        notes.Add(GuitarGem(FiveFretGuitarFret.Green, NoteFlags.None, TimeOf(0), 0));
+
+        var frets = new[] { FiveFretGuitarFret.Green, FiveFretGuitarFret.Red };
+        uint breStart = 480, breEnd = 1440;
+        int p = 0;
+        for (uint t = breStart; t < breEnd; t += 120)
+        {
+            notes.Add(GuitarGem(frets[p++ % frets.Length], NoteFlags.BigRockEnding, TimeOf(t), t));
+        }
+
+        var finale = GuitarGem(FiveFretGuitarFret.Yellow, NoteFlags.BigRockEnding | NoteFlags.CodaEnd, TimeOf(breEnd), breEnd);
+        finale.AddChildNote(GuitarGem(FiveFretGuitarFret.Blue, NoteFlags.BigRockEnding, TimeOf(breEnd), breEnd));
+        notes.Add(finale);
+
+        for (int i = 1; i < notes.Count; i++)
+        {
+            notes[i].PreviousNote = notes[i - 1];
+            notes[i - 1].NextNote = notes[i];
+        }
+
+        var phrases = new List<Phrase>
+        {
+            new(PhraseType.BigRockEnding, TimeOf(breStart), TimeOf(breEnd) - TimeOf(breStart), breStart, breEnd - breStart),
+        };
+
+        var diff = new InstrumentDifficulty<GuitarNote>(Instrument.FiveFretGuitar, Difficulty.Expert, notes, phrases, new());
+
+        var syncTrack = new SyncTrack(GUITAR_RES);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new YargFiveFretGuitarEngine(diff, syncTrack, GuitarParams(), isBot: false);
+        return (engine, finale);
+    }
+
+    [Test]
+    public void Guitar_EndTickFinalChord_NotHit_StillAwardsBonus()
+    {
+        var (engine, finale) = BuildGuitarEndTickFinaleBre();
+        var (codaEnded, success) = RunWithoutHittingFinale(engine, finale.Time + 2.0);
+        AssertEndTickFinaleBonus(codaEnded, success, "Guitar (guard)");
     }
 
     [Test]

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -145,7 +145,11 @@ namespace YARG.Core.Engine.Drums
             // out of order while mashing; without this the skipped gems stay unresolved and
             // NoteIndex strands on an already-hit note, soft-locking the engine for the rest
             // of the song.
-            if (IsCodaActive && note.IsBigRockEnding)
+            // Key on CodaHasStarted, not IsCodaActive: a note is judged at its back-end time,
+            // which can fall after the coda's EndTime (where IsCodaActive is already false) for a
+            // finale charted exactly on the BRE-end tick. Such a note is IsBigRockEnding and is
+            // hidden by the BRE lanes, so it must be suppressed through the whole coda regardless.
+            if (CodaHasStarted && note.IsBigRockEnding)
             {
                 SkipPreviousNotes(note.ParentOrSelf);
                 base.HitNote(note);
@@ -316,10 +320,16 @@ namespace YARG.Core.Engine.Drums
                 return;
             }
 
-            // BRE notes can't be missed
-            if (IsCodaActive && note.IsBigRockEnding)
+            // BRE notes can't be missed during the coda. Key on CodaHasStarted (not IsCodaActive):
+            // the miss is judged at the back-end time, which for an end-tick finale falls after the
+            // coda's EndTime where IsCodaActive is already false — so keying on IsCodaActive would
+            // let the hidden finale be normal-missed and forfeit the BRE bonus.
+            if (CodaHasStarted && note.IsBigRockEnding)
             {
-                note.SetHitState(true, false);
+                // Resolve the whole chord (parent + children), matching GuitarEngine: a BRE
+                // finale is often a chord, and auto-resolving children removes any dependence on
+                // each sub-note being individually missed.
+                note.SetHitState(true, true);
                 base.HitNote(note);
                 return;
             }

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -241,7 +241,10 @@ namespace YARG.Core.Engine.Guitar
             // previous notes skipped by an out-of-order BRE hit (mirror of the drums
             // fix) — otherwise NoteIndex strands on the already-hit note and the engine
             // soft-locks for the rest of the song.
-            if (IsCodaActive && note.IsBigRockEnding)
+            // Key on CodaHasStarted, not IsCodaActive (see DrumsEngine.HitNote): a finale charted
+            // exactly on the BRE-end tick is judged (hit/miss) after the coda's EndTime, where
+            // IsCodaActive is already false.
+            if (CodaHasStarted && note.IsBigRockEnding)
             {
                 SkipPreviousNotes(note);
                 base.HitNote(note);

--- a/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
@@ -62,8 +62,10 @@ namespace YARG.Core.Engine.Keys
 
             KeyPressTimes[(int)note.FiveLaneKeysAction] = DEFAULT_PRESS_TIME;
 
-            // Cancel rest of hit logic during BRE phrase
-            if (IsCodaActive && note.IsBigRockEnding)
+            // Cancel rest of hit logic during BRE phrase. Key on CodaHasStarted, not IsCodaActive
+            // (see DrumsEngine.HitNote): an end-tick finale is judged after the coda's EndTime,
+            // where IsCodaActive is already false.
+            if (CodaHasStarted && note.IsBigRockEnding)
             {
                 base.HitNote(note);
                 return;
@@ -130,10 +132,13 @@ namespace YARG.Core.Engine.Keys
 
             KeyPressTimes[(int)note.FiveLaneKeysAction] = DEFAULT_PRESS_TIME;
 
-            // Can't miss a note during BRE phrase
-            if (IsCodaActive && note.IsBigRockEnding)
+            // Can't miss a note during the coda. Key on CodaHasStarted, not IsCodaActive (see
+            // DrumsEngine.MissNote): the miss is judged at the back-end time, which for an
+            // end-tick finale falls after the coda's EndTime where IsCodaActive is already false.
+            if (CodaHasStarted && note.IsBigRockEnding)
             {
-                note.SetHitState(true, false);
+                // Resolve the whole chord, matching GuitarEngine (see DrumsEngine.MissNote).
+                note.SetHitState(true, true);
                 base.HitNote(note);
                 return;
             }

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -87,8 +87,10 @@ namespace YARG.Core.Engine.Keys
 
             KeyPressTimes[note.Key] = DEFAULT_PRESS_TIME;
 
-            // Cancel rest of hit logic during BRE phrase
-            if (IsCodaActive && note.IsBigRockEnding)
+            // Cancel rest of hit logic during BRE phrase. Key on CodaHasStarted, not IsCodaActive
+            // (see DrumsEngine.HitNote): an end-tick finale is judged after the coda's EndTime,
+            // where IsCodaActive is already false.
+            if (CodaHasStarted && note.IsBigRockEnding)
             {
                 // Be sure to disable the stagger timer so it doesn't run long
                 ChordStaggerTimer.Disable(CurrentTime, early: true);
@@ -180,10 +182,13 @@ namespace YARG.Core.Engine.Keys
 
             KeyPressTimes[note.Key] = DEFAULT_PRESS_TIME;
 
-            // Can't miss a note during BRE phrase
-            if (IsCodaActive && note.IsBigRockEnding)
+            // Can't miss a note during the coda. Key on CodaHasStarted, not IsCodaActive (see
+            // DrumsEngine.MissNote): the miss is judged at the back-end time, which for an
+            // end-tick finale falls after the coda's EndTime where IsCodaActive is already false.
+            if (CodaHasStarted && note.IsBigRockEnding)
             {
-                note.SetHitState(true, false);
+                // Resolve the whole chord, matching GuitarEngine (see DrumsEngine.MissNote).
+                note.SetHitState(true, true);
                 base.HitNote(note);
                 return;
             }


### PR DESCRIPTION
## Summary

Ties the BRE-note suppression gates to `CodaHasStarted` instead of `IsCodaActive` across all four engines: `DrumsEngine`, `FiveLaneKeysEngine`, `ProKeysEngine` (`HitNote` + `MissNote`) and `GuitarEngine.HitNote`, matching what `GuitarEngine.MissNote` already does (`9b8802fa4`). Also normalizes the drums/keys miss branches to `SetHitState(true, true)`.

## Why

A note charted exactly on the BRE-end tick is `IsBigRockEnding` and hidden under the BRE lanes, so it must be auto-suppressed (freestyle) so the bonus triggers regardless of whether or not it's hit. Instead it's treated as a normal must-hit note: missing it forfeits the BRE bonus, and hitting it (judged after `EndTime`) potentially drives `NotesMissed` **negative** on a full combo, because `TotalNotes` excludes BRE notes but the normal hit path still increments `NotesHit`.

`060ed95a` (`time >= EndTime` → `time > EndTime`) addresses the *hit-path* edge at the `EndTime` boundary, but the *miss path* is judged at the finale's back-end (`note.Time + backEnd`), strictly after `EndTime`, where `IsCodaActive` is false under either operator. So on current `master` the missed finale still falls through and the bug persists (in-game: `NotesMissed` goes to -2, bonus lost unless the invisible notes are hit).

## Root cause (short)

`IsCodaActive` deactivates at `EndTime`; a note is judged at its back-end (after `EndTime`) so the `IsCodaActive && note.IsBigRockEnding` is no longer true. `GuitarEngine.MissNote` uses `CodaHasStarted` (`9b8802fa4`) so it didn't trigger this problem.

## Fix / Design

Change the gates to `CodaHasStarted && note.IsBigRockEnding` (what `GuitarEngine` uses). `CodaHasStarted` stays true until `EndCoda()` fires (when the finale resolves), so it covers the finale's whole judgment window. The change leaves `IsCodaActive` (and its window) untouched. It still governs fret/key freestyle input, overhit logic, etc.

## Changes

| File | Change |
|------|--------|
| `YARG.Core/Engine/Drums/DrumsEngine.cs` | `HitNote`+`MissNote` gates → `CodaHasStarted`; miss branch `SetHitState(true, true)` |
| `YARG.Core/Engine/Guitar/GuitarEngine.cs` | `HitNote` gate → `CodaHasStarted` (`MissNote` already correct) |
| `YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs` | `HitNote`+`MissNote` gates → `CodaHasStarted`; miss branch `SetHitState(true, true)` |
| `YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs` | `HitNote`+`MissNote` gates → `CodaHasStarted`; miss branch `SetHitState(true, true)` |
| `YARG.Core.UnitTests/Engine/BreSoftlockTests.cs` | +4 `EndTickFinalChord` tests: drums/five-lane-keys/pro-keys repros + a guitar regression guard, sharing a `RunWithoutHittingFinale` helper |

## Testing done

- **Unit (GREEN):** `dotnet test YARG.Core.UnitTests` → **419 passed, 2 skipped** (`FullScan`/`QuickScan`), 0 failed.
- **RED/GREEN (run against `060ed95a`):** before the fix, the 4 `EndTickFinalChord` tests report **Failed: 3, Passed: 1** (drums / five-lane-keys / pro-keys fail, `CodaSuccess = false`); guitar passes (its `MissNote` was already `CodaHasStarted`). After the fix, all 4 pass.
- **In-game (2026-06-21):** `dirtydeeds_live`, FourLane Expert, BRE phrase `288000..296160`, finale `[Yellow+Blue]` at tick `296160`. On base `master`: missing the hidden finale forfeits the bonus and drives `NotesMissed` to -2. After fix, BRE finale works as expected.

## Notes

- **Builds on `060ed95a`** (wyrdough's `IsCodaActive` inclusive-end change). The two coexist; the `CodaHasStarted` gate is the load-bearing part for the miss path. If preferred, `060ed95a`'s one-line change could be reverted, but leaving it is harmless.
- The 7 gate sites are the complete set (`grep "IsCodaActive && note.IsBigRockEnding"` returns nothing after this PR); no `Yarg*` subclass re-gates differently.
