### PR TITLE
Fix unison event creation when SP phrases are not identically timed

### DIFF
--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -381,6 +381,9 @@ namespace YARG.Core.Engine
                     }
                 }
 
+                double maxEndTime = benchmark.TimeEnd;
+                uint maxEndTick = benchmark.TickEnd;
+
                 // Find all phrases in the group that end at roughly the same time as the benchmark
                 finalParticipants.Clear();
                 foreach (var participant in potentialGroup)
@@ -388,13 +391,17 @@ namespace YARG.Core.Engine
                     if (participant.EndTickAlmostEquals(benchmark, tickTolerance))
                     {
                         finalParticipants.Add(participant);
+                        maxEndTick = Math.Max(maxEndTick, participant.TickEnd);
+                        maxEndTime = Math.Max(maxEndTime, participant.TimeEnd);
                     }
                 }
 
                 // If we still have at least two, it's a valid unison.
                 if (finalParticipants.Count >= 2)
                 {
-                    phrases.Add(sourceSection.PhraseRef);
+                    // We create a new phrase with the largest boundaries possible to ensure
+                    // unison phrase times are consistent across all instruments.
+                    phrases.Add(new Phrase(PhraseType.StarPower, benchmark.Time, maxEndTime - benchmark.Time, benchmark.Tick, maxEndTick - benchmark.Tick));
                 }
             }
 


### PR DESCRIPTION
This is the same issue as 7fae52e59d67d8bbee25d9e0f6dc83887a60dc92. That fixed the actual creation of the unison phrases, by checking if the ticks were close enough - however, when creating the master unison events list, this causes an issue. Each instrument's unison phrases list is identical to their list of SP phrases, with non-unisons removed. However, when adding a player to the master unison events list, it only considers events identical if they start and end at the same time, not considering tolerance. This leads to these nearly-correct unison phrases becoming duplicates only containing a subset of the instruments.

My fix here is to keep track of the earliest and latest time and tick end, and use those to create a new phrase for the unisons list, ensuring the start and end should be identical across instruments. This means it does not correspond exactly to an SP phrase, however this doesn't appear to be an issue as EngineManager only cares about whether OnStarPowerHit falls within the unison phrase to count as a success.

Another solution I considered was using the same tick comparison to determine whether two unison phrases were identical. The reason I didn't use this is that it would require a unison event to also store the tick tolerance in order to do the comparison, as it is sourced from the chart's resolution. 

Demo of the issue:

https://github.com/user-attachments/assets/767aec9f-7c88-42dd-9660-9471f95a78bb


