### PR TITLE
Unison Display (core)

### DIFF
--- a/YARG.Core.UnitTests/Engine/EngineManagerTester.cs
+++ b/YARG.Core.UnitTests/Engine/EngineManagerTester.cs
@@ -44,10 +44,10 @@ public class EngineManagerTester : EngineTester
     [Test]
     public void EngineManagerGeneratesUnisonPhrases()
     {
-        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, GetChart());
-        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, GetChart());
-        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, GetChart());
-        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, GetChart());
+        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, Difficulty.Expert, GetChart(), false);
+        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, Difficulty.Expert, GetChart(), true);
+        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, Difficulty.Expert, GetChart(), false);
+        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, Difficulty.Expert, GetChart(), false);
 
         using (Assert.EnterMultipleScope())
         {
@@ -61,17 +61,96 @@ public class EngineManagerTester : EngineTester
     [Test]
     public void EngineManagerGeneratesEqualUnisonPhrases()
     {
-        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, GetChart());
-        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, GetChart());
-        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, GetChart());
-        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, GetChart());
+        var tolerance = (GetChart().Resolution / 4) - 1; // 16th note tolerance
+        Func<EngineManager.UnisonPhrase, EngineManager.UnisonPhrase, bool> comparer = (a, b) => EngineManager.TickWithinTolerance(a.Tick, b.Tick, tolerance) && EngineManager.TickWithinTolerance(a.TickEnd, b.TickEnd, tolerance);
+        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, Difficulty.Expert, GetChart(), false);
+        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, Difficulty.Expert, GetChart(), false);
+        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, Difficulty.Expert, GetChart(), true);
+        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, Difficulty.Expert, GetChart(), false);
 
         using (Assert.EnterMultipleScope())
         {
-            Assert.That(guitarPhrases, Is.EqualTo(bassPhrases).UsingPropertiesComparer());
-            Assert.That(guitarPhrases, Is.EqualTo(drumsPhrases).UsingPropertiesComparer());
+            Assert.That(guitarPhrases, Is.EqualTo(bassPhrases).Using<EngineManager.UnisonPhrase, EngineManager.UnisonPhrase>(comparer));
+            Assert.That(guitarPhrases, Is.EqualTo(drumsPhrases).Using<EngineManager.UnisonPhrase, EngineManager.UnisonPhrase>(comparer));
             // Keys does not participate in all unisons in the test chart
-            Assert.That(guitarPhrases, Is.SupersetOf(keysPhrases).UsingPropertiesComparer());
+            Assert.That(guitarPhrases, Is.SupersetOf(keysPhrases).Using(comparer));
+        }
+    }
+
+    [Test]
+    public void EngineManagerUnisonPhraseNoteCountIsCorrect()
+    {
+        var chart = GetChart();
+        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, Difficulty.Expert, GetChart(), false);
+        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, Difficulty.Expert, GetChart(), false);
+        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, Difficulty.Expert, GetChart(), true);
+        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, Difficulty.Expert, GetChart(), false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            foreach (var phrase in guitarPhrases)
+            {
+                var notes = chart.GetFiveFretTrack(Instrument.FiveFretGuitar).GetDifficulty(Difficulty.Expert).Notes;
+                var noteCount = notes.Count(n => n.Tick >= phrase.Tick && n.Tick < phrase.TickEnd);
+                Assert.That(phrase.NoteCount, Is.EqualTo(noteCount));
+            }
+            foreach (var phrase in bassPhrases)
+            {
+                var notes = chart.GetFiveFretTrack(Instrument.FiveFretBass).GetDifficulty(Difficulty.Expert).Notes;
+                var noteCount = notes.Count(n => n.Tick >= phrase.Tick && n.Tick < phrase.TickEnd);
+                Assert.That(phrase.NoteCount, Is.EqualTo(noteCount));
+            }
+            foreach (var phrase in drumsPhrases)
+            {
+                var notes = chart.GetDrumsTrack(Instrument.FourLaneDrums).GetDifficulty(Difficulty.Expert).Notes;
+                var noteCount = notes.Sum(n => (n.Tick >= phrase.Tick && n.Tick < phrase.TickEnd) ? n.ChildNotes.Count + 1 : 0);
+                Assert.That(phrase.NoteCount, Is.EqualTo(noteCount));
+            }
+
+            foreach (var phrase in keysPhrases)
+            {
+                // For some reason, chart.GetProKeysTrack doesn't exist?
+                var notes = CreateEngine(_keysEngineParams, true).Notes.Notes;
+                var noteCount = notes.Count(n => n.Tick >= phrase.Tick && n.Tick < phrase.TickEnd);
+                Assert.That(phrase.NoteCount, Is.EqualTo(noteCount));
+            }
+        }
+    }
+
+    [Test]
+    public void EngineManagerAddsUnisonPhrasesToGlobalListCorrectly()
+    {
+        var engineManager = new EngineManager();
+        var chart = GetChart();
+
+        var guitarEngineContainer = engineManager.Register(CreateEngine(_guitarEngineParams, true, false).Engine, Instrument.FiveFretGuitar, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var bassEngineContainer = engineManager.Register(CreateEngine(_bassEngineParams, true, true).Engine, Instrument.FiveFretBass, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var drumsEngineContainer = engineManager.Register(CreateEngine(_drumsEngineParams, true).Engine, Instrument.FourLaneDrums, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var keysEngineContainer = engineManager.Register(CreateEngine(_keysEngineParams, true).Engine, Instrument.ProKeys, Difficulty.Expert, chart, RockMeterPreset.Normal);
+
+        var globalUnisonEvents = engineManager.UnisonEvents;
+        using (Assert.EnterMultipleScope())
+        {
+            // Check that every unison phrase is accounted for here
+            foreach (var phrase in guitarEngineContainer.UnisonPhrases)
+            {
+                // Exactly one global unison event should have this phrase in its ParticipantsToPhrase list
+                Assert.That(globalUnisonEvents.Count(e => e.ParticipantToPhrase.TryGetValue(guitarEngineContainer.EngineId, out var foundPhrase) && foundPhrase == phrase), Is.EqualTo(1));
+            }
+            foreach (var phrase in bassEngineContainer.UnisonPhrases)
+            {
+                Assert.That(globalUnisonEvents.Count(e => e.ParticipantToPhrase.TryGetValue(bassEngineContainer.EngineId, out var foundPhrase) && foundPhrase == phrase), Is.EqualTo(1));
+            }
+
+            foreach (var phrase in drumsEngineContainer.UnisonPhrases)
+            {
+                Assert.That(globalUnisonEvents.Count(e => e.ParticipantToPhrase.TryGetValue(drumsEngineContainer.EngineId, out var foundPhrase) && foundPhrase == phrase), Is.EqualTo(1));
+            }
+
+            foreach (var phrase in keysEngineContainer.UnisonPhrases)
+            {
+                Assert.That(globalUnisonEvents.Count(e => e.ParticipantToPhrase.TryGetValue(keysEngineContainer.EngineId, out var foundPhrase) && foundPhrase == phrase), Is.EqualTo(1));
+            }
         }
     }
 
@@ -134,10 +213,10 @@ public class EngineManagerTester : EngineTester
         var drumsEngine = CreateEngine(_drumsEngineParams, true);
         var keysEngine = CreateEngine(_keysEngineParams, true);
 
-        var guitarContainer = manager.Register(guitarEngine.Engine, Instrument.FiveFretGuitar, chart, RockMeterPreset.Normal);
-        var bassContainer = manager.Register(bassEngine.Engine, Instrument.FiveFretBass, chart, RockMeterPreset.Normal);
-        var drumsContainer = manager.Register(drumsEngine.Engine, Instrument.FourLaneDrums, chart, RockMeterPreset.Normal);
-        var keysContainer = manager.Register(keysEngine.Engine, Instrument.ProKeys, chart, RockMeterPreset.Normal);
+        var guitarContainer = manager.Register(guitarEngine.Engine, Instrument.FiveFretGuitar, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var bassContainer = manager.Register(bassEngine.Engine, Instrument.FiveFretBass, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var drumsContainer = manager.Register(drumsEngine.Engine, Instrument.FourLaneDrums, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var keysContainer = manager.Register(keysEngine.Engine, Instrument.ProKeys, Difficulty.Expert, chart, RockMeterPreset.Normal);
 
         return (manager, [guitarContainer, bassContainer, drumsContainer, keysContainer]);
     }

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -88,6 +88,8 @@ namespace YARG.Core.Engine
 
         private List<UnisonEvent> _unisonEvents = new();
 
+        public IReadOnlyList<UnisonEvent> UnisonEvents => _unisonEvents.AsReadOnly();
+
         public struct StarPowerSection : IEquatable<StarPowerSection>
         {
             public double Time;
@@ -383,18 +385,26 @@ namespace YARG.Core.Engine
 
                 // Find all phrases in the group that end at roughly the same time as the benchmark
                 finalParticipants.Clear();
+                double maxEndTime = benchmark.TimeEnd;
+                uint maxEndTick = benchmark.TickEnd;
                 foreach (var participant in potentialGroup)
                 {
                     if (participant.EndTickAlmostEquals(benchmark, tickTolerance))
                     {
                         finalParticipants.Add(participant);
+                        // Do this instead of Math.Max to ensure the time and tick are consistent with each other
+                        if (participant.TickEnd > maxEndTick)
+                        {
+                            maxEndTime = participant.TimeEnd;
+                            maxEndTick = participant.TickEnd;
+                        }
                     }
                 }
 
                 // If we still have at least two, it's a valid unison.
                 if (finalParticipants.Count >= 2)
                 {
-                    phrases.Add(sourceSection.PhraseRef);
+                    phrases.Add(new Phrase(PhraseType.StarPower, benchmark.Time, maxEndTime - benchmark.Time, benchmark.Tick, maxEndTick - benchmark.Tick));
                 }
             }
 
@@ -452,6 +462,7 @@ namespace YARG.Core.Engine
                 engineContainer.SendCommand(EngineCommandType.AwardUnisonBonus);
             }
             unison.Awarded = true;
+            OnUnisonPhraseSuccess?.Invoke();
         }
     }
 }

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -12,47 +12,43 @@ namespace YARG.Core.Engine
 {
     public partial class EngineManager
     {
-        public class UnisonEvent : IEquatable<UnisonEvent>
+        public class UnisonEvent
         {
-            public double    Time           { get; }
-            public double    TimeEnd        { get; }
-            public int       PartCount      { get; private set; }
-            public int       SuccessCount   { get; private set; }
-            public bool      Awarded        { get; set; }
-            public List<int> ParticipantIds { get; }
+            public double                        Time                { get; }
+            public double                        TimeEnd             { get; }
+            public uint                          Tick                { get; }
+            public uint                          TickEnd             { get; }
+            public int                           PartCount           { get; private set; }
+            public int                           SuccessCount        { get; private set; }
+            public bool                          Awarded             { get; set; }
+            public Dictionary<int, UnisonPhrase> ParticipantToPhrase { get; }
 
-            public bool Equals(UnisonEvent other) => Time.Equals(other.Time) && TimeEnd.Equals(other.TimeEnd);
-
-            // public bool Equals(double startTime, double endTime) => Time.Equals(startTime) && TimeEnd.Equals(endTime);
-            // public override bool Equals(object obj) => Equals(obj as UnisonEvent);
-            public override int GetHashCode() => HashCode.Combine(Time, TimeEnd);
-
-            public UnisonEvent(double time, double timeEnd)
+            public UnisonEvent(double time, double timeEnd, uint tick, uint tickEnd)
             {
                 Time = time;
                 TimeEnd = timeEnd;
+                Tick = tick;
+                TickEnd = tickEnd;
                 PartCount = 0;
                 SuccessCount = 0;
                 Awarded = false;
-                ParticipantIds = new List<int>();
+                ParticipantToPhrase = new Dictionary<int, UnisonPhrase>();
             }
 
-            public void AddPlayer(EngineContainer engineContainer)
+            public void AddPlayer(EngineContainer engineContainer, UnisonPhrase sourcePhrase)
             {
-                if (ParticipantIds.Contains(engineContainer.EngineId))
+                if (!ParticipantToPhrase.TryAdd(engineContainer.EngineId, sourcePhrase))
                 {
                     return;
                 }
 
-                ParticipantIds.Add(engineContainer.EngineId);
                 PartCount++;
             }
 
             public void RemovePlayer(EngineContainer engineContainer)
             {
-                if (ParticipantIds.Contains(engineContainer.EngineId))
+                if (ParticipantToPhrase.Remove(engineContainer.EngineId))
                 {
-                    ParticipantIds.Remove(engineContainer.EngineId);
                     PartCount--;
                 }
             }
@@ -60,14 +56,14 @@ namespace YARG.Core.Engine
             // Returns true if all players succesfully completed the unison
             public bool Success(EngineContainer engineContainer)
             {
-                if (ParticipantIds.Contains(engineContainer.EngineId))
+                if (ParticipantToPhrase.ContainsKey(engineContainer.EngineId))
                 {
                     YargLogger.LogFormatDebug("Player {0} successfully completed unison ending at time {1}",
                         engineContainer.EngineId, TimeEnd);
                     SuccessCount++;
                 }
 
-                if (SuccessCount == ParticipantIds.Count)
+                if (SuccessCount == ParticipantToPhrase.Count)
                 {
                     YargLogger.LogFormatDebug("Unison phrase ending at time {0} successfully completed by all participants",
                         TimeEnd);
@@ -75,7 +71,7 @@ namespace YARG.Core.Engine
                 }
 
                 // If SuccessCount is ever greater than the number of players, something has gone seriously wrong
-                YargLogger.Assert(SuccessCount <= ParticipantIds.Count, "SuccessCount mismanagement detected");
+                YargLogger.Assert(SuccessCount <= ParticipantToPhrase.Count, "SuccessCount mismanagement detected");
                 return false;
             }
 
@@ -86,7 +82,21 @@ namespace YARG.Core.Engine
             }
         }
 
-        private List<UnisonEvent> _unisonEvents = new();
+        public class UnisonPhrase : Phrase
+        {
+            public int NoteCount { get; }
+            public UnisonPhrase(double time, double timeLength, uint tick, uint tickLength, int noteCount) : base(PhraseType.StarPower, time, timeLength, tick, tickLength)
+            {
+                NoteCount = noteCount;
+            }
+
+            public UnisonPhrase(Phrase other, int noteCount) : base(PhraseType.StarPower, other.Time, other.TimeLength, other.Tick, other.TickLength)
+            {
+                NoteCount = noteCount;
+            }
+        }
+
+        private readonly List<UnisonEvent> _unisonEvents = new();
 
         public IReadOnlyList<UnisonEvent> UnisonEvents => _unisonEvents.AsReadOnly();
 
@@ -133,18 +143,13 @@ namespace YARG.Core.Engine
             /// <returns></returns>
             public bool TickAlmostEquals(StarPowerSection other, uint tolerance)
             {
-                return StartTickAlmostEquals(other, tolerance) && EndTickAlmostEquals(other, tolerance);
+                return TickWithinTolerance(Tick, other.Tick, tolerance) && TickWithinTolerance(TickEnd, other.TickEnd, tolerance);
             }
+        }
 
-            public bool StartTickAlmostEquals(StarPowerSection other, uint tolerance)
-            {
-                return Tick - other.Tick <= tolerance || other.Tick - Tick <= tolerance;
-            }
-
-            public bool EndTickAlmostEquals(StarPowerSection other, uint tolerance)
-            {
-                return TickEnd - other.TickEnd <= tolerance || other.TickEnd - TickEnd <= tolerance;
-            }
+        public static bool TickWithinTolerance(uint t1, uint t2, uint tolerance)
+        {
+            return t1 - t2 <= tolerance || t2 - t1 <= tolerance;
         }
 
         public delegate void UnisonPhrasesReadyEvent(List<UnisonEvent> unisonEvents);
@@ -162,30 +167,45 @@ namespace YARG.Core.Engine
             new List<Instrument> { Instrument.Keys, Instrument.ProKeys }
         };
 
-        private void AddPlayerToUnisons(EngineContainer engineContainer)
+        private void AddPlayerToUnisons(EngineContainer engineContainer, SongChart chart)
         {
             // Vocals don't participate in unisons, so don't add them to the list
             if (engineContainer.Engine is BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats>)
             {
                 return;
             }
-
+            bool noEvents = _unisonEvents.Count == 0;
             foreach (var phrase in engineContainer.UnisonPhrases)
             {
-                var unisonEvent = new UnisonEvent(phrase.Time, phrase.TimeEnd);
-                if (!_unisonEvents.Contains(unisonEvent))
+                var tolerance = (chart.Resolution / 4) - 1; // 16th note minus one tick
+                if (!noEvents) // No reason for the first player to be added to loop at all.
                 {
-                    _unisonEvents.Add(unisonEvent);
-                    unisonEvent.AddPlayer(engineContainer);
-                }
-                else
-                {
-                    var idx = _unisonEvents.IndexOf(unisonEvent);
-                    if (idx != -1)
+                    bool found = false;
+                    foreach (var ev in _unisonEvents)
                     {
-                        _unisonEvents[idx].AddPlayer(engineContainer);
+                        // If a phrase is within the tolerance of the event's start and end tick...
+                        if (!TickWithinTolerance(phrase.Tick, ev.Tick, tolerance) ||
+                            !TickWithinTolerance(phrase.TickEnd, ev.TickEnd, tolerance))
+                        {
+                            continue;
+                        }
+
+                        // Add it to the event.
+                        ev.AddPlayer(engineContainer, phrase);
+                        found = true;
+                        break;
+                    }
+
+                    if (found)
+                    {
+                        continue;
                     }
                 }
+
+                // No matching event has been found, so create a new one.
+                var unisonEvent = new UnisonEvent(phrase.Time, phrase.TimeEnd, phrase.Tick, phrase.TickEnd);
+                _unisonEvents.Add(unisonEvent);
+                unisonEvent.AddPlayer(engineContainer, phrase);
             }
             // Subscribe the container to OnStarPowerPhraseHit so bonuses can be awarded as appropriate
             if (engineContainer.Engine is BaseEngine<GuitarNote,GuitarEngineParameters,GuitarStats> guitarEngine)
@@ -246,13 +266,99 @@ namespace YARG.Core.Engine
         /// <summary>
         /// Builds unison phrases for a combination of instrument and chart
         /// </summary>
-        /// <param name="instrument">YARG.Core.Instrument</param>
-        /// <param name="chart">YARG.Core.Chart.SongChart</param>
-        /// <returns>List of Phrase objects with Type == PhraseType.StarPower
+        /// <param name="instrument"><see cref="Instrument"/></param>
+        /// <param name="difficulty"><see cref="Difficulty"/></param>
+        /// <param name="chart"><see cref="SongChart"/></param>
+        /// <param name="includeChildNotesInNoteCount">Used to determine how to calculate note count in the phrase.</param>
+        /// <returns>List of UnisonPhrase objects.
         /// <br />These Phrases have corresponding StarPower Phrases in other tracks,
         /// <br />which is what makes them unison phrases.
         /// </returns>
-        public static List<Phrase> GetUnisonPhrases(Instrument instrument, SongChart chart)
+        public static List<UnisonPhrase> GetUnisonPhrases(Instrument instrument, Difficulty difficulty, SongChart chart, bool includeChildNotesInNoteCount)
+        {
+
+            // Find a track that corresponds to the player's instrument
+            if (TryFindTrackForInstrument(instrument, chart.FiveFretTracks, out var fiveFretTrack))
+            {
+                if (fiveFretTrack.TryGetDifficulty(difficulty, out var track))
+                {
+                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
+                }
+            }
+
+            if (TryFindTrackForInstrument(instrument, chart.DrumsTracks, out var drumsTrack))
+            {
+                if (drumsTrack.TryGetDifficulty(difficulty, out var track))
+                {
+                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
+                }
+            }
+
+            if (TryFindTrackForInstrument(instrument, chart.SixFretTracks, out var sixFretTrack))
+            {
+                if (sixFretTrack.TryGetDifficulty(difficulty, out var track))
+                {
+                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
+                }
+            }
+
+            if (TryFindTrackForInstrument(instrument, chart.ProGuitarTracks, out var proGuitarTrack))
+            {
+                if (proGuitarTrack.TryGetDifficulty(difficulty, out var track))
+                {
+                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
+                }
+            }
+
+            if (chart.ProKeys.Instrument == instrument)
+            {
+                if (chart.ProKeys.TryGetDifficulty(difficulty, out var track))
+                {
+                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
+                }
+            }
+
+            if (chart.Keys.Instrument == instrument)
+            {
+                if (chart.Keys.TryGetDifficulty(difficulty, out var track))
+                {
+                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
+                }
+            }
+
+
+            YargLogger.LogFormatError("Could not find any instrument difficulty for {0}", instrument);
+            return new List<UnisonPhrase>();
+
+            // Get the track for a given instrument, if it exists
+            static bool TryFindTrackForInstrument<TNote>(Instrument instrument,
+                IEnumerable<InstrumentTrack<TNote>> trackEnumerable, out InstrumentTrack<TNote> instrumentTrack) where TNote : Note<TNote>
+            {
+                foreach (var track in trackEnumerable)
+                {
+                    if (track.Instrument == instrument)
+                    {
+                        instrumentTrack = track;
+                        return true;
+                    }
+                }
+
+                instrumentTrack = null!;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Builds unison phrases for a combination of instrument and chart
+        /// </summary>
+        /// <param name="instrumentDifficulty"><see cref="InstrumentDifficulty{TNote}"/></param>
+        /// <param name="chart"><see cref="SongChart"/></param>
+        /// <param name="includeChildNotesInNoteCount">Used to determine how to calculate note count in the phrase.</param>
+        /// <returns>List of UnisonPhrase objects.
+        /// <br />These Phrases have corresponding StarPower Phrases in other tracks,
+        /// <br />which is what makes them unison phrases.
+        /// </returns>
+        public static List<UnisonPhrase> GetUnisonPhrases<TNoteType>(InstrumentDifficulty<TNoteType> instrumentDifficulty, SongChart chart, bool includeChildNotesInNoteCount) where TNoteType : Note<TNoteType>
         {
             // Unisons must have at least 2 participants.
 
@@ -260,83 +366,21 @@ namespace YARG.Core.Engine
             var tickTolerance = (chart.Resolution / 4) - 1;
 
             // Since vocals can't have unisons, we may as well pull the ripcord early
-            if (instrument is Instrument.Vocals or Instrument.Harmony)
+            if (instrumentDifficulty.Instrument is Instrument.Vocals or Instrument.Harmony)
             {
-                return new List<Phrase>();
+                return new List<UnisonPhrase>();
             }
 
-            var sourceSpSections = new List<StarPowerSection>();
-            var foundSelf = false;
-
-            // Find a track that corresponds to the player's instrument
-            if (TryFindTrackForInstrument(instrument, chart.FiveFretTracks, out var fiveFretTrack))
-            {
-                if (fiveFretTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
-                {
-                    sourceSpSections = difficulty!.GetStarpowerSections();
-                    foundSelf = true;
-                }
-            }
-
-            if (!foundSelf && TryFindTrackForInstrument(instrument, chart.DrumsTracks, out var drumsTrack))
-            {
-                if (drumsTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
-                {
-                    sourceSpSections = difficulty!.GetStarpowerSections();
-                    foundSelf = true;
-                }
-            }
-
-            if (!foundSelf && TryFindTrackForInstrument(instrument, chart.SixFretTracks, out var sixFretTrack))
-            {
-                if (sixFretTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
-                {
-                    sourceSpSections = difficulty!.GetStarpowerSections();
-                    foundSelf = true;
-                }
-            }
-
-            if (!foundSelf && TryFindTrackForInstrument(instrument, chart.ProGuitarTracks, out var proGuitarTrack))
-            {
-                if (proGuitarTrack.TryGetAnyInstrumentDifficulty(out var difficulty))
-                {
-                    sourceSpSections = difficulty!.GetStarpowerSections();
-                    foundSelf = true;
-                }
-            }
-
-            if (!foundSelf && chart.ProKeys.Instrument == instrument)
-            {
-                if (chart.ProKeys.TryGetAnyInstrumentDifficulty(out var difficulty))
-                {
-                    sourceSpSections = difficulty!.GetStarpowerSections();
-                    foundSelf = true;
-                }
-            }
-
-            if (!foundSelf && chart.Keys.Instrument == instrument)
-            {
-                if (chart.Keys.TryGetAnyInstrumentDifficulty(out var difficulty))
-                {
-                    sourceSpSections = difficulty!.GetStarpowerSections();
-                    foundSelf = true;
-                }
-            }
-
-            if (!foundSelf)
-            {
-                YargLogger.LogFormatError("Could not find any instrument difficulty for {0}", instrument);
-                return new List<Phrase>();
-            }
+            var sourceSpSections = instrumentDifficulty.GetStarpowerSections();
 
             // Add ourselves to the beginning of the accepted list so any dupes with us will be filtered
             var acceptedSpSections = new List<List<StarPowerSection>> { sourceSpSections };
 
-            chart.FiveFretTracks.GetStarpowerSections(ref acceptedSpSections, instrument, tickTolerance);
-            chart.SixFretTracks.GetStarpowerSections(ref acceptedSpSections, instrument, tickTolerance);
-            chart.DrumsTracks.GetStarpowerSections(ref acceptedSpSections, instrument, tickTolerance);
-            chart.ProKeys.GetStarpowerSections(ref acceptedSpSections, instrument, tickTolerance);
-            chart.Keys.GetStarpowerSections(ref acceptedSpSections, instrument, tickTolerance);
+            chart.FiveFretTracks.GetStarpowerSections(ref acceptedSpSections, instrumentDifficulty.Instrument, tickTolerance);
+            chart.SixFretTracks.GetStarpowerSections(ref acceptedSpSections, instrumentDifficulty.Instrument, tickTolerance);
+            chart.DrumsTracks.GetStarpowerSections(ref acceptedSpSections, instrumentDifficulty.Instrument, tickTolerance);
+            chart.ProKeys.GetStarpowerSections(ref acceptedSpSections, instrumentDifficulty.Instrument, tickTolerance);
+            chart.Keys.GetStarpowerSections(ref acceptedSpSections, instrumentDifficulty.Instrument, tickTolerance);
 
             // Now we delete self from the accepted list to ensure we don't match against self
             acceptedSpSections.Remove(sourceSpSections);
@@ -348,7 +392,7 @@ namespace YARG.Core.Engine
                 othersSpSections.AddRange(sectionList);
             }
 
-            var phrases = new List<Phrase>();
+            var phrases = new List<UnisonPhrase>();
             var potentialGroup = new List<StarPowerSection>();
             var finalParticipants = new List<StarPowerSection>();
 
@@ -361,7 +405,7 @@ namespace YARG.Core.Engine
 
                 foreach (var otherSection in othersSpSections)
                 {
-                    if (sourceSection.StartTickAlmostEquals(otherSection, tickTolerance))
+                    if (TickWithinTolerance(sourceSection.Tick, otherSection.Tick, tickTolerance))
                     {
                         potentialGroup.Add(otherSection);
                     }
@@ -385,47 +429,35 @@ namespace YARG.Core.Engine
 
                 // Find all phrases in the group that end at roughly the same time as the benchmark
                 finalParticipants.Clear();
-                double maxEndTime = benchmark.TimeEnd;
-                uint maxEndTick = benchmark.TickEnd;
                 foreach (var participant in potentialGroup)
                 {
-                    if (participant.EndTickAlmostEquals(benchmark, tickTolerance))
+                    if (TickWithinTolerance(participant.TickEnd, benchmark.TickEnd, tickTolerance))
                     {
                         finalParticipants.Add(participant);
-                        // Do this instead of Math.Max to ensure the time and tick are consistent with each other
-                        if (participant.TickEnd > maxEndTick)
-                        {
-                            maxEndTime = participant.TimeEnd;
-                            maxEndTick = participant.TickEnd;
-                        }
                     }
                 }
 
                 // If we still have at least two, it's a valid unison.
                 if (finalParticipants.Count >= 2)
                 {
-                    phrases.Add(new Phrase(PhraseType.StarPower, benchmark.Time, maxEndTime - benchmark.Time, benchmark.Tick, maxEndTick - benchmark.Tick));
+                    var count = 0;
+                    foreach (var note in instrumentDifficulty.Notes)
+                    {
+                        if (note.Tick < sourceSection.Tick)
+                        {
+                            continue;
+                        }
+                        if (note.Tick >= sourceSection.TickEnd)
+                        {
+                            break;
+                        }
+                        count += includeChildNotesInNoteCount ? note.ChildNotes.Count + 1 : 1;
+                    }
+                    phrases.Add(new UnisonPhrase(sourceSection.PhraseRef, count));
                 }
             }
 
             return phrases;
-
-            // Get the track for a given instrument, if it exists
-            static bool TryFindTrackForInstrument<TNote>(Instrument instrument,
-                IEnumerable<InstrumentTrack<TNote>> trackEnumerable, out InstrumentTrack<TNote> instrumentTrack) where TNote : Note<TNote>
-            {
-                foreach (var track in trackEnumerable)
-                {
-                    if (track.Instrument == instrument)
-                    {
-                        instrumentTrack = track;
-                        return true;
-                    }
-                }
-
-                instrumentTrack = null!;
-                return false;
-            }
         }
 
         public void OnStarPowerPhraseHit(EngineContainer container, double time)
@@ -433,9 +465,13 @@ namespace YARG.Core.Engine
             // Find the relevant unison and increment its SuccessCount
             foreach (var unison in _unisonEvents)
             {
+                if (!unison.ParticipantToPhrase.TryGetValue(container.EngineId, out var phrase))
+                {
+                    continue;
+                }
                 // The engine's conception of SP phrases for each instrument end at different times,
                 // so an exact match is impossible even though the phrases have identical times
-                if (unison.Time <= time && time <= unison.TimeEnd)
+                if (phrase.Time <= time && time <= phrase.TimeEnd)
                 {
                     if (unison.Success(container))
                     {
@@ -444,6 +480,8 @@ namespace YARG.Core.Engine
                         YargLogger.LogDebug("EngineManager bonus SP award triggered");
                         AwardStarPowerBonus(unison);
                     }
+
+                    return;
                 }
             }
         }
@@ -455,7 +493,7 @@ namespace YARG.Core.Engine
                 YargLogger.LogDebug("Attempted to award bonus SP, but it was already awarded");
                 return;
             }
-            foreach (var id in unison.ParticipantIds)
+            foreach (var id in unison.ParticipantToPhrase.Keys)
             {
                 YargLogger.LogFormatDebug("EngineManager awarding bonus SP to participant ID {0}", id);
                 var engineContainer = _allEnginesById[id];

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using YARG.Core.Chart;
+using YARG.Core.Engine.Drums;
 using YARG.Core.Game;
 
 namespace YARG.Core.Engine
@@ -21,23 +22,25 @@ namespace YARG.Core.Engine
             public  int             EngineId         { get; }
             public  BaseEngine      Engine           { get; }
             public  Instrument      Instrument       { get; }
+            public  Difficulty      Difficulty       { get; }
             public  int             HarmonyIndex     { get; }
             private SongChart       SongChart        { get; }
-            public  List<Phrase>    UnisonPhrases    { get; }
+            public  List<UnisonPhrase>    UnisonPhrases    { get; }
             public  RockMeterPreset RockMeterPreset  { get; }
 
             private List<EngineCommand> _sentCommands = new();
             private int                 _commandCount => _sentCommands.Count;
             private EngineManager       _engineManager;
 
-            public EngineContainer(BaseEngine engine, Instrument instrument, int harmonyIndex, SongChart songChart, int engineId, EngineManager manager, RockMeterPreset rockMeterPreset)
+            public EngineContainer(BaseEngine engine, Instrument instrument, Difficulty difficulty, int harmonyIndex, SongChart songChart, int engineId, EngineManager manager, RockMeterPreset rockMeterPreset)
             {
                 EngineId = engineId;
                 Engine = engine;
                 Instrument = instrument;
+                Difficulty = difficulty;
                 HarmonyIndex = harmonyIndex;
                 SongChart = songChart;
-                UnisonPhrases = GetUnisonPhrases(Instrument, SongChart);
+                UnisonPhrases = GetUnisonPhrases(Instrument, Difficulty, SongChart, Engine is DrumsEngine);
                 RockMeterPreset = rockMeterPreset;
                 _engineManager = manager;
                 Happiness = rockMeterPreset.StartingHappiness;
@@ -77,13 +80,13 @@ namespace YARG.Core.Engine
             }
         }
 
-        public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, SongChart chart, RockMeterPreset rockMeterPreset)
+        public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, Difficulty difficulty, SongChart chart, RockMeterPreset rockMeterPreset)
             where TEngineType : BaseEngine
         {
-            return Register(engine, instrument, 0, chart, rockMeterPreset);
+            return Register(engine, instrument, difficulty, 0, chart, rockMeterPreset);
         }
 
-        public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, int harmonyIndex, SongChart chart, RockMeterPreset rockMeterPreset)
+        public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, Difficulty difficulty, int harmonyIndex, SongChart chart, RockMeterPreset rockMeterPreset)
             where TEngineType : BaseEngine
         {
             if (_chart == null)
@@ -98,13 +101,13 @@ namespace YARG.Core.Engine
                 }
             }
 
-            var engineContainer = new EngineContainer(engine, instrument, harmonyIndex, chart, _nextEngineIndex++, this, rockMeterPreset);
+            var engineContainer = new EngineContainer(engine, instrument, difficulty, harmonyIndex, chart, _nextEngineIndex++, this, rockMeterPreset);
 
             // _previousHappiness = rockMeterPreset.StartingHappiness;
 
             _allEngines.Add(engineContainer);
             _allEnginesById.Add(engineContainer.EngineId, engineContainer);
-            AddPlayerToUnisons(engineContainer);
+            AddPlayerToUnisons(engineContainer, chart);
             engine.OnCodaStart += CodaStartHandler;
             engine.OnCodaEnd += CodaEndHandler;
 

--- a/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
+++ b/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
@@ -172,7 +172,7 @@ namespace YARG.Core.Replays.Analyzer
                 engines.Add(engine);
 
                 // TODO: Implement support for custom RockMeterPresets in replays
-                manager.Register(engine, frame.Profile.CurrentInstrument, _chart, RockMeterPreset.Normal);
+                manager.Register(engine, frame.Profile.CurrentInstrument, frame.Profile.CurrentDifficulty, _chart, RockMeterPreset.Normal);
                 engine.SetSpeed(frame.EngineParameters.SongSpeed);
                 engine.Reset();
 


### PR DESCRIPTION
Main changes:
### UnisonEvent
- UnisonEvent doesn't implement `IEquatable` anymore, since whether it and another unison event are equal depends on whether the ticks are within a given tolerance, so no `==`.
- UnisonEvent has a `Tick` and `TickEnd` now.
- Determining whether a unison phrase is part of a UnisonEvent now uses tick tolerance instead of comparing times.
- `ParticipantIds` has been replaced with a dictionary mapping participant IDs to their corresponding phrase for a given event.
- UnisonEvents is exposed as a read only list.
- `OnStarPowerPhraseHit` now checks that engine's unison phrase to determine whether the star power hit fell within it, instead of within the event itself.
### UnisonPhrase and GetUnisonPhrases
- `UnisonPhrase` class added, which is similar to a phrase, but tracks `NoteCount` and is forced as type `StarPower`.
- `EngineContainer` now takes `Difficulty` as a parameter, and stores it. I could have done `InstrumentDifficulty` instead, but I didn't want to deal with generic types since it would generally just make life hard.
- `GetUnisonPhrases` is now split into two overloaded functions, one of which gets the corresponding `InstrumentDifficulty<>` from instrument and difficulty and then calls the other which gets the phrases.
    - This was necessary so that I could read the list of notes without having them as generic `ChartEvent` types, in order to determine the note count.
- When determining whether child notes should be counted in the phrase's note count, it just checks whether the engine is of type `DrumsEngine`, which feels slightly hacky, but I didn't want to pass in another parameter from somewhere just for that.

Requires YARC-Official/YARG#1545