### PR TITLE
Rework EngineContainer to use generics

### DIFF
--- a/YARG.Core.UnitTests/Engine/EngineManagerTester.cs
+++ b/YARG.Core.UnitTests/Engine/EngineManagerTester.cs
@@ -44,10 +44,11 @@ public class EngineManagerTester : EngineTester
     [Test]
     public void EngineManagerGeneratesUnisonPhrases()
     {
-        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, Difficulty.Expert, GetChart(), false);
-        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, Difficulty.Expert, GetChart(), true);
-        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, Difficulty.Expert, GetChart(), false);
-        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, Difficulty.Expert, GetChart(), false);
+        var chart = GetChart();
+        var guitarPhrases = EngineManager.GetUnisonPhrases(chart.FiveFretGuitar.GetDifficulty(Difficulty.Expert), GetChart(), false);
+        var bassPhrases = EngineManager.GetUnisonPhrases(chart.FiveFretBass.GetDifficulty(Difficulty.Expert), GetChart(), true);
+        var drumsPhrases = EngineManager.GetUnisonPhrases(chart.FourLaneDrums.GetDifficulty(Difficulty.Expert), GetChart(), false);
+        var keysPhrases = EngineManager.GetUnisonPhrases(chart.ProKeys.GetDifficulty(Difficulty.Expert), GetChart(), false);
 
         using (Assert.EnterMultipleScope())
         {
@@ -63,10 +64,11 @@ public class EngineManagerTester : EngineTester
     {
         var tolerance = (GetChart().Resolution / 4) - 1; // 16th note tolerance
         Func<EngineManager.UnisonPhrase, EngineManager.UnisonPhrase, bool> comparer = (a, b) => EngineManager.TickWithinTolerance(a.Tick, b.Tick, tolerance) && EngineManager.TickWithinTolerance(a.TickEnd, b.TickEnd, tolerance);
-        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, Difficulty.Expert, GetChart(), false);
-        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, Difficulty.Expert, GetChart(), false);
-        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, Difficulty.Expert, GetChart(), true);
-        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, Difficulty.Expert, GetChart(), false);
+        var chart = GetChart();
+        var guitarPhrases = EngineManager.GetUnisonPhrases(chart.FiveFretGuitar.GetDifficulty(Difficulty.Expert), chart, false);
+        var bassPhrases = EngineManager.GetUnisonPhrases(chart.FiveFretBass.GetDifficulty(Difficulty.Expert), chart, false);
+        var drumsPhrases = EngineManager.GetUnisonPhrases(chart.FourLaneDrums.GetDifficulty(Difficulty.Expert), chart, true);
+        var keysPhrases = EngineManager.GetUnisonPhrases(chart.ProKeys.GetDifficulty(Difficulty.Expert), chart, false);
 
         using (Assert.EnterMultipleScope())
         {
@@ -81,28 +83,28 @@ public class EngineManagerTester : EngineTester
     public void EngineManagerUnisonPhraseNoteCountIsCorrect()
     {
         var chart = GetChart();
-        var guitarPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretGuitar, Difficulty.Expert, GetChart(), false);
-        var bassPhrases = EngineManager.GetUnisonPhrases(Instrument.FiveFretBass, Difficulty.Expert, GetChart(), false);
-        var drumsPhrases = EngineManager.GetUnisonPhrases(Instrument.FourLaneDrums, Difficulty.Expert, GetChart(), true);
-        var keysPhrases = EngineManager.GetUnisonPhrases(Instrument.ProKeys, Difficulty.Expert, GetChart(), false);
+        var guitarPhrases = EngineManager.GetUnisonPhrases(chart.FiveFretGuitar.GetDifficulty(Difficulty.Expert), chart, false);
+        var bassPhrases = EngineManager.GetUnisonPhrases(chart.FiveFretBass.GetDifficulty(Difficulty.Expert), chart, false);
+        var drumsPhrases = EngineManager.GetUnisonPhrases(chart.FourLaneDrums.GetDifficulty(Difficulty.Expert), chart, true);
+        var keysPhrases = EngineManager.GetUnisonPhrases(chart.ProKeys.GetDifficulty(Difficulty.Expert), chart, false);
 
         using (Assert.EnterMultipleScope())
         {
             foreach (var phrase in guitarPhrases)
             {
-                var notes = chart.GetFiveFretTrack(Instrument.FiveFretGuitar).GetDifficulty(Difficulty.Expert).Notes;
+                var notes = chart.FiveFretGuitar.GetDifficulty(Difficulty.Expert).Notes;
                 var noteCount = notes.Count(n => n.Tick >= phrase.Tick && n.Tick < phrase.TickEnd);
                 Assert.That(phrase.NoteCount, Is.EqualTo(noteCount));
             }
             foreach (var phrase in bassPhrases)
             {
-                var notes = chart.GetFiveFretTrack(Instrument.FiveFretBass).GetDifficulty(Difficulty.Expert).Notes;
+                var notes = chart.FiveFretBass.GetDifficulty(Difficulty.Expert).Notes;
                 var noteCount = notes.Count(n => n.Tick >= phrase.Tick && n.Tick < phrase.TickEnd);
                 Assert.That(phrase.NoteCount, Is.EqualTo(noteCount));
             }
             foreach (var phrase in drumsPhrases)
             {
-                var notes = chart.GetDrumsTrack(Instrument.FourLaneDrums).GetDifficulty(Difficulty.Expert).Notes;
+                var notes = chart.FourLaneDrums.GetDifficulty(Difficulty.Expert).Notes;
                 var noteCount = notes.Sum(n => (n.Tick >= phrase.Tick && n.Tick < phrase.TickEnd) ? n.ChildNotes.Count + 1 : 0);
                 Assert.That(phrase.NoteCount, Is.EqualTo(noteCount));
             }
@@ -123,10 +125,10 @@ public class EngineManagerTester : EngineTester
         var engineManager = new EngineManager();
         var chart = GetChart();
 
-        var guitarEngineContainer = engineManager.Register(CreateEngine(_guitarEngineParams, true, false).Engine, Instrument.FiveFretGuitar, Difficulty.Expert, chart, RockMeterPreset.Normal);
-        var bassEngineContainer = engineManager.Register(CreateEngine(_bassEngineParams, true, true).Engine, Instrument.FiveFretBass, Difficulty.Expert, chart, RockMeterPreset.Normal);
-        var drumsEngineContainer = engineManager.Register(CreateEngine(_drumsEngineParams, true).Engine, Instrument.FourLaneDrums, Difficulty.Expert, chart, RockMeterPreset.Normal);
-        var keysEngineContainer = engineManager.Register(CreateEngine(_keysEngineParams, true).Engine, Instrument.ProKeys, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var guitarEngineContainer = engineManager.Register(CreateEngine(_guitarEngineParams, true, false).Engine, chart.FiveFretGuitar.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
+        var bassEngineContainer = engineManager.Register(CreateEngine(_bassEngineParams, true, true).Engine, chart.FiveFretBass.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
+        var drumsEngineContainer = engineManager.Register(CreateEngine(_drumsEngineParams, true).Engine, chart.FourLaneDrums.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
+        var keysEngineContainer = engineManager.Register(CreateEngine(_keysEngineParams, true).Engine, chart.Keys.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
 
         var globalUnisonEvents = engineManager.UnisonEvents;
         using (Assert.EnterMultipleScope())
@@ -213,10 +215,10 @@ public class EngineManagerTester : EngineTester
         var drumsEngine = CreateEngine(_drumsEngineParams, true);
         var keysEngine = CreateEngine(_keysEngineParams, true);
 
-        var guitarContainer = manager.Register(guitarEngine.Engine, Instrument.FiveFretGuitar, Difficulty.Expert, chart, RockMeterPreset.Normal);
-        var bassContainer = manager.Register(bassEngine.Engine, Instrument.FiveFretBass, Difficulty.Expert, chart, RockMeterPreset.Normal);
-        var drumsContainer = manager.Register(drumsEngine.Engine, Instrument.FourLaneDrums, Difficulty.Expert, chart, RockMeterPreset.Normal);
-        var keysContainer = manager.Register(keysEngine.Engine, Instrument.ProKeys, Difficulty.Expert, chart, RockMeterPreset.Normal);
+        var guitarContainer = manager.Register(guitarEngine.Engine, chart.FiveFretGuitar.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
+        var bassContainer = manager.Register(bassEngine.Engine, chart.FiveFretBass.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
+        var drumsContainer = manager.Register(drumsEngine.Engine, chart.FourLaneDrums.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
+        var keysContainer = manager.Register(keysEngine.Engine, chart.Keys.GetDifficulty(Difficulty.Expert), chart, RockMeterPreset.Normal);
 
         return (manager, [guitarContainer, bassContainer, drumsContainer, keysContainer]);
     }

--- a/YARG.Core/Engine/EngineManager.Band.cs
+++ b/YARG.Core/Engine/EngineManager.Band.cs
@@ -31,7 +31,7 @@ namespace YARG.Core.Engine
                 var totalBonus = 0;
                 foreach (var engine in Engines)
                 {
-                    totalBonus += engine.Engine.CurrentCodaBonus;
+                    totalBonus += engine.BaseEngine.CurrentCodaBonus;
                 }
 
                 return totalBonus;
@@ -44,7 +44,7 @@ namespace YARG.Core.Engine
             {
                 foreach (var engine in Engines)
                 {
-                    if (!engine.Engine.CodaSuccess)
+                    if (!engine.BaseEngine.CodaSuccess)
                     {
                         return false;
                     }
@@ -74,7 +74,7 @@ namespace YARG.Core.Engine
 
                 foreach (var engine in Engines)
                 {
-                    engine.Engine.AwardCodaBonus(success);
+                    engine.BaseEngine.AwardCodaBonus(success);
                 }
             }
         }
@@ -83,7 +83,7 @@ namespace YARG.Core.Engine
         {
             foreach (var engine in Engines)
             {
-                engine.Engine.UpdateBandMultiplier(BandMultiplier);
+                engine.BaseEngine.UpdateBandMultiplier(BandMultiplier);
             }
         }
 

--- a/YARG.Core/Engine/EngineManager.FailMeter.cs
+++ b/YARG.Core/Engine/EngineManager.FailMeter.cs
@@ -20,7 +20,7 @@ namespace YARG.Core.Engine
         /// <summary>
         /// The amount of happiness lost if a single note/gem for non-vocal players is completely missed.
         /// Note that this value also controls the amount of happiness lost for overstrums/overhits, but this is further scaled by the
-        /// <see cref="YARG.Core.Game.RockMeterPreset.OverHitDamageMultiplier">OverHitDamageMultiplier</see> value of the current RockMeterPreset.
+        /// <see cref="YARG.Core.Game.RockMeterPreset.OverhitDamageMultiplier">OverhitDamageMultiplier</see> value of the current RockMeterPreset.
         /// </summary>
         private const float HAPPINESS_PER_NOTE_MISS         = 1.0f / 42;
 
@@ -136,9 +136,9 @@ namespace YARG.Core.Engine
             // Get current engine time
             foreach (var engine in Engines)
             {
-                if (engine.Engine.CurrentTime > _lastUpdateTime)
+                if (engine.BaseEngine.CurrentTime > _lastUpdateTime)
                 {
-                    currentTime = engine.Engine.CurrentTime;
+                    currentTime = engine.BaseEngine.CurrentTime;
                 }
             }
 
@@ -210,12 +210,12 @@ namespace YARG.Core.Engine
             return (happiness / _allEngines.Count) - _happinessAdjustment;
         }
 
-        public partial class EngineContainer
+        public abstract partial class EngineContainer
         {
             private const float HAPPINESS_NEAR_FAIL_THRESHOLD = 0.333f;
-            public        float Happiness { get; private set; } = 0.0f;
-            private       bool  _nearFail         = false;
-            private       bool  _thisPlayerFailed = false;
+            public         float Happiness { get; protected set; } = 0.0f;
+            protected      bool  NearFail         = false;
+            protected      bool  ThisPlayerFailed = false;
 
             private bool _noFail;
 
@@ -226,10 +226,16 @@ namespace YARG.Core.Engine
             public event HappinessNearFailEvent? OnHappinessNearFail;
             public event HappinessOverFailEvent? OnHappinessOverFail;
 
+            protected void InvokeHappinessNearFail() => OnHappinessNearFail?.Invoke();
+            protected void InvokeHappinessOverFail() => OnHappinessOverFail?.Invoke();
+
+            public abstract void RevivePlayer();
+            public abstract void PlayerHasFailed(int engineId, bool noFail);
+
             public void SetNoFail(bool noFail)
             {
                 _noFail = noFail;
-                if (noFail && _thisPlayerFailed)
+                if (noFail && ThisPlayerFailed)
                 {
                     RevivePlayer();
                 }
@@ -237,14 +243,14 @@ namespace YARG.Core.Engine
 
             public void ResetHappiness()
             {
-                _thisPlayerFailed = false;
+                ThisPlayerFailed = false;
                 Happiness = RockMeterPreset.StartingHappiness;
             }
 
-            private void OnVocalPhraseHit(double hitPercentAfterParams, bool fullPoints, bool isLastPhrase)
+            protected void OnVocalPhraseHit(double hitPercentAfterParams, bool fullPoints, bool isLastPhrase)
             {
                 hitPercentAfterParams = Math.Clamp(hitPercentAfterParams, 0.0, 1.0);
-                var delta = 0.0f;
+                float delta = 0.0f;
 
                 // If the hit percent is below the midpoint, the player loses happiness based on how far they are from the midpoint
                 if (hitPercentAfterParams < VOCAL_HIT_PERC_MIDPOINT)
@@ -257,7 +263,7 @@ namespace YARG.Core.Engine
                 {
                     delta = HAPPINESS_PER_VOCAL_PHRASE_HIT * RockMeterPreset.VocalsHitRecoveryMultiplier;
                     delta *= YargMath.InverseLerpF(VOCAL_HIT_PERC_MIDPOINT, 1.0f, hitPercentAfterParams);
-                    if (_engineManager.IsAnyStarpowerActive)
+                    if (EngineManager.IsAnyStarpowerActive)
                     {
                         delta *= RockMeterPreset.StarPowerEffectMultiplier;
                     }
@@ -266,7 +272,78 @@ namespace YARG.Core.Engine
                 AddHappiness(delta);
             }
 
-            private void OnNoteHit<TNote>(int index, TNote note) where TNote : Note<TNote>
+            protected void AddHappiness(float delta)
+            {
+                Happiness = Math.Clamp(Happiness + delta, HAPPINESS_MINIMUM, 1f);
+                if (Happiness < HAPPINESS_NEAR_FAIL_THRESHOLD && !NearFail)
+                {
+                    NearFail = true;
+                    if (!_noFail)
+                    {
+                        InvokeHappinessNearFail();
+                    }
+                }
+                else if (Happiness >= HAPPINESS_NEAR_FAIL_THRESHOLD && NearFail)
+                {
+                    NearFail = false;
+                    // This is not gated behind _noFail being false because we want to always allow transitions
+                    // away from fail in case no fail has been turned on
+                    InvokeHappinessOverFail();
+                }
+
+                EngineManager.UpdateHappiness();
+            }
+
+            protected void OnPlayerFailedReceived(int engineId)
+            {
+                PlayerHasFailed(engineId, _noFail);
+            }
+
+            protected void OnPlayerRevivedReceived()
+            {
+                EngineManager.RevivePlayer();
+            }
+        }
+
+        public partial class EngineContainer<TNoteType, TEngineParams, TEngineStats>
+            where TNoteType : Note<TNoteType>
+            where TEngineParams : BaseEngineParameters
+            where TEngineStats : BaseStats, new()
+        {
+
+            public override void RevivePlayer()
+            {
+                if (ThisPlayerFailed)
+                {
+                    Happiness = 0.5f;
+                }
+
+                Engine.PlayerHasRevived();
+
+                if (!NearFail)
+                {
+                    InvokeHappinessOverFail();
+                }
+
+                ThisPlayerFailed = false;
+            }
+
+            public override void PlayerHasFailed(int engineId, bool noFail)
+            {
+                if (noFail)
+                {
+                    return;
+                }
+
+                if (engineId == EngineId)
+                {
+                    ThisPlayerFailed = true;
+                }
+
+                Engine.PlayerHasFailed();
+                InvokeHappinessNearFail();
+            }
+            private void OnNoteHit(int index, TNoteType note)
             {
                 // Ignore any notes that have not been fully hit yet on the assumption that a call
                 // where the note group was fully hit will eventually come if they are all hit
@@ -275,8 +352,8 @@ namespace YARG.Core.Engine
                     return;
                 }
 
-                var delta = HAPPINESS_PER_NOTE_HIT * RockMeterPreset.HitRecoveryMultiplier;
-                if (_engineManager.IsAnyStarpowerActive)
+                float delta = HAPPINESS_PER_NOTE_HIT * RockMeterPreset.HitRecoveryMultiplier;
+                if (EngineManager.IsAnyStarpowerActive)
                 {
                     delta *= RockMeterPreset.StarPowerEffectMultiplier;
                 }
@@ -284,137 +361,58 @@ namespace YARG.Core.Engine
                 AddHappiness(delta);
             }
 
-            private void OnNoteMissed<TNote>(int index, TNote note) where TNote : Note<TNote>
+            private void OnNoteMissed(int index, TNoteType note)
             {
                 if (!note.WasFullyMissed())
                 {
                     return;
                 }
 
-                var delta = -1 * HAPPINESS_PER_NOTE_MISS * RockMeterPreset.MissDamageMultiplier;
+                float delta = -1 * HAPPINESS_PER_NOTE_MISS * RockMeterPreset.MissDamageMultiplier;
                 AddHappiness(delta);
             }
 
             private void OnOverstrum()
             {
-                var delta = -1 * HAPPINESS_PER_NOTE_MISS * RockMeterPreset.OverhitDamageMultiplier;
+                float delta = -1 * HAPPINESS_PER_NOTE_MISS * RockMeterPreset.OverhitDamageMultiplier;
                 AddHappiness(delta);
             }
 
             private void OnKeysOverhit(int key) => OnOverstrum();
 
-            public void RevivePlayer()
-            {
-                if (_thisPlayerFailed)
-                {
-                    Happiness = 0.5f;
-                }
-
-                Engine.PlayerHasRevived();
-
-                if (!_nearFail)
-                {
-                    OnHappinessOverFail?.Invoke();
-                }
-
-                _thisPlayerFailed = false;
-            }
-
-            public void PlayerHasFailed(int engineId)
-            {
-                if (_noFail)
-                {
-                    return;
-                }
-
-                if (engineId == EngineId)
-                {
-                    _thisPlayerFailed = true;
-                }
-
-                Engine.PlayerHasFailed();
-                OnHappinessNearFail?.Invoke();
-            }
-
-            private void AddHappiness(float delta)
-            {
-                Happiness = Math.Clamp(Happiness + delta, HAPPINESS_MINIMUM, 1f);
-                if (Happiness < HAPPINESS_NEAR_FAIL_THRESHOLD && !_nearFail)
-                {
-                    _nearFail = true;
-                    if (!_noFail)
-                    {
-                        OnHappinessNearFail?.Invoke();
-                    }
-                }
-                else if (Happiness >= HAPPINESS_NEAR_FAIL_THRESHOLD && _nearFail)
-                {
-                    _nearFail = false;
-                    // This is not gated behind _noFail being false because we want to always allow transitions
-                    // away from fail in case no fail has been turned on
-                    OnHappinessOverFail?.Invoke();
-                }
-
-                _engineManager.UpdateHappiness();
-            }
-
-            private void OnPlayerFailedReceived(int engineId)
-            {
-                PlayerHasFailed(engineId);
-            }
-
-            private void OnPlayerRevivedReceived()
-            {
-                _engineManager.RevivePlayer();
-            }
-
             private void SubscribeToEvents()
             {
-                // Subscribe to OnNoteHit and OnNoteMissed events
-                if (Engine is BaseEngine<GuitarNote,GuitarEngineParameters,GuitarStats> guitarEngine)
+                // Vocals engine handles hit events differently, so we don't want to subscribe to the note hit/miss events for it
+                if (Engine is not VocalsEngine)
                 {
-                    var engine = (GuitarEngine) guitarEngine;
-                    engine.OnNoteHit += OnNoteHit;
-                    engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarPowerStatus;
-                    engine.OnOverstrum += OnOverstrum;
+                    Engine.OnNoteHit += OnNoteHit;
+                    Engine.OnNoteMissed += OnNoteMissed;
                 }
 
-                if (Engine is BaseEngine<DrumNote, DrumsEngineParameters, DrumsStats> drumEngine)
+                Engine.OnStarPowerStatus += OnStarPowerStatus;
+
+                // Overhit/Overstrum events are not in BaseEngine,
+                // so we need to check the type of engine and subscribe to the appropriate event
+                switch (Engine)
                 {
-                    var engine = (DrumsEngine) drumEngine;
-                    engine.OnNoteHit += OnNoteHit;
-                    engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarPowerStatus;
-                    engine.OnOverhit += OnOverstrum;
+                    case GuitarEngine guitarEngine:
+                        guitarEngine.OnOverstrum += OnOverstrum;
+                        break;
+                    case DrumsEngine drumsEngine:
+                        drumsEngine.OnOverhit += OnOverstrum;
+                        break;
+                    case ProKeysEngine proKeysEngine:
+                        proKeysEngine.OnOverhit += OnKeysOverhit;
+                        break;
+                    case FiveLaneKeysEngine fiveLaneKeysEngine:
+                        fiveLaneKeysEngine.OnOverhit += OnKeysOverhit;
+                        break;
+                    case VocalsEngine vocalsEngine:
+                        vocalsEngine.OnPhraseHit += OnVocalPhraseHit;
+                        break;
                 }
 
-                if (Engine is BaseEngine<ProKeysNote, KeysEngineParameters, KeysStats>
-                    proKeysEngine)
-                {
-                    var engine = (ProKeysEngine) proKeysEngine;
-                    engine.OnNoteHit += OnNoteHit;
-                    engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarPowerStatus;
-                    engine.OnOverhit += OnKeysOverhit;
-                }
-
-                if (Engine is BaseEngine<GuitarNote, KeysEngineParameters, KeysStats> keysEngine)
-                {
-                    var engine = (FiveLaneKeysEngine) keysEngine;
-                    engine.OnNoteHit += OnNoteHit;
-                    engine.OnNoteMissed += OnNoteMissed;
-                    engine.OnStarPowerStatus += OnStarPowerStatus;
-                    engine.OnOverhit += OnKeysOverhit;
-                }
-
-                if (Engine is VocalsEngine vocalsEngine)
-                {
-                    vocalsEngine.OnPhraseHit += OnVocalPhraseHit;
-                    vocalsEngine.OnStarPowerStatus += OnStarPowerStatus;
-                }
-
-                _engineManager.OnPlayerFailed += OnPlayerFailedReceived;
+                EngineManager.OnPlayerFailed += OnPlayerFailedReceived;
                 Engine.OnPlayerRevived += OnPlayerRevivedReceived;
             }
         }

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using YARG.Core.Chart;
-using YARG.Core.Engine.Drums;
-using YARG.Core.Engine.Guitar;
-using YARG.Core.Engine.Keys;
 using YARG.Core.Engine.Vocals;
 using YARG.Core.Logging;
 using YARG.Core.Extensions;
@@ -170,7 +167,7 @@ namespace YARG.Core.Engine
         private void AddPlayerToUnisons(EngineContainer engineContainer, SongChart chart)
         {
             // Vocals don't participate in unisons, so don't add them to the list
-            if (engineContainer.Engine is BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats>)
+            if (engineContainer is EngineContainer<VocalNote, VocalsEngineParameters, VocalsStats>)
             {
                 return;
             }
@@ -208,28 +205,7 @@ namespace YARG.Core.Engine
                 unisonEvent.AddPlayer(engineContainer, phrase);
             }
             // Subscribe the container to OnStarPowerPhraseHit so bonuses can be awarded as appropriate
-            if (engineContainer.Engine is BaseEngine<GuitarNote,GuitarEngineParameters,GuitarStats> guitarEngine)
-            {
-                guitarEngine.OnStarPowerPhraseHit += engineContainer.OnStarPowerPhraseHit;
-            }
-
-            if (engineContainer.Engine is BaseEngine<DrumNote, DrumsEngineParameters, DrumsStats> drumEngine)
-            {
-                drumEngine.OnStarPowerPhraseHit += engineContainer.OnStarPowerPhraseHit;
-            }
-
-            if (engineContainer.Engine is BaseEngine<ProKeysNote, KeysEngineParameters, KeysStats>
-                proKeysEngine)
-            {
-                proKeysEngine.OnStarPowerPhraseHit += engineContainer.OnStarPowerPhraseHit;
-            }
-
-            if (engineContainer.Engine is BaseEngine<GuitarNote, KeysEngineParameters, KeysStats>
-                fiveLaneKeysEngine)
-            {
-                fiveLaneKeysEngine.OnStarPowerPhraseHit += engineContainer.OnStarPowerPhraseHit;
-            }
-            // Vocals don't participate in unisons, so they get left out.
+            engineContainer.SubscribeToStarPowerPhraseHit();
         }
 
         private void RemovePlayerFromUnisons(EngineContainer engineContainer)
@@ -239,113 +215,7 @@ namespace YARG.Core.Engine
                 unisonEvent.RemovePlayer(engineContainer);
             }
 
-            // Unsubscribe the container from OnStarPowerPhraseHit so bonuses can be awarded as appropriate
-            if (engineContainer.Engine is BaseEngine<GuitarNote,GuitarEngineParameters,GuitarStats> guitarEngine)
-            {
-                guitarEngine.OnStarPowerPhraseHit -= engineContainer.OnStarPowerPhraseHit;
-            }
-
-            if (engineContainer.Engine is BaseEngine<DrumNote, DrumsEngineParameters, DrumsStats> drumEngine)
-            {
-                drumEngine.OnStarPowerPhraseHit -= engineContainer.OnStarPowerPhraseHit;
-            }
-
-            if (engineContainer.Engine is BaseEngine<ProKeysNote, KeysEngineParameters, KeysStats>
-                proKeysEngine)
-            {
-                proKeysEngine.OnStarPowerPhraseHit -= engineContainer.OnStarPowerPhraseHit;
-            }
-
-            if (engineContainer.Engine is BaseEngine<GuitarNote, KeysEngineParameters, KeysStats>
-                fiveLaneKeysEngine)
-            {
-                fiveLaneKeysEngine.OnStarPowerPhraseHit -= engineContainer.OnStarPowerPhraseHit;
-            }
-        }
-
-        /// <summary>
-        /// Builds unison phrases for a combination of instrument and chart
-        /// </summary>
-        /// <param name="instrument"><see cref="Instrument"/></param>
-        /// <param name="difficulty"><see cref="Difficulty"/></param>
-        /// <param name="chart"><see cref="SongChart"/></param>
-        /// <param name="includeChildNotesInNoteCount">Used to determine how to calculate note count in the phrase.</param>
-        /// <returns>List of UnisonPhrase objects.
-        /// <br />These Phrases have corresponding StarPower Phrases in other tracks,
-        /// <br />which is what makes them unison phrases.
-        /// </returns>
-        public static List<UnisonPhrase> GetUnisonPhrases(Instrument instrument, Difficulty difficulty, SongChart chart, bool includeChildNotesInNoteCount)
-        {
-
-            // Find a track that corresponds to the player's instrument
-            if (TryFindTrackForInstrument(instrument, chart.FiveFretTracks, out var fiveFretTrack))
-            {
-                if (fiveFretTrack.TryGetDifficulty(difficulty, out var track))
-                {
-                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
-                }
-            }
-
-            if (TryFindTrackForInstrument(instrument, chart.DrumsTracks, out var drumsTrack))
-            {
-                if (drumsTrack.TryGetDifficulty(difficulty, out var track))
-                {
-                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
-                }
-            }
-
-            if (TryFindTrackForInstrument(instrument, chart.SixFretTracks, out var sixFretTrack))
-            {
-                if (sixFretTrack.TryGetDifficulty(difficulty, out var track))
-                {
-                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
-                }
-            }
-
-            if (TryFindTrackForInstrument(instrument, chart.ProGuitarTracks, out var proGuitarTrack))
-            {
-                if (proGuitarTrack.TryGetDifficulty(difficulty, out var track))
-                {
-                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
-                }
-            }
-
-            if (chart.ProKeys.Instrument == instrument)
-            {
-                if (chart.ProKeys.TryGetDifficulty(difficulty, out var track))
-                {
-                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
-                }
-            }
-
-            if (chart.Keys.Instrument == instrument)
-            {
-                if (chart.Keys.TryGetDifficulty(difficulty, out var track))
-                {
-                    return GetUnisonPhrases(track, chart, includeChildNotesInNoteCount);
-                }
-            }
-
-
-            YargLogger.LogFormatError("Could not find any instrument difficulty for {0}", instrument);
-            return new List<UnisonPhrase>();
-
-            // Get the track for a given instrument, if it exists
-            static bool TryFindTrackForInstrument<TNote>(Instrument instrument,
-                IEnumerable<InstrumentTrack<TNote>> trackEnumerable, out InstrumentTrack<TNote> instrumentTrack) where TNote : Note<TNote>
-            {
-                foreach (var track in trackEnumerable)
-                {
-                    if (track.Instrument == instrument)
-                    {
-                        instrumentTrack = track;
-                        return true;
-                    }
-                }
-
-                instrumentTrack = null!;
-                return false;
-            }
+            engineContainer.UnsubscribeToStarPowerPhraseHit();
         }
 
         /// <summary>
@@ -358,7 +228,9 @@ namespace YARG.Core.Engine
         /// <br />These Phrases have corresponding StarPower Phrases in other tracks,
         /// <br />which is what makes them unison phrases.
         /// </returns>
-        public static List<UnisonPhrase> GetUnisonPhrases<TNoteType>(InstrumentDifficulty<TNoteType> instrumentDifficulty, SongChart chart, bool includeChildNotesInNoteCount) where TNoteType : Note<TNoteType>
+        public static List<UnisonPhrase> GetUnisonPhrases<TNoteType>(
+            InstrumentDifficulty<TNoteType> instrumentDifficulty, SongChart chart, bool includeChildNotesInNoteCount)
+            where TNoteType : Note<TNoteType>
         {
             // Unisons must have at least 2 participants.
 

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -17,38 +17,63 @@ namespace YARG.Core.Engine
 
         private SongChart?               _chart;
 
-        public partial class EngineContainer
+        public abstract partial class EngineContainer
         {
-            public  int             EngineId         { get; }
-            public  BaseEngine      Engine           { get; }
-            public  Instrument      Instrument       { get; }
-            public  Difficulty      Difficulty       { get; }
-            public  int             HarmonyIndex     { get; }
-            private SongChart       SongChart        { get; }
-            public  List<UnisonPhrase>    UnisonPhrases    { get; }
-            public  RockMeterPreset RockMeterPreset  { get; }
+            public    int                 EngineId        { get; }
+            public    int                 HarmonyIndex    { get; }
+            public    List<UnisonPhrase>  UnisonPhrases   { get; }
+            public    RockMeterPreset     RockMeterPreset { get; }
+            protected List<EngineCommand> SentCommands = new();
+            private   int                 CommandCount => SentCommands.Count;
+            protected EngineManager       EngineManager;
 
-            private List<EngineCommand> _sentCommands = new();
-            private int                 _commandCount => _sentCommands.Count;
-            private EngineManager       _engineManager;
+            protected void OnStarPowerStatus(bool active)
+            {
+                int count = EngineManager._starpowerCount;
+                count += active ? 1 : -1;
+                EngineManager.UpdateStarPowerCount(count);
+            }
 
-            public EngineContainer(BaseEngine engine, Instrument instrument, Difficulty difficulty, int harmonyIndex, SongChart songChart, int engineId, EngineManager manager, RockMeterPreset rockMeterPreset)
+            public abstract void SendCommand(EngineCommandType command);
+            public abstract void UpdateEngine(double time);
+            public abstract BaseEngine BaseEngine { get; }
+            public abstract Instrument Instrument { get; }
+            public abstract Difficulty Difficulty { get; }
+            public abstract void SubscribeToStarPowerPhraseHit();
+            public abstract void UnsubscribeToStarPowerPhraseHit();
+
+            protected EngineContainer(int engineId, int harmonyIndex, EngineManager manager,
+                RockMeterPreset rockMeterPreset, List<UnisonPhrase> unisonPhrases)
             {
                 EngineId = engineId;
-                Engine = engine;
-                Instrument = instrument;
-                Difficulty = difficulty;
                 HarmonyIndex = harmonyIndex;
-                SongChart = songChart;
-                UnisonPhrases = GetUnisonPhrases(Instrument, Difficulty, SongChart, Engine is DrumsEngine);
+                EngineManager = manager;
                 RockMeterPreset = rockMeterPreset;
-                _engineManager = manager;
-                Happiness = rockMeterPreset.StartingHappiness;
+                UnisonPhrases = unisonPhrases;
+            }
+        }
+
+        public partial class EngineContainer<TNoteType, TEngineParams, TEngineStats> : EngineContainer
+            where TNoteType : Note<TNoteType>
+            where TEngineParams : BaseEngineParameters
+            where TEngineStats : BaseStats, new()
+        {
+            public BaseEngine<TNoteType, TEngineParams, TEngineStats> Engine               { get; }
+            public InstrumentDifficulty<TNoteType>                    InstrumentDifficulty { get; }
+
+            public EngineContainer(BaseEngine<TNoteType, TEngineParams, TEngineStats> engine,
+                InstrumentDifficulty<TNoteType> instrumentDifficulty, int harmonyIndex, SongChart songChart,
+                int engineId, EngineManager manager, RockMeterPreset rockMeterPreset)
+                : base(engineId, harmonyIndex, manager, rockMeterPreset,
+                    GetUnisonPhrases(instrumentDifficulty, songChart, engine is DrumsEngine))
+            {
+                Engine = engine;
+                InstrumentDifficulty = instrumentDifficulty;
 
                 SubscribeToEvents();
             }
 
-            public void SendCommand(EngineCommandType command)
+            public override void SendCommand(EngineCommandType command)
             {
                 // TODO: This will require rethinking when there are more commands, but for now this should work?
                 if (command == EngineCommandType.AwardUnisonBonus)
@@ -59,35 +84,55 @@ namespace YARG.Core.Engine
                 {
                     return;
                 }
-                _sentCommands.Add(new EngineCommand { CommandType = command, Time = Engine.CurrentTime });
+
+                SentCommands.Add(new EngineCommand
+                {
+                    CommandType = command,
+                    Time = Engine.CurrentTime,
+                });
             }
 
-            public void OnStarPowerPhraseHit<TNote>(TNote note) where TNote : Note<TNote>
+            public void OnStarPowerPhraseHit(TNoteType note)
             {
-                _engineManager.OnStarPowerPhraseHit(this, note.Time);
+                EngineManager.OnStarPowerPhraseHit(this, note.Time);
             }
 
-            public void UpdateEngine(double time)
+            public override void UpdateEngine(double time)
             {
                 Engine.Update(time);
             }
 
-            private void OnStarPowerStatus(bool active)
+            public override BaseEngine BaseEngine => Engine;
+            public override Instrument Instrument => InstrumentDifficulty.Instrument;
+
+            public override Difficulty Difficulty => InstrumentDifficulty.Difficulty;
+
+            public override void SubscribeToStarPowerPhraseHit()
             {
-                var count = _engineManager._starpowerCount;
-                count += active ? 1 : -1;
-                _engineManager.UpdateStarPowerCount(count);
+                Engine.OnStarPowerPhraseHit += OnStarPowerPhraseHit;
+            }
+
+            public override void UnsubscribeToStarPowerPhraseHit()
+            {
+                Engine.OnStarPowerPhraseHit -= OnStarPowerPhraseHit;
             }
         }
 
-        public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, Difficulty difficulty, SongChart chart, RockMeterPreset rockMeterPreset)
-            where TEngineType : BaseEngine
-        {
-            return Register(engine, instrument, difficulty, 0, chart, rockMeterPreset);
-        }
+        public EngineContainer Register<TNoteType, TEngineParams, TEngineStats>(
+            BaseEngine<TNoteType, TEngineParams, TEngineStats> engine,
+            InstrumentDifficulty<TNoteType> instrumentDifficulty, SongChart chart, RockMeterPreset rockMeterPreset)
+            where TNoteType : Note<TNoteType>
+            where TEngineParams : BaseEngineParameters
+            where TEngineStats : BaseStats, new() =>
+            Register(engine, instrumentDifficulty, 0, chart, rockMeterPreset);
 
-        public EngineContainer Register<TEngineType>(TEngineType engine, Instrument instrument, Difficulty difficulty, int harmonyIndex, SongChart chart, RockMeterPreset rockMeterPreset)
-            where TEngineType : BaseEngine
+        public EngineContainer Register<TNoteType, TEngineParams, TEngineStats>(
+            BaseEngine<TNoteType, TEngineParams, TEngineStats> engine,
+            InstrumentDifficulty<TNoteType> instrumentDifficulty, int harmonyIndex, SongChart chart,
+            RockMeterPreset rockMeterPreset)
+            where TNoteType : Note<TNoteType>
+            where TEngineParams : BaseEngineParameters
+            where TEngineStats : BaseStats, new()
         {
             if (_chart == null)
             {
@@ -101,7 +146,8 @@ namespace YARG.Core.Engine
                 }
             }
 
-            var engineContainer = new EngineContainer(engine, instrument, difficulty, harmonyIndex, chart, _nextEngineIndex++, this, rockMeterPreset);
+            var engineContainer = new EngineContainer<TNoteType, TEngineParams, TEngineStats>(engine,
+                instrumentDifficulty, harmonyIndex, chart, _nextEngineIndex++, this, rockMeterPreset);
 
             // _previousHappiness = rockMeterPreset.StartingHappiness;
 
@@ -118,7 +164,7 @@ namespace YARG.Core.Engine
         {
             foreach (var engine in _allEngines)
             {
-                if (engine.Engine == target)
+                if (engine.BaseEngine == target)
                 {
                     return engine;
                 }
@@ -173,7 +219,7 @@ namespace YARG.Core.Engine
             AwardUnisonBonus,
         }
 
-        private struct EngineCommand
+        public struct EngineCommand
         {
             public EngineCommandType CommandType;
             public double            Time;

--- a/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
+++ b/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
@@ -170,9 +170,7 @@ namespace YARG.Core.Replays.Analyzer
             {
                 var engine = CreateEngine(frame.Profile, frame.EngineParameters);
                 engines.Add(engine);
-
-                // TODO: Implement support for custom RockMeterPresets in replays
-                manager.Register(engine, frame.Profile.CurrentInstrument, frame.Profile.CurrentDifficulty, _chart, RockMeterPreset.Normal);
+                RegisterEngine(frame.Profile, engine, manager, frame.EngineParameters, frame);
                 engine.SetSpeed(frame.EngineParameters.SongSpeed);
                 engine.Reset();
 
@@ -221,6 +219,63 @@ namespace YARG.Core.Replays.Analyzer
                 });
             }
             return results;
+        }
+
+        private void RegisterEngine(YargProfile profile, BaseEngine engine, EngineManager manager, BaseEngineParameters parameters, ReplayFrame frame)
+        {
+            switch (frame.Profile.GameMode)
+            {
+                case GameMode.FiveFretGuitar:
+                {
+                    var notes = _chart.GetFiveFretTrack(frame.Profile.CurrentInstrument)
+                        .GetDifficulty(frame.Profile.CurrentDifficulty).Clone();
+                    profile.ApplyModifiers(notes, _chart.SyncTrack);
+                    // TODO: Implement support for custom RockMeterPresets in replays
+                    manager.Register((GuitarEngine)engine, notes, _chart, RockMeterPreset.Normal);
+                    break;
+                }
+                case GameMode.FourLaneDrums:
+                case GameMode.FiveLaneDrums:
+                case GameMode.EliteDrums:
+                {
+                    var notes = _chart.GetDrumsTrack(profile.CurrentInstrument)
+                        .GetDifficulty(profile.CurrentDifficulty).Clone();
+                    profile.ApplyModifiers(notes, _chart.SyncTrack);
+                    // TODO: Implement support for custom RockMeterPresets in replays
+                    manager.Register((DrumsEngine)engine, notes, _chart, RockMeterPreset.Normal);
+                    break;
+                }
+                case GameMode.ProKeys:
+                {
+                    if (profile.CurrentInstrument is Instrument.ProKeys) // Pro Keys
+                    {
+                        // Reset the notes
+                        var notes = _chart.ProKeys.GetDifficulty(profile.CurrentDifficulty).Clone();
+                        profile.ApplyModifiers(notes, _chart.SyncTrack);
+                        // TODO: Implement support for custom RockMeterPresets in replays
+                        manager.Register((ProKeysEngine)engine, notes, _chart, RockMeterPreset.Normal);
+                        break;
+                    }
+
+                    // Five-Lane Keys
+                    var fiveLaneNotes = _chart.GetFiveFretTrack(profile.CurrentInstrument)
+                        .GetDifficulty(profile.CurrentDifficulty).Clone();
+                    profile.ApplyModifiers(fiveLaneNotes, _chart.SyncTrack);
+                    manager.Register((FiveLaneKeysEngine)engine, fiveLaneNotes, _chart, RockMeterPreset.Normal);
+                    break;
+                }
+                case GameMode.Vocals:
+                {
+                    // Get the notes
+                    var notes = _chart.GetVocalsTrack(profile.CurrentInstrument)
+                        .Parts[profile.HarmonyIndex].Clone();
+                    profile.ApplyVocalModifiers(notes);
+                    manager.Register((VocalsEngine)engine, notes.CloneAsInstrumentDifficulty(), _chart, RockMeterPreset.Normal);
+                    break;
+                }
+                default:
+                    throw new InvalidOperationException("Game mode not configured!");
+            }
         }
 
         private BaseEngine CreateEngine(YargProfile profile, BaseEngineParameters parameters)


### PR DESCRIPTION
We also store an `InstrumentDifficulty<TNoteType>` now, instead of separate Instrument and Difficulty members (though we still expose these through an auto-property for convenience). This has the benefit of `GetUnisonSections` using the note chart the engine uses, instead of the original note chart, preserving any modifications made by modifiers.

We pass in all three parameters the engine requires (note, params, stats) instead of a note/engine pair because it allows us to use anything in `BaseEngine.Generic.cs`, including a bunch of events (e.g. `OnNoteHit`) that we would otherwise not be able to use without manual type checks. This saves us a bunch of boilerplate in event subscriptions, for example (though we still need some, e.g. because of `OnOverhit`/`OnOverstrum`, and vocals-specific events).

Unfortunately a fair bit of boilerplate had to be added to ReplayAnalyzer since it can't really use generics easily.

Requires YARC-Official/YARG#1560.