### PR TITLE
feat: add preset preview color profile support

### DIFF
--- a/YARG.Core.UnitTests/Engine/ProKeysUtilitiesTests.cs
+++ b/YARG.Core.UnitTests/Engine/ProKeysUtilitiesTests.cs
@@ -1,10 +1,44 @@
 using NUnit.Framework;
 using YARG.Core.Engine.Keys;
 
+// pattern: Functional Core
+
 namespace YARG.Core.UnitTests.Engine;
 
 public class ProKeysUtilitiesTests
 {
+    [TestCase(false, 0, 0)]
+    [TestCase(true, 0, 1)]
+    [TestCase(false, 1, 2)]
+    [TestCase(true, 1, 3)]
+    [TestCase(false, 2, 4)]
+    [TestCase(false, 3, 5)]
+    [TestCase(true, 2, 6)]
+    [TestCase(false, 4, 7)]
+    [TestCase(true, 3, 8)]
+    [TestCase(false, 5, 9)]
+    [TestCase(true, 4, 10)]
+    [TestCase(false, 6, 11)]
+    [TestCase(false, 7, 12)]
+    [TestCase(true, 5, 13)]
+    [TestCase(false, 8, 14)]
+    [TestCase(true, 6, 15)]
+    [TestCase(false, 9, 16)]
+    public void GetKeyIndexForColor_UsesTheLowCWindow(bool black, int colorIndex, int expected)
+    {
+        Assert.That(ProKeysUtilities.GetKeyIndexForColor(black, colorIndex), Is.EqualTo(expected));
+    }
+
+    [TestCase(false, -1)]
+    [TestCase(false, ProKeysUtilities.WHITE_KEY_COUNT)]
+    [TestCase(true, -1)]
+    [TestCase(true, ProKeysUtilities.BLACK_KEY_COUNT)]
+    public void GetKeyIndexForColor_RejectsInvalidColorIndex(bool black, int colorIndex)
+    {
+        Assert.That(() => ProKeysUtilities.GetKeyIndexForColor(black, colorIndex),
+            Throws.TypeOf<ArgumentOutOfRangeException>());
+    }
+
     [TestCase(ProKeysUtilities.LOW_C, false)]
     [TestCase(ProKeysUtilities.LOW_C_SHARP, true)]
     [TestCase(ProKeysUtilities.LOW_D, false)]

--- a/YARG.Core.UnitTests/Game/ColorProfileTests.cs
+++ b/YARG.Core.UnitTests/Game/ColorProfileTests.cs
@@ -1,0 +1,44 @@
+// pattern: Imperative Shell
+
+using System.Drawing;
+using System.IO;
+using System.Text;
+using NUnit.Framework;
+using YARG.Core.Game;
+
+namespace YARG.Core.UnitTests.Game;
+
+public class ColorProfileTests
+{
+    [Test]
+    public void BinarySerialization_PreservesFiveFretGuitarAppearanceFields()
+    {
+        var source = new ColorProfile("Source");
+        source.FiveFretGuitar.TapStripEmission = 37.5f;
+        source.FiveFretGuitar.OpenHopoNote = Color.FromArgb(255, 12, 34, 56);
+        source.FiveFretGuitar.OpenHopoNoteStarPower = Color.FromArgb(255, 78, 90, 12);
+
+        using var stream = new MemoryStream();
+        using (var writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            source.Serialize(writer);
+        }
+
+        stream.Position = 0;
+        var restored = new ColorProfile("Restored");
+        using (var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true))
+        {
+            restored.Deserialize(reader);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(restored.FiveFretGuitar.TapStripEmission,
+                Is.EqualTo(source.FiveFretGuitar.TapStripEmission));
+            Assert.That(restored.FiveFretGuitar.OpenHopoNote,
+                Is.EqualTo(source.FiveFretGuitar.OpenHopoNote));
+            Assert.That(restored.FiveFretGuitar.OpenHopoNoteStarPower,
+                Is.EqualTo(source.FiveFretGuitar.OpenHopoNoteStarPower));
+        }
+    }
+}

--- a/YARG.Core/Engine/Keys/ProKeys/ProKeysUtilities.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/ProKeysUtilities.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 
+// pattern: Functional Core
+
 namespace YARG.Core.Engine.Keys
 {
     public static class ProKeysUtilities
@@ -33,6 +35,50 @@ namespace YARG.Core.Engine.Keys
         public static bool IsWhiteKey(int noteIndex)
         {
             return !IsBlackKey(noteIndex);
+        }
+
+        public const int WHITE_KEY_COUNT = 10;
+        public const int BLACK_KEY_COUNT = 7;
+
+        /// <summary>
+        /// Returns a key index from the 17-key window starting at low C for the
+        /// requested key color and zero-based color index.
+        /// </summary>
+        public static int GetKeyIndexForColor(bool black, int colorIndex)
+        {
+            int colorCount = black ? BLACK_KEY_COUNT : WHITE_KEY_COUNT;
+            if (colorIndex < 0 || colorIndex >= colorCount)
+            {
+                throw new ArgumentOutOfRangeException(nameof(colorIndex), colorIndex,
+                    "The color index must be within the low-C key window.");
+            }
+
+            return black
+                ? colorIndex switch
+                {
+                    0 => 1,
+                    1 => 3,
+                    2 => 6,
+                    3 => 8,
+                    4 => 10,
+                    5 => 13,
+                    6 => 15,
+                    _ => throw new ArgumentOutOfRangeException(nameof(colorIndex), colorIndex, null)
+                }
+                : colorIndex switch
+                {
+                    0 => 0,
+                    1 => 2,
+                    2 => 4,
+                    3 => 5,
+                    4 => 7,
+                    5 => 9,
+                    6 => 11,
+                    7 => 12,
+                    8 => 14,
+                    9 => 16,
+                    _ => throw new ArgumentOutOfRangeException(nameof(colorIndex), colorIndex, null)
+                };
         }
 
         /// <return>

--- a/YARG.Core/Game/Presets/ColorProfile.FiveFretGuitar.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FiveFretGuitar.cs
@@ -11,6 +11,20 @@ namespace YARG.Core.Game
     {
         public class FiveFretGuitarColors : IFretColorProvider, IBinarySerializable
         {
+            #region Note Appearance
+
+            /// <summary>
+            /// Emission intensity for the center strip of tap notes, as a
+            /// percentage (0–100). At 0 the strip appears dark (no emission
+            /// glow); at 100 it has full emission. Internally normalized to
+            /// 0.0–1.0 when applied as a material emission multiplier.
+            /// </summary>
+            [SettingType(SettingType.Slider)]
+            [SettingRange(0f, 100f)]
+            public float TapStripEmission = 0f;
+
+            #endregion
+
             #region Frets
 
             public Color OpenFret   = DefaultPurple;
@@ -125,6 +139,14 @@ namespace YARG.Core.Game
             public Color BlueNoteStarPower     = DefaultStarpower;
             public Color OrangeNoteStarPower   = DefaultStarpower;
 
+            // Open HOPO notes have EmissionAddition: 1 on their model material,
+            // which washes any color to white. The dedicated field lets users
+            // control this independently; ResetEmissionAddition in NoteGroup
+            // nullifies the addition so the color is visible. Default is white
+            // to match the existing appearance.
+            public Color OpenHopoNote          = DefaultStarpower;
+            public Color OpenHopoNoteStarPower = DefaultStarpower;
+
             /// <summary>
             /// Gets the Star Power note color for a specific note index.
             /// 1 = green, 5 = orange.
@@ -208,6 +230,10 @@ namespace YARG.Core.Game
                 writer.Write(YellowNoteStarPower);
                 writer.Write(BlueNoteStarPower);
                 writer.Write(OrangeNoteStarPower);
+
+                writer.Write(TapStripEmission);
+                writer.Write(OpenHopoNote);
+                writer.Write(OpenHopoNoteStarPower);
             }
 
             public void Deserialize(BinaryReader reader, int version = 0)
@@ -246,6 +272,13 @@ namespace YARG.Core.Game
                 YellowNoteStarPower = reader.ReadColor();
                 BlueNoteStarPower = reader.ReadColor();
                 OrangeNoteStarPower = reader.ReadColor();
+
+                if (version >= 2)
+                {
+                    TapStripEmission = reader.ReadSingle();
+                    OpenHopoNote = reader.ReadColor();
+                    OpenHopoNoteStarPower = reader.ReadColor();
+                }
             }
 
             #endregion

--- a/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using YARG.Core.Chart;
 using YARG.Core.Extensions;
+using YARG.Core.Game.Settings;
 using YARG.Core.Utility;
 
 namespace YARG.Core.Game
@@ -232,6 +233,20 @@ namespace YARG.Core.Game
 
             #endregion
 
+            #region Note Appearance
+
+            /// <summary>
+            /// Emission intensity for the center strip of ghost/grace notes, as a
+            /// percentage (0–100). At 0 the strip appears dark (no emission
+            /// glow); at 100 it has full emission. Internally normalized to
+            /// 0.0–1.0 when applied as a material emission multiplier.
+            /// </summary>
+            [SettingType(SettingType.Slider)]
+            [SettingRange(0f, 100f)]
+            public float GhostStripEmission = 0f;
+
+            #endregion
+
             #region Metal
 
             public Color Metal          = DefaultMetal;
@@ -312,6 +327,8 @@ namespace YARG.Core.Game
                 writer.Write(DoubleKickNote);
                 writer.Write(DoubleKickStarpower);
                 writer.Write(DoubleKickActivationNote);
+
+                writer.Write(GhostStripEmission);
             }
 
             public void Deserialize(BinaryReader reader, int version = 0)
@@ -368,6 +385,11 @@ namespace YARG.Core.Game
                 DoubleKickNote = reader.ReadColor();
                 DoubleKickStarpower = reader.ReadColor();
                 DoubleKickActivationNote = reader.ReadColor();
+
+                if (version >= 2)
+                {
+                    GhostStripEmission = reader.ReadSingle();
+                }
             }
 
             #endregion

--- a/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using YARG.Core.Chart;
 using YARG.Core.Extensions;
+using YARG.Core.Game.Settings;
 using YARG.Core.Utility;
 
 namespace YARG.Core.Game
@@ -295,6 +296,20 @@ namespace YARG.Core.Game
                 };
             }
 
+            #region Note Appearance
+
+            /// <summary>
+            /// Emission intensity for the center strip of ghost/grace notes, as a
+            /// percentage (0–100). At 0 the strip appears dark (no emission
+            /// glow); at 100 it has full emission. Internally normalized to
+            /// 0.0–1.0 when applied as a material emission multiplier.
+            /// </summary>
+            [SettingType(SettingType.Slider)]
+            [SettingRange(0f, 100f)]
+            public float GhostStripEmission = 0f;
+
+            #endregion
+
             #region Metal
 
             public Color Metal          = DefaultMetal;
@@ -403,6 +418,7 @@ namespace YARG.Core.Game
                 writer.Write(DoubleKickStarpower);
                 writer.Write(DoubleKickActivationNote);
 
+                writer.Write(GhostStripEmission);
             }
 
             public void Deserialize(BinaryReader reader, int version = 0)
@@ -483,6 +499,11 @@ namespace YARG.Core.Game
                 DoubleKickNote = reader.ReadColor();
                 DoubleKickStarpower = reader.ReadColor();
                 DoubleKickActivationNote = reader.ReadColor();
+
+                if (version >= 2)
+                {
+                    GhostStripEmission = reader.ReadSingle();
+                }
             }
 
             #endregion

--- a/YARG.Core/Game/Presets/ColorProfile.cs
+++ b/YARG.Core/Game/Presets/ColorProfile.cs
@@ -8,7 +8,7 @@ namespace YARG.Core.Game
 {
     public partial class ColorProfile : BasePreset, IBinarySerializable
     {
-        private const int COLOR_PROFILE_VERSION = 1;
+        private const int COLOR_PROFILE_VERSION = 2;
 
         /// <summary>
         /// Interface that has methods that allows for generic fret color retrieval.


### PR DESCRIPTION
### Summary

Adds persistent color-profile fields for tap-strip and ghost-strip emission and dedicated open-HOPO colors. Adds the Pro Keys low-C key-position mapping used by the Unity preview to select white and black notes by color class.

### Why

The preset editor exposes these values, but profiles need Core fields and binary persistence before customized settings can survive a save/load cycle. The Pro Keys preview also needs a shared mapping for its ten white-key and seven black-key positions.

### Design

- New profile fields default to the existing visual behavior.
- The color-profile binary version advances from 1 to 2. New values are written by version 2 profiles and read only when the version supports them; older profiles retain defaults.
- `GetKeyIndexForColor` maps the 17-key low-C window to a zero-based white- or black-key color index and rejects invalid indices.
- The Core changes are additive and have no observable effect until the Unity preview/editor consumes the new fields.

### Changes

| File | Change |
|------|--------|
| `YARG.Core/Game/Presets/ColorProfile.cs` | Bump the color-profile binary version to 2. |
| `YARG.Core/Game/Presets/ColorProfile.FiveFretGuitar.cs` | Persist `TapStripEmission`, `OpenHopoNote`, and `OpenHopoNoteStarPower`. |
| `YARG.Core/Game/Presets/ColorProfile.FourLaneDrums.cs` | Persist `GhostStripEmission`. |
| `YARG.Core/Game/Presets/ColorProfile.FiveLaneDrums.cs` | Persist `GhostStripEmission`. |
| `YARG.Core/Engine/Keys/ProKeys/ProKeysUtilities.cs` | Add low-C white/black key counts and color-index mapping. |
| `YARG.Core.UnitTests/Game/ColorProfileTests.cs` | Verify binary round-tripping of the new guitar fields. |
| `YARG.Core.UnitTests/Engine/ProKeysUtilitiesTests.cs` | Verify valid and invalid Pro Keys color-index mappings. |

### Notes

- This PR is necessary for the Unity side PR for feat/preset-preview to work.
- Existing profiles remain readable because the new fields are version-gated and default-compatible.
- The new fields are profile data, not replay data; replay format compatibility is unchanged.

### Testing done

`dotnet test YARG.Core.UnitTests/YARG.Core.UnitTests.csproj --nologo -v minimal`: 443 passed, 2 skipped, 0 failed.
