### PR TITLE
Fix pro keys single chord solo leak

### DIFF
--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -507,6 +507,11 @@ namespace YARG.Core.Engine
                 EndCoda();
             }
 
+            if (note.IsSolo)
+            {
+                HandleSoloNote(note);
+            }
+
             if (note.ParentOrSelf.WasFullyHitOrMissed())
             {
                 AdvanceToNextNote(note);
@@ -589,6 +594,11 @@ namespace YARG.Core.Engine
             if (CodaHasStarted && ChordHasCodaEnd(note) && note.ParentOrSelf.WasFullyHitOrMissed())
             {
                 EndCoda();
+            }
+
+            if (note.IsSolo)
+            {
+                HandleSoloNote(note);
             }
 
             if (note.ParentOrSelf.WasFullyHitOrMissed())
@@ -795,6 +805,29 @@ namespace YARG.Core.Engine
             }
 
             UpdateStars();
+        }
+
+        protected void HandleSoloNote(TNoteType note)
+        {
+            if (!note.IsSolo)
+            {
+                return;
+            }
+
+            if (note.IsSoloStart)
+            {
+                StartSolo();
+            }
+
+            if (note.WasHit)
+            {
+                Solos[CurrentSoloIndex].NotesHit++;
+            }
+
+            if (note.IsSoloEnd && note.ParentOrSelf.WasFullyHitOrMissed())
+            {
+                EndSolo();
+            }
         }
 
         protected virtual void UpdateSustains()

--- a/YARG.Core/Engine/Drums/DrumsEngine.cs
+++ b/YARG.Core/Engine/Drums/DrumsEngine.cs
@@ -185,21 +185,6 @@ namespace YARG.Core.Engine.Drums
                 }
             }
 
-            if (note.IsSoloStart)
-            {
-                StartSolo();
-            }
-
-            if (IsSoloActive)
-            {
-                Solos[CurrentSoloIndex].NotesHit++;
-            }
-
-            if (note.IsSoloEnd && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                EndSolo();
-            }
-
             if (!activationAutoHit && note.IsStarPowerActivator && CanStarPowerActivate && IsActivationComplete(note))
             {
                 ActivateStarPower();
@@ -351,30 +336,6 @@ namespace YARG.Core.Engine.Drums
             if (note.IsStarPower)
             {
                 StripStarPower(note);
-            }
-
-            if (note is { IsSoloStart: true, IsSoloEnd: true } && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                // While a solo is active, end the current solo and immediately start the next.
-                if (IsSoloActive)
-                {
-                    EndSolo();
-                    StartSolo();
-                }
-                else
-                {
-                    // If no solo is currently active, start and immediately end the solo.
-                    StartSolo();
-                    EndSolo();
-                }
-            }
-            else if (note.IsSoloEnd && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                EndSolo();
-            }
-            else if (note.IsSoloStart)
-            {
-                StartSolo();
             }
 
             ResetCombo();

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -267,21 +267,6 @@ namespace YARG.Core.Engine.Guitar
                 }
             }
 
-            if (note.IsSoloStart)
-            {
-                StartSolo();
-            }
-
-            if (IsSoloActive)
-            {
-                Solos[CurrentSoloIndex].NotesHit++;
-            }
-
-            if (note.IsSoloEnd)
-            {
-                EndSolo();
-            }
-
             IncrementCombo();
 
             EngineStats.IncrementNotesHit(note, CurrentTime);
@@ -335,29 +320,6 @@ namespace YARG.Core.Engine.Guitar
             if (note.IsStarPower)
             {
                 StripStarPower(note);
-            }
-
-            // Solo has the start and end flag
-            if(note is { IsSoloStart: true, IsSoloEnd: true })
-            {
-                // While a solo is active, end the current solo and immediately start the next.
-                if (IsSoloActive)
-                {
-                    EndSolo();
-                    StartSolo();
-                }
-                else
-                {
-                    // If no solo is currently active, start and immediately end the solo.
-                    StartSolo();
-                    EndSolo();
-                }
-            } else if(note.IsSoloEnd)
-            {
-                EndSolo();
-            } else if (note.IsSoloStart)
-            {
-                StartSolo();
             }
 
             WasNoteGhosted = false;

--- a/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
@@ -82,21 +82,6 @@ namespace YARG.Core.Engine.Keys
                 EngineStats.StarPowerPhrasesHit++;
             }
 
-            if (note.IsSoloStart)
-            {
-                StartSolo();
-            }
-
-            if (IsSoloActive)
-            {
-                Solos[CurrentSoloIndex].NotesHit++;
-            }
-
-            if (note.IsSoloEnd && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                EndSolo();
-            }
-
             if (note.ParentOrSelf.WasFullyHit())
             {
                 ChordStaggerTimer.Disable(CurrentTime, early: true);
@@ -150,30 +135,6 @@ namespace YARG.Core.Engine.Keys
             if (note.IsStarPower)
             {
                 StripStarPower(note);
-            }
-
-            if (note is { IsSoloStart: true, IsSoloEnd: true } && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                // While a solo is active, end the current solo and immediately start the next.
-                if (IsSoloActive)
-                {
-                    EndSolo();
-                    StartSolo();
-                }
-                else
-                {
-                    // If no solo is currently active, start and immediately end the solo.
-                    StartSolo();
-                    EndSolo();
-                }
-            }
-            else if (note.IsSoloEnd && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                EndSolo();
-            }
-            else if (note.IsSoloStart)
-            {
-                StartSolo();
             }
 
             // If no notes within a chord were hit, combo is 0

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -208,8 +208,13 @@ namespace YARG.Core.Engine.Keys
                 StripStarPower(note);
             }
 
-            if (note is { IsSoloStart: true, IsSoloEnd: true } && note.ParentOrSelf.WasFullyHitOrMissed())
+            if (note is { IsSoloStart: true, IsSoloEnd: true })
             {
+                if (!note.ParentOrSelf.WasFullyHitOrMissed())
+                {
+                    // If the note hasn't been fully hit or missed, just eat the event until it is
+                    return;
+                }
                 // While a solo is active, end the current solo and immediately start the next.
                 if (IsSoloActive)
                 {

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -115,21 +115,6 @@ namespace YARG.Core.Engine.Keys
                 }
             }
 
-            if (note.IsSoloStart)
-            {
-                StartSolo();
-            }
-
-            if (IsSoloActive)
-            {
-                Solos[CurrentSoloIndex].NotesHit++;
-            }
-
-            if (note.IsSoloEnd && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                EndSolo();
-            }
-
             if (note.ParentOrSelf.WasFullyHit())
             {
                 ChordStaggerTimer.Disable(CurrentTime, early: true);
@@ -206,35 +191,6 @@ namespace YARG.Core.Engine.Keys
             if (note.IsStarPower)
             {
                 StripStarPower(note);
-            }
-
-            if (note is { IsSoloStart: true, IsSoloEnd: true })
-            {
-                if (!note.ParentOrSelf.WasFullyHitOrMissed())
-                {
-                    // If the note hasn't been fully hit or missed, just eat the event until it is
-                    return;
-                }
-                // While a solo is active, end the current solo and immediately start the next.
-                if (IsSoloActive)
-                {
-                    EndSolo();
-                    StartSolo();
-                }
-                else
-                {
-                    // If no solo is currently active, start and immediately end the solo.
-                    StartSolo();
-                    EndSolo();
-                }
-            }
-            else if (note.IsSoloEnd && note.ParentOrSelf.WasFullyHitOrMissed())
-            {
-                EndSolo();
-            }
-            else if (note.IsSoloStart)
-            {
-                StartSolo();
             }
 
             if (note.IsGlissandoStart)

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -144,20 +144,7 @@ namespace YARG.Core.Engine.Vocals
                     EngineStats.StarPowerPhrasesHit++;
                 }
 
-                if (note.IsSoloStart)
-                {
-                    StartSolo();
-                }
-
-                if (IsSoloActive)
-                {
-                    Solos[CurrentSoloIndex].NotesHit++;
-                }
-
-                if (note.IsSoloEnd)
-                {
-                    EndSolo();
-                }
+                HandleSoloNote(note);
 
                 // If there aren't any ticks in the phrase, then don't add
                 // any score or update the multiplier.
@@ -204,14 +191,7 @@ namespace YARG.Core.Engine.Vocals
                 StripStarPower(note);
             }
 
-            if (note.IsSoloEnd)
-            {
-                EndSolo();
-            }
-            if (note.IsSoloStart)
-            {
-                StartSolo();
-            }
+            HandleSoloNote(note);
 
             ResetCombo();
 


### PR DESCRIPTION
I vaguely feel like there might also be issues with the way pro keys solos are handled in HitNote, but it doesn't seem to be causing issues, so I guess it's fine.

The problem was the essentially the code for when a note has both a solo start and end flag on it would only trigger if the note had also been fully hit or missed, so instead for the first few notes of a chord it would fall back to the normal solo start/end which caused the next solo to be started when it should not have.