### PR TITLE
fix(ultrastar): percussion flag, BPM sync, duet solo, freestyle pitch, and melisma continuation

### DIFF
--- a/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.Basic.cs
+++ b/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.Basic.cs
@@ -1,4 +1,5 @@
 ﻿using NUnit.Framework;
+using YARG.Core.Chart;
 
 namespace YARG.Core.UnitTests.Parsing;
 
@@ -27,7 +28,8 @@ internal class UltraStarLoaderTests_Basic : UltraStarLoaderTests
         ));
 
         var syncTrack = loader.LoadSyncTrack();
-        Assert.That(syncTrack.Tempos[0].BeatsPerMinute, Is.EqualTo(140f));
+        // UltraStar BPM is halved for SyncTrack (beatlines/crowd clapping)
+        Assert.That(syncTrack.Tempos[0].BeatsPerMinute, Is.EqualTo(70f));
     }
 
     [Test]
@@ -39,7 +41,8 @@ internal class UltraStarLoaderTests_Basic : UltraStarLoaderTests
         ));
 
         var syncTrack = loader.LoadSyncTrack();
-        Assert.That(syncTrack.Tempos[0].BeatsPerMinute, Is.EqualTo(120.5f));
+        // UltraStar BPM is halved for SyncTrack
+        Assert.That(syncTrack.Tempos[0].BeatsPerMinute, Is.EqualTo(60.25f));
     }
 
     [Test]
@@ -156,14 +159,69 @@ internal class UltraStarLoaderTests_Basic : UltraStarLoaderTests
     {
         var loader = LoadUltraStar(Us(
             "#BPM:120",
-            "F 0 4 -1 Scream"
+            "F 0 4 3 Scream"
         ));
 
         var track = loader.LoadVocalsTrack(Instrument.Vocals);
         var note = track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
 
-        // Freestyle should be unpitched (-1)
-        Assert.That(note.IsNonPitched, Is.True);
+        // Freestyle now keeps real MIDI pitch (like SingStar): 3 + 60 = 63
+        Assert.That(note.IsNonPitched, Is.False);
+        Assert.That(note.Pitch, Is.EqualTo(63f));
+    }
+
+    [Test]
+    public void FreestyleNoteIsNotPercussion()
+    {
+        // Bug fix: freestyle (F) notes must be VocalNoteType.Lyric, not Percussion
+        var loader = LoadUltraStar(Us(
+            "#BPM:120",
+            "F 0 4 3 Scream"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var note = track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        Assert.That(note.Type, Is.EqualTo(VocalNoteType.Lyric));
+        Assert.That(note.IsPercussion, Is.False);
+        // Freestyle keeps real MIDI pitch (like SingStar)
+        Assert.That(note.Pitch, Is.EqualTo(63f));
+    }
+
+    [Test]
+    public void RapNoteIsNotPercussion()
+    {
+        // Bug fix: rap (R) notes must be VocalNoteType.Lyric, not Percussion
+        var loader = LoadUltraStar(Us(
+            "#BPM:120",
+            "R 0 4 5 RapBar"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var note = track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        Assert.That(note.Type, Is.EqualTo(VocalNoteType.Lyric));
+        Assert.That(note.IsPercussion, Is.False);
+        // Rap keeps real MIDI pitch (like SingStar): 5 + 60 = 65
+        Assert.That(note.Pitch, Is.EqualTo(65f));
+    }
+
+    [Test]
+    public void GoldenFreestyleIsNotPercussion()
+    {
+        // Bug fix: golden freestyle (G) notes must be VocalNoteType.Lyric, not Percussion
+        var loader = LoadUltraStar(Us(
+            "#BPM:120",
+            "G 0 4 7 GoldenScream"
+        ));
+
+        var track = loader.LoadVocalsTrack(Instrument.Vocals);
+        var note = track.Parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        Assert.That(note.Type, Is.EqualTo(VocalNoteType.Lyric));
+        Assert.That(note.IsPercussion, Is.False);
+        // Golden freestyle keeps real MIDI pitch (like SingStar): 7 + 60 = 67
+        Assert.That(note.Pitch, Is.EqualTo(67f));
     }
 
     [Test]

--- a/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.Duet.cs
+++ b/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.Duet.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Text;
+using NUnit.Framework;
+using YARG.Core.Chart;
 
 namespace YARG.Core.UnitTests.Parsing
 {
@@ -175,6 +177,64 @@ namespace YARG.Core.UnitTests.Parsing
             Assert.That(track.Parts[1].NotePhrases[0].IsStarPower, Is.False);
             Assert.That(track.Parts[1].NotePhrases[1].IsStarPower, Is.False);
             Assert.That(track.Parts[1].NotePhrases[2].IsStarPower, Is.False);
+        }
+
+        [Test]
+        public void DuetSoloVocalsOnlyShowsFirstPart()
+        {
+            // Bug fix: when duet, solo Vocals chart should only contain P1
+            var content = Us(
+                "#BPM:120",
+                "#PARTS:2",
+                "P1",
+                ": 0 4 0 Hello",
+                ": 5 4 0 World",
+                "P2",
+                ": 0 4 2 Hi",
+                ": 5 4 2 There"
+            );
+            var settings = ParseSettings.Default;
+            var songChart = SongChart.FromUltraStarBytes(settings, Encoding.UTF8.GetBytes(content));
+
+            // Solo Vocals should only have P1 notes (Hello, World)
+            var vocalsTrack = songChart.Vocals;
+            Assert.That(vocalsTrack.Parts, Has.Count.EqualTo(1));
+
+            var lyrics = new List<string>();
+            foreach (var phrase in vocalsTrack.Parts[0].NotePhrases)
+            {
+                foreach (var lyric in phrase.Lyrics)
+                {
+                    lyrics.Add(lyric.Text);
+                }
+            }
+
+            Assert.That(lyrics, Contains.Item("Hello"));
+            Assert.That(lyrics, Contains.Item("World"));
+            Assert.That(lyrics, Does.Not.Contain("Hi"));
+            Assert.That(lyrics, Does.Not.Contain("There"));
+        }
+
+        [Test]
+        public void DuetHarmonyHasBothParts()
+        {
+            // Both parts should still be available in Harmony tracks
+            var content = Us(
+                "#BPM:120",
+                "#PARTS:2",
+                "P1",
+                ": 0 4 0 Hello",
+                "P2",
+                ": 0 4 2 Hi"
+            );
+            var settings = ParseSettings.Default;
+            var songChart = SongChart.FromUltraStarBytes(settings, Encoding.UTF8.GetBytes(content));
+
+            // Harmony track loads 3 parts from MoonSong (HARM1, HARM2, HARM3)
+            // For UltraStar duet, HARM3 is empty
+            var harmonyTrack = songChart.Harmony;
+            Assert.That(harmonyTrack.Parts[0].NotePhrases, Has.Count.EqualTo(1));
+            Assert.That(harmonyTrack.Parts[1].NotePhrases, Has.Count.EqualTo(1));
         }
     }
 }

--- a/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.Lyrics.cs
+++ b/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.Lyrics.cs
@@ -54,6 +54,43 @@ namespace YARG.Core.UnitTests.Parsing
         }
 
         [Test]
+        public void MelismaJoinAppendsHyphenToLyric()
+        {
+            // ni ~ght. should display as "ni-ght." with JoinWithNext on "ni-"
+            var loader = LoadUltraStar(Us(
+                "#BPM:120",
+                ": 0 4 0 ni",
+                ": 5 4 2 ~ght."
+            ));
+
+            var track = loader.LoadVocalsTrack(Instrument.Vocals);
+            var lyrics = track.Parts[0].NotePhrases[0].Lyrics;
+
+            Assert.That(lyrics, Has.Count.EqualTo(2));
+            Assert.That(lyrics[0].Text, Is.EqualTo("ni-"));
+            Assert.That(lyrics[0].JoinWithNext, Is.True);
+            Assert.That(lyrics[1].Text, Does.Contain("ght."));
+        }
+
+        [Test]
+        public void MelismaJoinInLyricsTrack()
+        {
+            var loader = LoadUltraStar(Us(
+                "#BPM:120",
+                ": 0 4 0 ni",
+                ": 5 4 2 ~ght."
+            ));
+
+            var lyricsTrack = loader.LoadLyrics();
+            var events = lyricsTrack.Phrases[0].Lyrics;
+
+            Assert.That(events, Has.Count.EqualTo(2));
+            Assert.That(events[0].Text, Is.EqualTo("ni-"));
+            Assert.That(events[0].JoinWithNext, Is.True);
+            Assert.That(events[1].Text, Does.Contain("ght."));
+        }
+
+        [Test]
         public void ParseHyphenJoinWithNext()
         {
             var loader = LoadUltraStar(Us(

--- a/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.StarPower.cs
+++ b/YARG.Core.UnitTests/Parsing/UltraStarLoader/UltraStarLoaderTests.StarPower.cs
@@ -31,8 +31,9 @@ namespace YARG.Core.UnitTests.Parsing
             var phrase = track.Parts[0].NotePhrases[0];
             var note = phrase.PhraseParentNote.ChildNotes[0];
 
-            // Golden Rap is unpitched and golden
-            Assert.That(note.IsNonPitched, Is.True);
+            // Golden Rap keeps real MIDI pitch (like SingStar): -1 + 60 = 59
+            Assert.That(note.IsNonPitched, Is.False);
+            Assert.That(note.Pitch, Is.EqualTo(59f));
             Assert.That(phrase.IsStarPower, Is.True);
         }
 

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.UltraStar.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.UltraStar.cs
@@ -55,12 +55,15 @@ namespace YARG.Core.Chart
 
                     foreach (var child in parent.ChildNotes)
                     {
-                        if (child.Type != VocalNoteType.Lyric)
+                        if (child.Type != VocalNoteType.Lyric && child.Type != VocalNoteType.Percussion)
                         {
                             continue;
                         }
 
-                        var flags = child.IsNonPitched ? MoonNote.Flags.Vocals_Percussion : MoonNote.Flags.None;
+                        // UltraStar freestyle (F), rap (R), and golden freestyle (G) notes are
+                        // unpitched lyrical notes, NOT percussion. Keep as None so they stay
+                        // VocalNoteType.Lyric downstream.
+                        var flags = MoonNote.Flags.None;
 
                         int rawNote = child.IsNonPitched ? 0 : (int) child.Pitch;
 
@@ -90,7 +93,7 @@ namespace YARG.Core.Chart
 
             foreach (var p in allPhrasesList.OrderBy(p => p.tick))
             {
-                chart.Add(p); 
+                chart.Add(p);
             }
 
             var uniqueText = allText
@@ -139,7 +142,12 @@ namespace YARG.Core.Chart
 
             if (vocalTrack.Parts.Count > 0)
             {
-                AddPartToChart(vocalTrack.Parts, soloChart);
+                // For duet, only show first part in solo Vocals chart.
+                // Both parts are still available separately in Harmony1/Harmony2.
+                var soloParts = isDuet
+                    ? new List<VocalsPart> { vocalTrack.Parts[0] }
+                    : vocalTrack.Parts;
+                AddPartToChart(soloParts, soloChart);
             }
 
             if (isDuet && vocalTrack.Parts.Count >= 2)

--- a/YARG.Core/Chart/Loaders/UltraStar/UltraStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/UltraStar/UltraStarLoader.cs
@@ -46,7 +46,7 @@ namespace YARG.Core.Chart.Loaders.UltraStar
 
         private class UltraStarNote
         {
-            public int    PartIndex     { get; set; } = 0; 
+            public int    PartIndex     { get; set; } = 0;
             public char   Type          { get; set; }
             public uint   StartBeat     { get; set; }
             public uint   DurationBeats { get; set; }
@@ -125,8 +125,8 @@ namespace YARG.Core.Chart.Loaders.UltraStar
             string value = line[(colon + 1)..].Trim().TrimEnd(',');
             _metadata[key] = value;
 
-            if (key.Equals("BPM", StringComparison.OrdinalIgnoreCase)) 
-            { 
+            if (key.Equals("BPM", StringComparison.OrdinalIgnoreCase))
+            {
                 string norm = value.Replace(',', '.');
                 if (double.TryParse(norm, NumberStyles.Float, CultureInfo.InvariantCulture, out double bpm) && bpm > 0)
                 {
@@ -210,8 +210,8 @@ namespace YARG.Core.Chart.Loaders.UltraStar
 
         private uint BeatToTick(uint beat)
         {
-            uint ticksPerUSBeat = _ticksPerBeat / 4;
-            uint gapTicks = (uint) (_gapMs / 1000.0 * _bpm / 60.0 * _ticksPerBeat);
+            uint ticksPerUSBeat = _ticksPerBeat / 8;
+            uint gapTicks = (uint) (_gapMs / 1000.0 * _bpm);
             return gapTicks + (beat * ticksPerUSBeat);
         }
         private double BeatToTime(uint beat) => beat * 60.0 / _bpm;
@@ -242,8 +242,13 @@ namespace YARG.Core.Chart.Loaders.UltraStar
                 return _syncTrack;
             }
 
+            // UltraStar BPM is typically 2x the real musical BPM.
+            // Halve it for the SyncTrack so beatlines and crowd clapping
+            // fire at the correct rate. Note timing via BeatToTime/BeatToTick
+            // still uses the original _bpm and remains correct because
+            // UltraStar beat positions are also in "double time".
             _syncTrack = new SyncTrack(120,
-                new List<TempoChange> { new(_bpm, -_gapMs / 1000.0, 0u) },
+                new List<TempoChange> { new(_bpm / 2.0, -_gapMs / 1000.0, 0u) },
                 new List<TimeSignatureChange> { new(4, 4, -_gapMs / 1000.0, 0u, 0u, 0u, 0u, 0.0) },
                 new List<Beatline>());
             return _syncTrack;
@@ -279,8 +284,12 @@ namespace YARG.Core.Chart.Loaders.UltraStar
                         continue;
                     }
 
+                    // Freestyle notes get "#" appended (like SingStar)
+                    string lyric = n.IsUnpitched
+                        ? FormatLyric(n.Lyric) + LyricSymbols.NONPITCHED_SYMBOL
+                        : FormatLyric(n.Lyric);
                     var flags = n.IsUnpitched ? LyricSymbolFlags.NonPitched : LyricSymbolFlags.None;
-                    events.Add(new LyricEvent(flags, FormatLyric(n.Lyric),
+                    events.Add(new LyricEvent(flags, lyric,
                         BeatToTime(n.StartBeat), BeatToTick(n.StartBeat)));
                 }
 
@@ -434,7 +443,7 @@ namespace YARG.Core.Chart.Loaders.UltraStar
 
             foreach (var uNote in phraseNotes)
             {
-                uint ticksPerUsBeat = _ticksPerBeat / 4;
+                uint ticksPerUsBeat = _ticksPerBeat / 8;
                 uint noteTick = BeatToTick(uNote.StartBeat);
                 uint noteTickLen = uNote.DurationBeats * ticksPerUsBeat;
                 double noteTime = BeatToTime(uNote.StartBeat);
@@ -443,8 +452,8 @@ namespace YARG.Core.Chart.Loaders.UltraStar
                 bool isUnpitched = uNote.IsUnpitched;
 
                 // Pitch conversion: UltraStar relative → MIDI absolute
-                // Unpitched (freestyle, pitch=-1): pass -1 to VocalNote
-                float midiPitch = isUnpitched ? -1f : ToMidiPitch(uNote.Pitch); 
+                // Freestyle/rap notes keep their real pitch (like SingStar)
+                float midiPitch = ToMidiPitch(uNote.Pitch);
 
                 var childNote = new VocalNote(
                     midiPitch,
@@ -459,8 +468,12 @@ namespace YARG.Core.Chart.Loaders.UltraStar
 
                 if (!string.IsNullOrWhiteSpace(uNote.Lyric))
                 {
+                    // Freestyle notes get "#" appended (like SingStar)
+                    string lyric = isUnpitched
+                        ? FormatLyric(uNote.Lyric) + LyricSymbols.NONPITCHED_SYMBOL
+                        : FormatLyric(uNote.Lyric);
                     var flags = isUnpitched ? LyricSymbolFlags.NonPitched : LyricSymbolFlags.None;
-                    lyrics.Add(new LyricEvent(flags, FormatLyric(uNote.Lyric), noteTime, noteTick)); 
+                    lyrics.Add(new LyricEvent(flags, lyric, noteTime, noteTick));
                 }
             }
 

--- a/YARG.Core/Chart/Loaders/UltraStar/UltraStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/UltraStar/UltraStarLoader.cs
@@ -53,6 +53,13 @@ namespace YARG.Core.Chart.Loaders.UltraStar
             public int    Pitch         { get; set; }
             public string Lyric         { get; set; } = string.Empty;
 
+            /// <summary>
+            /// When true, a hyphen ('-') should be appended to this note's lyric
+            /// and JoinWithNext flag set on its LyricEvent. Set when the NEXT note
+            /// in the phrase has a '~' (melisma continuation) prefix.
+            /// </summary>
+            public bool MelismaJoin { get; set; }
+
             public bool IsGolden    => Type == '*' || Type == 'G';
             public bool IsUnpitched => Type == 'F' || Type == 'R' || Type == 'G';
             public bool IsRest      => Type == '-';
@@ -187,10 +194,28 @@ namespace YARG.Core.Chart.Loaders.UltraStar
             if (lyric.StartsWith("~"))
             {
                 lyric = lyric.Substring(1);
-                if (lyric.Length > 0)
+                bool hasText = lyric.Length > 0;
+                if (hasText)
                     lyric += "+";
                 else
                     lyric = "+";
+
+                // Only mark the previous note with MelismaJoin when the '~'
+                // carries actual text (e.g. ~ght.). A bare '~' is a silent
+                // continuation hold and should NOT add a hyphen to the
+                // previous note's lyric.
+                if (hasText)
+                {
+                    var partNotes = _partNotes[_currentPart];
+                    for (int i = partNotes.Count - 1; i >= 0; i--)
+                    {
+                        if (!partNotes[i].IsRest)
+                        {
+                            partNotes[i].MelismaJoin = true;
+                            break;
+                        }
+                    }
+                }
             }
 
             _partNotes[_currentPart].Add(new UltraStarNote
@@ -289,6 +314,14 @@ namespace YARG.Core.Chart.Loaders.UltraStar
                         ? FormatLyric(n.Lyric) + LyricSymbols.NONPITCHED_SYMBOL
                         : FormatLyric(n.Lyric);
                     var flags = n.IsUnpitched ? LyricSymbolFlags.NonPitched : LyricSymbolFlags.None;
+
+                    // Melisma: append '-' and set JoinWithNext when next note has '~' prefix
+                    if (n.MelismaJoin)
+                    {
+                        lyric += LyricSymbols.LYRIC_JOIN_SYMBOL;
+                        flags |= LyricSymbolFlags.JoinWithNext;
+                    }
+
                     events.Add(new LyricEvent(flags, lyric,
                         BeatToTime(n.StartBeat), BeatToTick(n.StartBeat)));
                 }
@@ -473,6 +506,14 @@ namespace YARG.Core.Chart.Loaders.UltraStar
                         ? FormatLyric(uNote.Lyric) + LyricSymbols.NONPITCHED_SYMBOL
                         : FormatLyric(uNote.Lyric);
                     var flags = isUnpitched ? LyricSymbolFlags.NonPitched : LyricSymbolFlags.None;
+
+                    // Melisma: append '-' and set JoinWithNext when next note has '~' prefix
+                    if (uNote.MelismaJoin)
+                    {
+                        lyric += LyricSymbols.LYRIC_JOIN_SYMBOL;
+                        flags |= LyricSymbolFlags.JoinWithNext;
+                    }
+
                     lyrics.Add(new LyricEvent(flags, lyric, noteTime, noteTick));
                 }
             }


### PR DESCRIPTION
## Summary
Fixes multiple bugs in the UltraStar chart loader, incorrect note type classification, broken BPM sync, duet behavior, and melisma lyric joining
## Changes
- Freestyle (`F`), rap (`R`), and golden freestyle (`G`) notes are now `VocalNoteType.Lyric` with `#` suffix instead of being misclassified as percussion
-  SyncTrack now halves UltraStar BPM (which is 2× real BPM) for correct beatline/crowd clapping timing
- Solo Vocals chart in duets shows only Part 1; both parts accessible via Harmony tracks
- Freestyle notes preserve real MIDI pitch instead of passing `-1`
- Text continuations (e.g. `~ght.`) append `-` to previous lyric with `JoinWithNext`
## Tests
7 new unit tests covering all fixed scenarios. Existing tests updated for corrected BPM and pitch values

## Related
https://discord.com/channels/1086048856678084609/1086048857714069519/1489763890320642139
https://discord.com/channels/1086048856678084609/1488191103680122940
https://discord.com/channels/1086048856678084609/1488189061859381399