### PR TITLE
EngineManager unregistration changes

### DIFF
--- a/YARG.Core/Engine/EngineManager.FailMeter.cs
+++ b/YARG.Core/Engine/EngineManager.FailMeter.cs
@@ -415,6 +415,43 @@ namespace YARG.Core.Engine
                 EngineManager.OnPlayerFailed += OnPlayerFailedReceived;
                 Engine.OnPlayerRevived += OnPlayerRevivedReceived;
             }
+
+            public override void UnsubscribeFromEvents()
+            {
+                base.UnsubscribeFromEvents();
+                // Vocals engine handles hit events differently, so we don't want to subscribe to the note hit/miss events for it
+                if (Engine is not VocalsEngine)
+                {
+                    Engine.OnNoteHit -= OnNoteHit;
+                    Engine.OnNoteMissed -= OnNoteMissed;
+                }
+
+                Engine.OnStarPowerStatus -= OnStarPowerStatus;
+
+                // Overhit/Overstrum events are not in BaseEngine,
+                // so we need to check the type of engine and subscribe to the appropriate event
+                switch (Engine)
+                {
+                    case GuitarEngine guitarEngine:
+                        guitarEngine.OnOverstrum -= OnOverstrum;
+                        break;
+                    case DrumsEngine drumsEngine:
+                        drumsEngine.OnOverhit -= OnOverstrum;
+                        break;
+                    case ProKeysEngine proKeysEngine:
+                        proKeysEngine.OnOverhit -= OnKeysOverhit;
+                        break;
+                    case FiveLaneKeysEngine fiveLaneKeysEngine:
+                        fiveLaneKeysEngine.OnOverhit -= OnKeysOverhit;
+                        break;
+                    case VocalsEngine vocalsEngine:
+                        vocalsEngine.OnPhraseHit -= OnVocalPhraseHit;
+                        break;
+                }
+
+                EngineManager.OnPlayerFailed -= OnPlayerFailedReceived;
+                Engine.OnPlayerRevived -= OnPlayerRevivedReceived;
+            }
         }
     }
 }

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -15,7 +15,7 @@ namespace YARG.Core.Engine
             public double                        TimeEnd             { get; }
             public uint                          Tick                { get; }
             public uint                          TickEnd             { get; }
-            public int                           PartCount           { get; private set; }
+            public int                           PartCount           => ParticipantToPhrase.Count;
             public int                           SuccessCount        { get; private set; }
             public bool                          Awarded             { get; set; }
             public Dictionary<int, UnisonPhrase> ParticipantToPhrase { get; }
@@ -26,7 +26,6 @@ namespace YARG.Core.Engine
                 TimeEnd = timeEnd;
                 Tick = tick;
                 TickEnd = tickEnd;
-                PartCount = 0;
                 SuccessCount = 0;
                 Awarded = false;
                 ParticipantToPhrase = new Dictionary<int, UnisonPhrase>();
@@ -34,20 +33,12 @@ namespace YARG.Core.Engine
 
             public void AddPlayer(EngineContainer engineContainer, UnisonPhrase sourcePhrase)
             {
-                if (!ParticipantToPhrase.TryAdd(engineContainer.EngineId, sourcePhrase))
-                {
-                    return;
-                }
-
-                PartCount++;
+                ParticipantToPhrase[engineContainer.EngineId] = sourcePhrase;
             }
 
             public void RemovePlayer(EngineContainer engineContainer)
             {
-                if (ParticipantToPhrase.Remove(engineContainer.EngineId))
-                {
-                    PartCount--;
-                }
+                ParticipantToPhrase.Remove(engineContainer.EngineId);
             }
 
             // Returns true if all players succesfully completed the unison
@@ -210,12 +201,22 @@ namespace YARG.Core.Engine
 
         private void RemovePlayerFromUnisons(EngineContainer engineContainer)
         {
-            foreach (var unisonEvent in _unisonEvents)
+            for (int i = _unisonEvents.Count - 1; i >= 0; i--)
             {
+                var unisonEvent = _unisonEvents[i];
+                if (unisonEvent.TimeEnd < engineContainer.BaseEngine.CurrentTime)
+                {
+                    // This unison has already passed, don't update it
+                    continue;
+                }
                 unisonEvent.RemovePlayer(engineContainer);
+                if (unisonEvent.PartCount == 0)
+                {
+                    _unisonEvents.RemoveAt(i);
+                }
             }
 
-            engineContainer.UnsubscribeToStarPowerPhraseHit();
+            engineContainer.UnsubscribeFromStarPowerPhraseHit();
         }
 
         /// <summary>
@@ -365,11 +366,14 @@ namespace YARG.Core.Engine
                 YargLogger.LogDebug("Attempted to award bonus SP, but it was already awarded");
                 return;
             }
-            foreach (var id in unison.ParticipantToPhrase.Keys)
+
+            foreach (var engineContainer in _allEngines)
             {
-                YargLogger.LogFormatDebug("EngineManager awarding bonus SP to participant ID {0}", id);
-                var engineContainer = _allEnginesById[id];
-                engineContainer.SendCommand(EngineCommandType.AwardUnisonBonus);
+                if (unison.ParticipantToPhrase.ContainsKey(engineContainer.EngineId))
+                {
+                    YargLogger.LogFormatDebug("EngineManager awarding bonus SP to participant ID {0}", engineContainer.EngineId);
+                    engineContainer.SendCommand(EngineCommandType.AwardUnisonBonus);
+                }
             }
             unison.Awarded = true;
             OnUnisonPhraseSuccess?.Invoke();

--- a/YARG.Core/Engine/EngineManager.cs
+++ b/YARG.Core/Engine/EngineManager.cs
@@ -11,8 +11,6 @@ namespace YARG.Core.Engine
     {
         private int                      _nextEngineIndex;
         List <EngineContainer>           _allEngines     = new();
-        Dictionary<int, EngineContainer> _allEnginesById = new();
-
         public List<EngineContainer> Engines => _allEngines;
 
         private SongChart?               _chart;
@@ -34,14 +32,19 @@ namespace YARG.Core.Engine
                 EngineManager.UpdateStarPowerCount(count);
             }
 
+            public virtual void UnsubscribeFromEvents()
+            {
+                BaseEngine.OnCodaStart -= EngineManager.CodaStartHandler;
+                BaseEngine.OnCodaEnd -= EngineManager.CodaEndHandler;
+            }
+
             public abstract void SendCommand(EngineCommandType command);
             public abstract void UpdateEngine(double time);
             public abstract BaseEngine BaseEngine { get; }
             public abstract Instrument Instrument { get; }
             public abstract Difficulty Difficulty { get; }
             public abstract void SubscribeToStarPowerPhraseHit();
-            public abstract void UnsubscribeToStarPowerPhraseHit();
-
+            public abstract void UnsubscribeFromStarPowerPhraseHit();
             protected EngineContainer(int engineId, int harmonyIndex, EngineManager manager,
                 RockMeterPreset rockMeterPreset, List<UnisonPhrase> unisonPhrases)
             {
@@ -112,7 +115,7 @@ namespace YARG.Core.Engine
                 Engine.OnStarPowerPhraseHit += OnStarPowerPhraseHit;
             }
 
-            public override void UnsubscribeToStarPowerPhraseHit()
+            public override void UnsubscribeFromStarPowerPhraseHit()
             {
                 Engine.OnStarPowerPhraseHit -= OnStarPowerPhraseHit;
             }
@@ -152,24 +155,11 @@ namespace YARG.Core.Engine
             // _previousHappiness = rockMeterPreset.StartingHappiness;
 
             _allEngines.Add(engineContainer);
-            _allEnginesById.Add(engineContainer.EngineId, engineContainer);
             AddPlayerToUnisons(engineContainer, chart);
             engine.OnCodaStart += CodaStartHandler;
             engine.OnCodaEnd += CodaEndHandler;
 
             return engineContainer;
-        }
-
-        private EngineContainer GetEngineContainer(BaseEngine target)
-        {
-            foreach (var engine in _allEngines)
-            {
-                if (engine.BaseEngine == target)
-                {
-                    return engine;
-                }
-            }
-            throw new ArgumentException("Target engine not found");
         }
 
         private void UpdateStarPowerCount(int count)
@@ -183,12 +173,19 @@ namespace YARG.Core.Engine
             }
         }
 
-        public void Reset()
+        /// <summary>
+        /// Resets mutable state - stars, codas, fail meter, band combo, unison event successes.
+        /// </summary>
+        public void ResetState()
         {
             _activeCodaCount = 0;
             _currentStarIndex = 0;
             _previousHappiness = 100f;
             _starpowerCount = 0;
+            _activeCodaCount = 0;
+            _happinessAdjustment = 0f;
+            _lastUpdateTime = 0f;
+            _playerFailed = false;
             // These values are derived from others, so there's no reason to reset them
             // Score = 0; derived from all players' Score + BandBonusScore
             // Stars = 0; derived from Score
@@ -204,6 +201,8 @@ namespace YARG.Core.Engine
             {
                 unisonEvent.Reset();
             }
+
+            //_noFail = false; There should be no instance where we want to reset this
         }
 
         public void UpdateEngines(double time)
@@ -229,7 +228,43 @@ namespace YARG.Core.Engine
         {
             RemovePlayerFromUnisons(engineContainer);
             _allEngines.Remove(engineContainer);
-            _allEnginesById.Remove(engineContainer.EngineId);
+            engineContainer.UnsubscribeFromEvents();
+            RecalculateBandState();
+
+            if (engineContainer.BaseEngine.CodaHasStarted)
+            {
+                _activeCodaCount--;
+            }
+        }
+
+        /// <summary>
+        /// Unregisters all engines, removes all unison events, and resets all game state.
+        /// </summary>
+        public void Reset()
+        {
+            foreach (var engine in _allEngines)
+            {
+                engine.UnsubscribeFromEvents();
+            }
+            _allEngines.Clear();
+            _unisonEvents.Clear();
+            _nextEngineIndex = 0;
+            ResetState();
+        }
+
+        private void RecalculateBandState()
+        {
+            int activeSpCount = 0;
+            for (int i = 0; i < _allEngines.Count; i++)
+            {
+                var engine = _allEngines[i];
+                if (engine.BaseEngine.BaseStats.IsStarPowerActive)
+                    activeSpCount++;
+            }
+
+            UpdateStarPowerCount(activeSpCount);
+            UpdateBandMultiplier();
+            UpdateHappiness();
         }
     }
 }


### PR DESCRIPTION
These changes are in service of the goals to
1. Make EngineManager more capable and reliable when removing engines mid-gameplay
2. Fixing state mismanagement when unregistering and re-registering engines with the same EngineManager instance (practice mode)

To this effect, we now actually unsubscribe from engine events to avoid a memory leak when engines are recreated, unison events are now removed entirely if they have no participants from an unregistration, and there are now some fixes regarding coda and fail meter state when resetting EngineManager state (replay or practice).

Also, `_allEnginesById` is now removed. I don't think it was very useful, and was just extra state to keep track of.

Required by YARC-Official/YARG#1595
