### PR TITLE
Fix glissando notes not autohitting

### DIFF
--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -156,6 +156,29 @@ namespace YARG.Core.Engine.Keys
             base.HitNote(note);
         }
 
+        protected bool AutohitNoteFromGlissando(ProKeysNote note)
+        {
+            // If the note was already hit or missed, don't let the caller attempt to autohit it
+            if (note.WasHit || note.WasMissed)
+            {
+                return false;
+            }
+
+            if (note.Time > LaneAutohitExpireTime)
+            {
+                return false;
+            }
+
+            if (note.IsGlissando)
+            {
+                // Glissandos don't require the first note to be hit accurately, so we can just hit the note and return true
+                HitNote(note);
+                return true;
+            }
+
+            return false;
+        }
+
         protected override void MissNote(ProKeysNote note)
         {
             if (note.WasHit || note.WasMissed)

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/ProKeysEngine.cs
@@ -139,8 +139,6 @@ namespace YARG.Core.Engine.Keys
 
             if (note.IsGlissando)
             {
-                UpdateLaneAutohitExpireTime();
-
                 if (note.IsGlissandoStart)
                 {
                     IsGlissandoActive = true;
@@ -197,14 +195,6 @@ namespace YARG.Core.Engine.Keys
             {
                 // Resolve the whole chord, matching GuitarEngine (see DrumsEngine.MissNote).
                 note.SetHitState(true, true);
-                base.HitNote(note);
-                return;
-            }
-
-            // Autohit glissando notes as long as the player keeps providing inputs
-            if (note.IsGlissando && note.Time < LaneAutohitExpireTime)
-            {
-                note.SetHitState(true, false);
                 base.HitNote(note);
                 return;
             }

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
@@ -184,7 +184,10 @@ namespace YARG.Core.Engine.Keys.Engines
                     {
                         HitNote(childNote);
                     }
-
+                    if (parentNote.IsGlissando)
+                    {
+                        UpdateLaneAutohitExpireTime();
+                    }
                     KeyHitThisUpdate = null;
                 }
                 else
@@ -203,6 +206,10 @@ namespace YARG.Core.Engine.Keys.Engines
                                 if ((KeyMask & note.DisjointMask) == note.DisjointMask && IsKeyInTime(note, frontEnd))
                                 {
                                     HitNote(note);
+                                    if (note.IsGlissando)
+                                    {
+                                        UpdateLaneAutohitExpireTime();
+                                    }
                                     YargLogger.LogFormatTrace("Hit staggered note {0} in chord", note.Key);
                                 }
                                 else

--- a/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/ProKeys/Engines/YargProKeysEngine.cs
@@ -160,7 +160,7 @@ namespace YARG.Core.Engine.Keys.Engines
                 if (missed)
                 {
                     // Intercept missed note while lane phrase is active
-                    if (!AutohitNoteFromLane(parentNote))
+                    if (!AutohitNoteFromLane(parentNote) && !AutohitNoteFromGlissando(parentNote))
                     {
                         // If one of the notes in the chord was missed out the back end,
                         // that means all of them would miss.


### PR DESCRIPTION
Fix for https://discord.com/channels/1086048856678084609/1527893431362387978

I don't actually know how glissandos are supposed to work, but this just seems like a copy of the lane behaviour that wasn't applying to glissando notes since they are not marked as lane notes.

I made this a seperate function - could have folded it into an override of the lane autohit but this feels cleaner.