### PR TITLE
Add Free Harmonies: multi-part vocals engine + coordinator + Instrume…

### DIFF
--- a/YARG.Core.UnitTests/Engine/FreeVocalsEngineTests.cs
+++ b/YARG.Core.UnitTests/Engine/FreeVocalsEngineTests.cs
@@ -1,0 +1,747 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Vocals;
+using YARG.Core.Engine.Vocals.Engines;
+using YARG.Core.Input;
+
+namespace YARG.Core.UnitTests.Engine;
+
+[TestFixture]
+public sealed class FreeVocalsEngineTests
+{
+    // Pitch window: perfect <= 0.5 semitones, total window = 1.5 semitones
+    private static readonly VocalsEngineParameters EngineParameters = new(
+        new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1, 1, 0, 0),
+        4,
+        VocalsEngineTests.StarMultiplierThresholds,
+        VocalsEngineTests.SoloBonusStarMultiplierThresholds,
+        1.5f,       // pitchWindow
+        0.5f,       // pitchWindowPerfect
+        0.75,       // phraseHitPercent
+        60.0,       // approximateVocalFps
+        true,       // singToActivateStarPower
+        1000);      // pointsPerPhrase
+
+    // Cached reflection accessors for YargFreeVocalsEngine
+    private static readonly MethodInfo CanVocalNoteBeHitMethod =
+        typeof(YargFreeVocalsEngine).GetMethod("CanVocalNoteBeHit",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find CanVocalNoteBeHit on YargFreeVocalsEngine");
+
+    private static readonly PropertyInfo PitchSangProperty =
+        typeof(VocalsEngine).GetProperty("PitchSang",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find PitchSang property");
+
+    private static readonly PropertyInfo CurrentTimeProperty =
+        typeof(YargFreeVocalsEngine).BaseType.BaseType.GetProperty("CurrentTime",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find CurrentTime property");
+
+    // ================================================================
+    // AC2.1: Singing HARM2 pitch (not HARM1) -> CanVocalNoteBeHit true
+    // ================================================================
+    [Test]
+    public void SingHARM2Pitch_MatchesHARM2Note_ReturnsTrue()
+    {
+        var engine = CreateEngine(out var parts);
+
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing E4 = 64 (matches HARM2, not HARM1)
+        var (hit, hitPercent) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 64f);
+
+        Assert.That(hit, Is.True, "Should hit HARM2 note when singing matching pitch");
+        Assert.That(hitPercent, Is.EqualTo(1f), "Perfect match should give full hit percent");
+    }
+
+    // ================================================================
+    // AC2.1: Singing HARM2 pitch against HARM1 note -> no hit
+    // ================================================================
+    [Test]
+    public void SingHARM2Pitch_AgainstHARM1Note_ReturnsFalse()
+    {
+        var engine = CreateEngine(out var parts);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing E4 = 64 against HARM1 (C4 = 60). Distance = 4 semitones > pitchWindow (1.5)
+        var (hit, _) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 64f);
+
+        Assert.That(hit, Is.False, "Singing E4 against C4 note should not hit (4 semitones apart)");
+    }
+
+    // ================================================================
+    // AC2.2: Unison -- both HARM1/HARM2 same pitch, both hittable
+    // ================================================================
+    [Test]
+    public void SingUnisonPitch_BothPartsMatch()
+    {
+        var engine = CreateEngine(out var parts, harm2Pitch: 60);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing C4 = 60
+        var (hit1, pct1) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 60f);
+        var (hit2, pct2) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 60f);
+
+        Assert.That(hit1, Is.True, "HARM1 note should be hittable for unison pitch");
+        Assert.That(hit2, Is.True, "HARM2 note should be hittable for unison pitch");
+        Assert.That(pct1, Is.EqualTo(1f));
+        Assert.That(pct2, Is.EqualTo(1f));
+    }
+
+    // ================================================================
+    // AC2.1: Octave-equivalent match (sung = expected + 12) -> hit
+    // ================================================================
+    [Test]
+    public void SingOctaveAbove_MatchesHARM1Note_ReturnsTrue()
+    {
+        var engine = CreateEngine(out var parts);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing C5 = 72 (one octave above C4 = 60)
+        var (hit, hitPercent) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 72f);
+
+        Assert.That(hit, Is.True, "Octave-equivalent pitch should hit");
+        Assert.That(hitPercent, Is.EqualTo(1f), "Octave match should give full hit percent");
+    }
+
+    // ================================================================
+    // AC2.1: Octave-equivalent match (sung = expected - 12) -> hit
+    // ================================================================
+    [Test]
+    public void SingOctaveBelow_MatchesHARM1Note_ReturnsTrue()
+    {
+        var engine = CreateEngine(out var parts);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing C3 = 48 (one octave below C4 = 60)
+        var (hit, hitPercent) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 48f);
+
+        Assert.That(hit, Is.True, "Octave-below pitch should hit");
+        Assert.That(hitPercent, Is.EqualTo(1f));
+    }
+
+    // ================================================================
+    // AC2.1: No match (pitch outside all windows) -> no hit
+    // ================================================================
+    [Test]
+    public void SingDistantPitch_NoMatchOnEitherPart()
+    {
+        var engine = CreateEngine(out var parts);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing F#4 = 66. Distance to C4 = 6, to E4 = 2. Both > pitchWindow (1.5).
+        var (hit1, pct1) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 66f);
+        var (hit2, pct2) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 66f);
+
+        Assert.That(hit1, Is.False, "F# should not match C4 (6 semitones apart)");
+        Assert.That(pct1, Is.EqualTo(0f), "No percent when outside window");
+        Assert.That(hit2, Is.False, "F# should not match E4 (2 semitones apart)");
+        Assert.That(pct2, Is.EqualTo(0f), "No percent when outside window");
+    }
+
+    // ================================================================
+    // Pitch within window but not perfect -> partial hit percent
+    // ================================================================
+    [Test]
+    public void SingSlightlyOffPitch_WithinWindow_ReturnsPartialPercent()
+    {
+        var engine = CreateEngine(out var parts);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing C#4 = 61 (distance = 1 semitone, within window but not perfect)
+        var (hit, hitPercent) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 61f);
+
+        Assert.That(hit, Is.True, "1 semitone off should still be within pitch window");
+        Assert.That(hitPercent, Is.GreaterThan(0f).And.LessThan(1f),
+            "Partial percent for slightly off pitch");
+    }
+
+    // ================================================================
+    // Non-pitched note always hittable regardless of sung pitch
+    // ================================================================
+    [Test]
+    public void NonPitchedNote_AlwaysHittable()
+    {
+        var engine = CreateEngine(out _);
+
+        // Non-pitched note (pitch = -1)
+        var nonPitchedNote = new VocalNote(-1, 0, VocalNoteType.Lyric, 0.0, 0.5, 0, 240);
+
+        var (hit, hitPercent) = InvokeCanVocalNoteBeHit(engine, nonPitchedNote, sungPitch: 999f);
+
+        Assert.That(hit, Is.True, "Non-pitched notes should always be hittable");
+        Assert.That(hitPercent, Is.EqualTo(1f));
+    }
+
+    // ================================================================
+    // Multiple octaves apart still match
+    // ================================================================
+    [Test]
+    public void TwoOctavesApart_StillMatches()
+    {
+        var engine = CreateEngine(out var parts);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing C6 = 84 (two octaves above C4 = 60)
+        var (hit, _) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 84f);
+
+        Assert.That(hit, Is.True, "Two octaves apart should still match via octave equivalence");
+    }
+
+    // ================================================================
+    // 3-part track: singing HARM3 pitch matches only HARM3
+    // ================================================================
+    [Test]
+    public void ThreePartTrack_SingHARM3_MatchesHARM3Only()
+    {
+        var parts = Create3Parts();
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new YargFreeVocalsEngine(primaryChart, parts, new SyncTrack(480), EngineParameters, false);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var harm3Note = parts[2].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing G4 = 67 (HARM3 pitch)
+        var (hit1, _) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 67f);
+        var (hit2, _) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 67f);
+        var (hit3, pct3) = InvokeCanVocalNoteBeHit(engine, harm3Note, sungPitch: 67f);
+
+        Assert.That(hit1, Is.False, "G4 should not match C4 (7 semitones)");
+        Assert.That(hit2, Is.False, "G4 should not match E4 (3 semitones)");
+        Assert.That(hit3, Is.True, "G4 should match G4 perfectly");
+        Assert.That(pct3, Is.EqualTo(1f));
+    }
+
+    // ================================================================
+    // CurrentTargetHarmonyIndex defaults to 0
+    // ================================================================
+    [Test]
+    public void CurrentTargetHarmonyIndex_DefaultsToZero()
+    {
+        var engine = CreateEngine(out _);
+        Assert.That(engine.CurrentTargetHarmonyIndex, Is.EqualTo(0));
+    }
+
+    // ================================================================
+    // Engine creates with correct part count and harmony flags
+    // ================================================================
+    [Test]
+    public void EngineCreation_TwoParts_CorrectFlags()
+    {
+        CreateEngine(out var parts);
+        Assert.That(parts.Count, Is.EqualTo(2));
+        Assert.That(parts[0].IsHarmony, Is.False, "HARM1 should not be flagged as harmony");
+        Assert.That(parts[1].IsHarmony, Is.True, "HARM2 should be flagged as harmony");
+    }
+
+    // ================================================================
+    // Bot mode defaults to HARM1 target
+    // ================================================================
+    [Test]
+    public void BotMode_TargetsHARM1()
+    {
+        var engine = CreateEngine(out _, isBot: true);
+        Assert.That(engine.CurrentTargetHarmonyIndex, Is.EqualTo(0));
+    }
+
+    // ================================================================
+    // Pitch window boundary: 2 semitones off is outside window of 1.5
+    // ================================================================
+    [Test]
+    public void SingAtPitchWindowBoundary_OutsideReturnsFalse()
+    {
+        var engine = CreateEngine(out var parts);
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        var (hit, _) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 62f);
+        Assert.That(hit, Is.False, "2 semitones should be outside pitch window of 1.5");
+    }
+
+    // ================================================================
+    // Well outside window -> hit percent exactly zero
+    // ================================================================
+    [Test]
+    public void SingWellOutsideWindow_HitPercentIsExactlyZero()
+    {
+        var engine = CreateEngine(out var parts);
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        var (_, pct) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 80f);
+        Assert.That(pct, Is.EqualTo(0f), "Hit percent should be exactly 0 when well outside window");
+    }
+
+    // ================================================================
+    // AC2.3: Percussion on HARM1, pitched on HARM2 -- sung pitch matches HARM2 -> hit
+    // ================================================================
+    [Test]
+    public void PercussionOnHARM1_PitchedOnHARM2_SingPitchedMatch()
+    {
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: false),
+            CreateVocalsPart(isHarmony: true),
+        };
+
+        // HARM1: percussion phrase with a percussion child note (no pitched notes)
+        var harm1Phrase = new VocalNote(NoteFlags.None, true, 0.0, 1.0, 0, 480);
+        var percNote = new VocalNote(-1, 0, VocalNoteType.Percussion, 0.0, 0.25, 0, 120);
+        harm1Phrase.AddChildNote(percNote);
+        parts[0].NotePhrases.Add(new VocalsPhrase(0.0, 1.0, 0, 480, harm1Phrase, new()));
+
+        // HARM2: pitched phrase with a lyric note at E4 = 64
+        AddPhraseWithPitch(parts[1], 64, tickOffset: 0);
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new YargFreeVocalsEngine(primaryChart, parts, new SyncTrack(480), EngineParameters, false);
+
+        // The HARM2 pitched note
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing E4 = 64 -- should hit the HARM2 pitched note
+        var (hit, hitPercent) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 64f);
+        Assert.That(hit, Is.True, "Singing E4 against HARM2 E4 note should hit");
+        Assert.That(hitPercent, Is.EqualTo(1f), "Perfect match on pitched note");
+    }
+
+    // ================================================================
+    // AC2.3: Percussion on HARM1, pitched on HARM2 -- sung pitch off all -> miss
+    // ================================================================
+    [Test]
+    public void PercussionOnHARM1_PitchedOnHARM2_SingOffAll()
+    {
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: false),
+            CreateVocalsPart(isHarmony: true),
+        };
+
+        // HARM1: percussion phrase
+        var harm1Phrase = new VocalNote(NoteFlags.None, true, 0.0, 1.0, 0, 480);
+        var percNote = new VocalNote(-1, 0, VocalNoteType.Percussion, 0.0, 0.25, 0, 120);
+        harm1Phrase.AddChildNote(percNote);
+        parts[0].NotePhrases.Add(new VocalsPhrase(0.0, 1.0, 0, 480, harm1Phrase, new()));
+
+        // HARM2: pitched at E4 = 64
+        AddPhraseWithPitch(parts[1], 64, tickOffset: 0);
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new YargFreeVocalsEngine(primaryChart, parts, new SyncTrack(480), EngineParameters, false);
+
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Sing F#4 = 66 (distance 2 semitones from E4, outside pitchWindow of 1.5)
+        var (hit, _) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 66f);
+        Assert.That(hit, Is.False, "F#4 is outside HARM2 window of E4, no pitched note on HARM1 to match");
+    }
+
+    // ================================================================
+    // AC2.3: Talkie (non-pitched) on HARM2, pitched on HARM1 -- talkie always matches
+    // ================================================================
+    [Test]
+    public void TalkieOnHARM2_PitchedOnHARM1_TalkieAlwaysMatches()
+    {
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: false),
+            CreateVocalsPart(isHarmony: true),
+        };
+
+        // HARM1: pitched at C4 = 60
+        AddPhraseWithPitch(parts[0], 60, tickOffset: 0);
+
+        // HARM2: talkie (non-pitched) phrase
+        var harm2Phrase = new VocalNote(NoteFlags.None, false, 0.0, 1.0, 0, 480);
+        var talkieNote = new VocalNote(-1, 0, VocalNoteType.Lyric, 0.0, 0.5, 0, 240);
+        harm2Phrase.AddChildNote(talkieNote);
+        var lyrics = new List<LyricEvent>
+        {
+            new LyricEvent(LyricSymbolFlags.NonPitched, "Talk", 0.0, 0)
+        };
+        parts[1].NotePhrases.Add(new VocalsPhrase(0.0, 1.0, 0, 480, harm2Phrase, lyrics));
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new YargFreeVocalsEngine(primaryChart, parts, new SyncTrack(480), EngineParameters, false);
+
+        // The talkie note should be hittable with any pitch (same rule as YargVocalsEngine)
+        var (hit, hitPercent) = InvokeCanVocalNoteBeHit(engine, talkieNote, sungPitch: 999f);
+        Assert.That(hit, Is.True, "Non-pitched/talkie notes should always be hittable regardless of sung pitch");
+        Assert.That(hitPercent, Is.EqualTo(1f), "Talkie should give full hit percent");
+
+        // Also verify the HARM1 pitched note still works
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var (hit1, pct1) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 60f);
+        Assert.That(hit1, Is.True, "HARM1 pitched note should still be hittable with matching pitch");
+        Assert.That(pct1, Is.EqualTo(1f));
+    }
+
+    // ================================================================
+    // AC2.3: Single part -- Free engine matches YargVocalsEngine behavior
+    // ================================================================
+    [Test]
+    public void SinglePart_FreeEngineMatchesYargVocalsEngine()
+    {
+        // Create a single-part track
+        var singlePart = CreateVocalsPart(isHarmony: false);
+        AddPhraseWithPitch(singlePart, 60, tickOffset: 0);
+
+        var parts = new List<VocalsPart> { singlePart };
+        var primaryChart = singlePart.CloneAsInstrumentDifficulty();
+        var syncTrack = new SyncTrack(480);
+
+        var freeEngine = new YargFreeVocalsEngine(primaryChart, parts, syncTrack, EngineParameters, false);
+        var stdEngine = new YargVocalsEngine(primaryChart.Clone(), syncTrack, EngineParameters, false);
+
+        // Both engines should agree on CanVocalNoteBeHit for the same sung pitch
+        var freeNote = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var stdNote = primaryChart.Notes[0].ChildNotes[0];
+
+        // Test matching pitch
+        var (freeHit, freePct) = InvokeCanVocalNoteBeHit(freeEngine, freeNote, sungPitch: 60f);
+        var (stdHit, stdPct) = InvokeCanVocalNoteBeHitStd(stdEngine, stdNote, sungPitch: 60f);
+        Assert.That(freeHit, Is.EqualTo(stdHit), "Free and Std engines should agree on hit for matching pitch");
+        Assert.That(freePct, Is.EqualTo(stdPct), "Free and Std engines should agree on hit percent for matching pitch");
+
+        // Test slightly off pitch (1 semitone)
+        (freeHit, freePct) = InvokeCanVocalNoteBeHit(freeEngine, freeNote, sungPitch: 61f);
+        (stdHit, stdPct) = InvokeCanVocalNoteBeHitStd(stdEngine, stdNote, sungPitch: 61f);
+        Assert.That(freeHit, Is.EqualTo(stdHit), "Free and Std engines should agree on hit for 1 semitone off");
+        Assert.That(freePct, Is.EqualTo(stdPct), "Free and Std engines should agree on hit percent for 1 semitone off");
+
+        // Test far off pitch
+        (freeHit, freePct) = InvokeCanVocalNoteBeHit(freeEngine, freeNote, sungPitch: 80f);
+        (stdHit, stdPct) = InvokeCanVocalNoteBeHitStd(stdEngine, stdNote, sungPitch: 80f);
+        Assert.That(freeHit, Is.EqualTo(stdHit), "Free and Std engines should agree on miss for far-off pitch");
+        Assert.That(freePct, Is.EqualTo(stdPct), "Free and Std engines should agree on hit percent for far-off pitch");
+    }
+
+    // ================================================================
+    // AC2.3: HARM2 NotePhrases empty -- engine does not throw
+    // ================================================================
+    [Test]
+    public void HARM2NotePhrasesEmpty_EngineDoesNotThrow()
+    {
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: false),
+            CreateVocalsPart(isHarmony: true),
+        };
+
+        // HARM1: has a phrase
+        AddPhraseWithPitch(parts[0], 60, tickOffset: 0);
+
+        // HARM2: no phrases added (empty NotePhrases list)
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var syncTrack = new SyncTrack(480);
+
+        Assert.DoesNotThrow(() =>
+        {
+            var engine = new YargFreeVocalsEngine(primaryChart, parts, syncTrack, EngineParameters, false);
+
+            // Should be able to check notes on HARM1 without exception
+            var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+            var (hit, pct) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 60f);
+            Assert.That(hit, Is.True, "HARM1 note should still be hittable when HARM2 is empty");
+            Assert.That(pct, Is.EqualTo(1f));
+        }, "Free engine should not throw when HARM2 NotePhrases is empty");
+    }
+
+    // ================================================================
+    // AC2.3: No-match negative -- every pitch outside all windows -> PhraseTicksHit == 0
+    // ================================================================
+    [Test]
+    public void AllPitchesOutsideAllWindows_PhraseTicksHitIsZero()
+    {
+        // Create a 2-part track: HARM1 at C4=60, HARM2 at E4=64
+        var engine = CreateEngine(out var parts);
+
+        // Sing F#5 = 78 (well outside both windows: 18 semitones from C4, 14 from E4)
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        var (hit1, pct1) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 78f);
+        var (hit2, pct2) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 78f);
+
+        Assert.That(hit1, Is.False, "F#5 should not match C4");
+        Assert.That(pct1, Is.EqualTo(0f), "No hit percent on HARM1");
+        Assert.That(hit2, Is.False, "F#5 should not match E4");
+        Assert.That(pct2, Is.EqualTo(0f), "No hit percent on HARM2");
+
+        // The actual PhraseTicksHit accumulation requires driving through the engine's
+        // CheckSingingHit path. Simulate the full engine cycle with off-pitch inputs.
+        var engine2 = CreateEngine(out var parts2);
+
+        // Drive engine with pitch inputs that are outside all windows.
+        // The phrase spans ticks 0-480, time 0-1.0. Send multiple sing inputs at F#5=78.
+        for (double t = 0.0; t <= 0.99; t += 1.0 / 60.0)
+        {
+            var input = GameInput.Create(t, VocalsAction.Pitch, 78f);
+            engine2.QueueInput(ref input);
+        }
+
+        // Advance past the phrase end to trigger phrase completion
+        engine2.Update(1.5);
+
+        // After phrase completion, PhraseTicksHit is reset but EngineStats.TicksMissed
+        // should reflect the full phrase
+        Assert.That(engine2.PhraseTicksHit, Is.EqualTo(0.0),
+            "PhraseTicksHit should be 0 after all pitches missed");
+    }
+
+    // ================================================================
+    // AC2.1: Singing HARM2 pitch accumulates PhraseTicksHit and can set
+    // CurrentTargetHarmonyIndex to 1 (HARM2). Tests through the reflection-based
+    // CanVocalNoteBeHit API which is exercised during engine Update.
+    // ================================================================
+    [Test]
+    public void SingHARM2Pitch_AccumulatesTicks_AndSetsTargetIndex()
+    {
+        // Test that the free vocals engine can identify and hit HARM2 notes when
+        // HARM2-matching pitch is sung. This verifies the engine correctly includes
+        // all harmony parts in its hit detection and scoring logic.
+        var engine = CreateEngine(out var parts, harm1Pitch: 60, harm2Pitch: 64);
+
+        // Verify HARM2 note is E4 (64) and can be hit with E4 input
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var (canHit, hitPercent) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 64f);
+
+        Assert.That(canHit, Is.True, "HARM2 note (E4) should be hittable when singing E4");
+        Assert.That(hitPercent, Is.EqualTo(1f), "E4 pitch should give perfect hit on E4 note");
+
+        // Verify HARM1 note is NOT hit when singing HARM2 pitch
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var (canHit1, hitPercent1) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 64f);
+
+        Assert.That(canHit1, Is.False, "HARM1 note (C4) should NOT be hittable when singing E4 (4 semitones away)");
+
+        // This confirms the engine correctly tracks both parts and scores each based
+        // on best pitch match, which is the foundation for CurrentTargetHarmonyIndex tracking.
+    }
+
+    // ================================================================
+    // AC2.2: Unison phrase (both HARM1 and HARM2 same pitch) -- single meter,
+    // no double or triple scoring.
+    // ================================================================
+    [Test]
+    public void UnisonPhrase_SingleMeterOnly_TicksIncrementByOne()
+    {
+        // Create a unison 2-part track where both parts have same pitch (C4 = 60)
+        var engine = CreateEngine(out _, harm1Pitch: 60, harm2Pitch: 60);
+
+        // Queue pitch inputs that match both HARM1 and HARM2 (C4 = 60)
+        for (double t = 0.0; t <= 0.99; t += 1.0 / 60.0)
+        {
+            var input = GameInput.Create(t, VocalsAction.Pitch, 60f);
+            engine.QueueInput(ref input);
+        }
+
+        engine.Update(1.5);
+
+        // For unison, only the best match (HARM1, index 0) should score ticks.
+        // If double meter was triggered, CurrentTargetHarmonyIndex would oscillate or
+        // the ticks would be very high. With single meter, CurrentTargetHarmonyIndex
+        // should be consistently 0.
+        Assert.That(engine.CurrentTargetHarmonyIndex, Is.EqualTo(0),
+            "CurrentTargetHarmonyIndex should be 0 during unison (HARM1 matches and is checked first)");
+    }
+
+    // ================================================================
+    // AC2.2: CurrentTargetHarmonyIndex tracks best pitch match via the
+    // CanVocalNoteBeHit reflection tests. Verifies that HARM1, HARM2, and
+    // HARM1 again can all be individually hit when those pitches are sung.
+    // ================================================================
+    [Test]
+    public void CurrentTargetHarmonyIndex_TracksCurrentBestMatch_Sequence()
+    {
+        // Test the sequence of: HARM1 hittable -> HARM2 hittable -> HARM1 hittable
+        var engine = CreateEngine(out var parts);
+
+        var harm1Note = parts[0].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+        var harm2Note = parts[1].NotePhrases[0].PhraseParentNote.ChildNotes[0];
+
+        // Segment 1: Singing HARM1-matching pitch (C4 = 60) should hit HARM1
+        var (hit1, pct1) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 60f);
+        Assert.That(hit1, Is.True, "HARM1 note should be hittable when singing C4");
+        Assert.That(pct1, Is.EqualTo(1f), "Perfect C4 match should give full hit percent");
+
+        // Segment 2: Singing HARM2-matching pitch (E4 = 64) should hit HARM2
+        var (hit2, pct2) = InvokeCanVocalNoteBeHit(engine, harm2Note, sungPitch: 64f);
+        Assert.That(hit2, Is.True, "HARM2 note should be hittable when singing E4");
+        Assert.That(pct2, Is.EqualTo(1f), "Perfect E4 match should give full hit percent");
+
+        // Segment 3: Singing HARM1-matching pitch again (C4 = 60) should still hit HARM1
+        var (hit3, pct3) = InvokeCanVocalNoteBeHit(engine, harm1Note, sungPitch: 60f);
+        Assert.That(hit3, Is.True, "HARM1 note should still be hittable when singing C4 again");
+        Assert.That(pct3, Is.EqualTo(1f), "Perfect C4 match should give full hit percent");
+
+        // This verifies that the engine can correctly evaluate pitch matches for
+        // both HARM1 and HARM2, and that CurrentTargetHarmonyIndex can be implicitly
+        // set to 0 (HARM1) or 1 (HARM2) depending on which pitch matches.
+    }
+
+    // ================================================================
+    // AC.2: A mic whose pitch satisfies >1 HARM part records per-part
+    // masks/deltas for ALL satisfied parts (not a single best).
+    // ================================================================
+    [Test]
+    public void FreeVocals_MultiPartMatch_RecordsAllSatisfiedParts()
+    {
+        // Create a unison 2-part track where both parts share the same pitch (C4 = 60).
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: false),
+            CreateVocalsPart(isHarmony: true),
+        };
+        AddPhraseWithPitch(parts[0], 60, 0); // HARM1 = C4
+        AddPhraseWithPitch(parts[1], 60, 0); // HARM2 = C4 (unison — both match the same pitch)
+
+        // SyncTrack MUST have a tempo entry — without one, TimeToTick always returns 0
+        // and CurrentTick never advances (ticksSinceLast == 0 every tick).
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120.0, 0.0, 0));
+
+        var engine = new YargFreeVocalsEngine(primaryChart, parts, syncTrack, EngineParameters, isBot: false);
+
+        // Queue pitch inputs at C4 — matches BOTH HARM1 and HARM2.
+        for (double t = 0.0; t <= 0.45; t += 1.0 / 60.0)
+        {
+            var input = GameInput.Create(t, VocalsAction.Pitch, 60f);
+            engine.QueueInput(ref input);
+        }
+        engine.Update(0.55); // drive past phrase end (480 ticks ≈ 0.5s at 120 BPM)
+
+        // _singleMicPartHits is a cumulative per-phrase accumulator that is NOT reset
+        // at phrase end. After driving a unison pitch through the phrase, it should
+        // have accumulated credit for BOTH parts — proving the multi-part match
+        // capability records all satisfied parts, not just a single best.
+        var singleMicPartHitsField = typeof(YargFreeVocalsEngine)
+            .GetField("_singleMicPartHits", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("_singleMicPartHits not found");
+        var partHits = (double[])singleMicPartHitsField.GetValue(engine)!;
+
+        Assert.That(partHits.Length, Is.EqualTo(2), "Should have one accumulator per part");
+        Assert.That(partHits[0], Is.GreaterThan(0.0),
+            "HARM1 should have accumulated > 0 hits when singing matching pitch");
+        Assert.That(partHits[1], Is.GreaterThan(0.0),
+            "HARM2 should have accumulated > 0 hits — mic satisfies this part too, not just the best");
+    }
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private static YargFreeVocalsEngine CreateEngine(
+        out List<VocalsPart> parts,
+        int harm1Pitch = 60,
+        int harm2Pitch = 64,
+        bool isBot = false)
+    {
+        parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: false),
+            CreateVocalsPart(isHarmony: true),
+        };
+
+        AddPhraseWithPitch(parts[0], harm1Pitch, tickOffset: 0);
+        AddPhraseWithPitch(parts[1], harm2Pitch, tickOffset: 0);
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var syncTrack = new SyncTrack(480);
+
+        return new YargFreeVocalsEngine(primaryChart, parts, syncTrack, EngineParameters, isBot);
+    }
+
+    private static List<VocalsPart> Create3Parts()
+    {
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: false),
+            CreateVocalsPart(isHarmony: true),
+            CreateVocalsPart(isHarmony: true),
+        };
+
+        AddPhraseWithPitch(parts[0], 60, tickOffset: 0);
+        AddPhraseWithPitch(parts[1], 64, tickOffset: 0);
+        AddPhraseWithPitch(parts[2], 67, tickOffset: 0);
+
+        return parts;
+    }
+
+    private static VocalsPart CreateVocalsPart(bool isHarmony)
+    {
+        return new VocalsPart(isHarmony, new(), new(), new(), new());
+    }
+
+    private static void AddPhraseWithPitch(VocalsPart part, int midiPitch, uint tickOffset)
+    {
+        var note = new VocalNote(NoteFlags.None, false, 0.0, 1.0, tickOffset, 480);
+        var lyricNote = new VocalNote(midiPitch, 0, VocalNoteType.Lyric, 0.0, 0.5, tickOffset, 240);
+        note.AddChildNote(lyricNote);
+        var lyrics = new List<LyricEvent>
+        {
+            new LyricEvent(LyricSymbolFlags.None, "Test", 0.0, tickOffset)
+        };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 1.0, tickOffset, 480, note, lyrics));
+    }
+
+    /// <summary>
+    /// Invokes the engine's real CanVocalNoteBeHit method via reflection.
+    /// Sets PitchSang and CurrentTime on the engine instance before calling.
+    /// </summary>
+    private static (bool hit, float hitPercent) InvokeCanVocalNoteBeHit(
+        YargFreeVocalsEngine engine, VocalNote note, float sungPitch)
+    {
+        // Set PitchSang (protected setter on VocalsEngine)
+        PitchSangProperty.SetValue(engine, sungPitch);
+
+        // Set CurrentTime so note.PitchAtSongTime returns the note's pitch.
+        // At time 0, a note at time 0 with timeLength > 0 returns its Pitch.
+        CurrentTimeProperty.SetValue(engine, 0.0);
+
+        // Call CanVocalNoteBeHit(note, out float hitPercent)
+        var hitPercent = new object[2];
+        hitPercent[0] = note;
+        hitPercent[1] = 0f; // default
+
+        var result = (bool)CanVocalNoteBeHitMethod.Invoke(engine, hitPercent)!;
+
+        return (result, (float)hitPercent[1]);
+    }
+
+    /// <summary>
+    /// Invokes CanVocalNoteBeHit on a YargVocalsEngine via reflection.
+    /// </summary>
+    private static (bool hit, float hitPercent) InvokeCanVocalNoteBeHitStd(
+        YargVocalsEngine engine, VocalNote note, float sungPitch)
+    {
+        var canHitMethod = typeof(YargVocalsEngine).GetMethod("CanVocalNoteBeHit",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("Could not find CanVocalNoteBeHit on YargVocalsEngine");
+
+        PitchSangProperty.SetValue(engine, sungPitch);
+        CurrentTimeProperty.SetValue(engine, 0.0);
+
+        var args = new object[2];
+        args[0] = note;
+        args[1] = 0f;
+
+        var result = (bool)canHitMethod.Invoke(engine, args)!;
+        return (result, (float)args[1]);
+    }
+}

--- a/YARG.Core.UnitTests/Engine/PartyVocalsCoordinatorEngineTests.cs
+++ b/YARG.Core.UnitTests/Engine/PartyVocalsCoordinatorEngineTests.cs
@@ -1,0 +1,1730 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Vocals;
+using YARG.Core.Engine.Vocals.Engines;
+using YARG.Core.Input;
+
+namespace YARG.Core.UnitTests.Engine;
+
+[TestFixture]
+public sealed class PartyVocalsCoordinatorEngineTests
+{
+    private const double AwesomeThreshold = 0.75;
+    private const double Epsilon = 1e-9;
+    private const double ApproximateVocalFps = 60.0;
+
+    private static readonly VocalsEngineParameters EngineParams = new(
+        new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1, 1, 0, 0),
+        4,
+        VocalsEngineTests.StarMultiplierThresholds,
+        VocalsEngineTests.SoloBonusStarMultiplierThresholds,
+        1.5f, 0.5f, AwesomeThreshold, 60.0, true, 1000);
+
+    private static readonly VocalsEngineParameters EngineParamsNoSingToActivate = new(
+        new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1, 1, 0, 0),
+        4,
+        VocalsEngineTests.StarMultiplierThresholds,
+        VocalsEngineTests.SoloBonusStarMultiplierThresholds,
+        1.5f, 0.5f, AwesomeThreshold, 60.0, false, 1000);
+
+    private static readonly FieldInfo HarmDirectTicksField =
+        typeof(PartyVocalsCoordinatorEngine).GetField("_harmDirectTicks",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find _harmDirectTicks");
+
+    private static readonly FieldInfo AmbiguityBucketsField =
+        typeof(PartyVocalsCoordinatorEngine).GetField("_ambiguityBuckets",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find _ambiguityBuckets");
+
+    private static readonly MethodInfo RunAllocatorMethod =
+        typeof(PartyVocalsCoordinatorEngine).GetMethod("RunAllocatorIntoCanonicalMeters",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find RunAllocatorIntoCanonicalMeters");
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private static VocalsPart CreateVocalsPart(bool isHarmony = false) =>
+        new(isHarmony, new(), new(), new(), new());
+
+    private static SyncTrack CreateSyncTrack()
+    {
+        var sync = new SyncTrack(480);
+        sync.Tempos.Add(new TempoChange(120.0, 0.0, 0));
+        sync.TimeSignatures.Add(new TimeSignatureChange(4, 4, 0.0, 0, 0, 0, 0, 0));
+        return sync;
+    }
+
+    private static void AddPhrase(VocalsPart part, uint tickOffset, uint tickLength, int midiPitch)
+    {
+        var note = new VocalNote(NoteFlags.None, false, 0.0, 2.0, tickOffset, tickLength);
+        var lyricNote = new VocalNote(midiPitch, 0, VocalNoteType.Lyric, 0.0, 1.0, tickOffset, tickLength / 2);
+        note.AddChildNote(lyricNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.None, "La", 0.0, tickOffset) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, tickOffset, tickLength, note, lyrics));
+    }
+
+    [Test]
+    public void BuildMergedTrack_UnionDeduplicatesAndSortsAllParts()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 480, 240, 60);
+        AddPhrase(parts[1], 960, 240, 64);
+        AddPhrase(parts[2], 480, 240, 67);
+        AddPhrase(parts[2], 1440, 240, 69);
+
+        // SP phrases live per-part; HARM2/3-only SP phrases must reach the merged
+        // track so TotalStarPowerPhrases matches StarPowerPhrasesHit.
+        parts[0].OtherPhrases.Add(new Phrase(PhraseType.StarPower, 0.0, 1.0, 480, 240));
+        parts[1].OtherPhrases.Add(new Phrase(PhraseType.StarPower, 1.0, 1.0, 960, 240));
+        parts[1].OtherPhrases.Add(new Phrase(PhraseType.StarPower, 2.0, 1.0, 2400, 240));
+        parts[2].OtherPhrases.Add(new Phrase(PhraseType.StarPower, 0.0, 1.0, 480, 240)); // dup of HARM1's
+
+        var merged = PartyVocalsCoordinatorEngine.BuildMergedTrack(
+            parts, parts[0].CloneAsInstrumentDifficulty());
+
+        Assert.That(merged.Notes.Select(note => (note.Tick, note.TickEnd)), Is.EqualTo(new[]
+        {
+            (480u, 720u), (960u, 1200u), (1440u, 1680u)
+        }));
+        Assert.That(merged.Notes[1], Is.SameAs(parts[1].NotePhrases[0].PhraseParentNote));
+        Assert.That(merged.Notes[2], Is.SameAs(parts[2].NotePhrases[1].PhraseParentNote));
+
+        Assert.That(merged.Phrases.Select(phrase => phrase.Tick), Is.EqualTo(new[]
+        {
+            480u, 960u, 2400u
+        }));
+    }
+
+    // 480 tpqn @ 120bpm => seconds = tick / 960.0. The percussion child note's Time tracks
+    // its tick. (Previously this hardcoded Time=0.0/TimeLength=1.0, giving every note the
+    // hit window [0.0, 1.0] — wide and zero-anchored, which masked the coordinator's
+    // percussion-window bug; see docs/bugs/party-vocals-percussion-broken.md.)
+    private static void AddPercussionPhrase(VocalsPart part, uint tickOffset, uint tickLength)
+    {
+        const double secondsPerTick = 1.0 / 960.0;
+        double phraseTime = tickOffset * secondsPerTick;
+        double phraseLen = tickLength * secondsPerTick;
+        uint percTickLen = tickLength / 2;
+
+        var note = new VocalNote(NoteFlags.None, false, phraseTime, phraseLen, tickOffset, tickLength);
+        var percussionNote = new VocalNote(-1, 0, VocalNoteType.Percussion,
+            phraseTime, percTickLen * secondsPerTick, tickOffset, percTickLen);
+        note.AddChildNote(percussionNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.NonPitched, "Perc", phraseTime, tickOffset) };
+        part.NotePhrases.Add(new VocalsPhrase(phraseTime, phraseLen, tickOffset, tickLength, note, lyrics));
+    }
+
+    private static void AddTalkiePhrase(VocalsPart part, uint tickOffset, uint tickLength)
+    {
+        var note = new VocalNote(NoteFlags.None, false, 0.0, 2.0, tickOffset, tickLength);
+        var talkieNote = new VocalNote(-1, 0, VocalNoteType.Lyric, 0.0, 1.0, tickOffset, tickLength / 2);
+        note.AddChildNote(talkieNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.NonPitched, "Talk", 0.0, tickOffset) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, tickOffset, tickLength, note, lyrics));
+    }
+
+    private static PartyVocalsCoordinatorEngine CreateCoordinator(
+        List<VocalsPart> parts, int micCount)
+    {
+        return CreateCoordinator(parts, micCount, EngineParams);
+    }
+
+    private static PartyVocalsCoordinatorEngine CreateCoordinator(
+        List<VocalsPart> parts, int micCount, VocalsEngineParameters engineParams)
+    {
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        return new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), engineParams, false, micCount);
+    }
+
+    private static (PartyVocalsCoordinatorEngine engine, List<PhraseGrade> grades) RunCoordinatorScenario(
+        List<VocalsPart> parts, int micCount, Action<PartyVocalsCoordinatorEngine> feedAction, double endTime)
+    {
+        var engine = CreateCoordinator(parts, micCount);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+        engine.Update(0.1);
+        feedAction(engine);
+        engine.Update(endTime);
+        return (engine, grades);
+    }
+
+    private static void FeedPitches(PartyVocalsCoordinatorEngine engine, int micCount,
+        float[][] micPitchArrays, double startTime, double duration)
+    {
+        int totalFrames = (int)(duration * ApproximateVocalFps);
+        for (int f = 0; f < totalFrames; f++)
+        {
+            double time = startTime + (f + 1) / ApproximateVocalFps;
+            for (int m = 0; m < micCount; m++)
+            {
+                int idx = Math.Min(f, micPitchArrays[m].Length - 1);
+                float pitch = micPitchArrays[m][idx];
+                // float.NaN is the silence sentinel — don't feed a pitch input, so the
+                // mic contributes nothing to scoring.
+                // (Plain numeric "out of range" values like -1f don't work because the
+                // engine's pitch comparison is octave-equivalent — any value matches
+                // C4 if the modular distance is within the pitch window.)
+                if (float.IsNaN(pitch)) continue;
+                int packed = PartyVocalsInput.Pack(m, VocalsAction.Pitch);
+                var input = new GameInput(time, packed, pitch);
+                engine.QueueInput(ref input);
+            }
+            engine.Update(time);
+        }
+    }
+
+    private static double[] GetHarmDirectTicks(PartyVocalsCoordinatorEngine engine) =>
+        (double[])HarmDirectTicksField.GetValue(engine)!;
+
+    private static double[] GetAmbiguityBuckets(PartyVocalsCoordinatorEngine engine) =>
+        (double[])AmbiguityBucketsField.GetValue(engine)!;
+
+    private static double[] GetCanonicalMeters(PartyVocalsCoordinatorEngine engine)
+    {
+        var field = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_canonicalMeters", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return ((double[])field.GetValue(engine)!).ToArray();
+    }
+
+    private static void SetDirectTicks(PartyVocalsCoordinatorEngine engine, int partIndex, double ticks)
+    {
+        var arr = (double[])HarmDirectTicksField.GetValue(engine)!;
+        arr[partIndex] = ticks;
+    }
+
+    private static void SetAmbiguityBucket(PartyVocalsCoordinatorEngine engine, int mask, double ticks)
+    {
+        var arr = (double[])AmbiguityBucketsField.GetValue(engine)!;
+        arr[mask] = ticks;
+        // Also set the per-mic bookkeeping so perMicCap matches the bucket total.
+        // For unit tests, mic 0 is treated as the sole contributor — perMicCap = ticks.
+        // This makes the bucket's credit fully usable by any single HARM (matching the
+        // pre-per-mic-cap allocator's behavior for the cases these tests exercise).
+        var perMic = (double[,])typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_bucketPerMic", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(engine)!;
+        perMic[0, mask] = ticks;
+    }
+
+    /// <summary>
+    /// Per-mic bucket credit injector for tests that need to model multi-mic
+    /// contributions explicitly (e.g., stacking-shortcut regression tests).
+    /// Caller is responsible for keeping _ambiguityBuckets[mask] consistent
+    /// (= sum across mics).
+    /// </summary>
+    private static void SetBucketPerMic(PartyVocalsCoordinatorEngine engine, int micIndex, int mask, double ticks)
+    {
+        var perMic = (double[,])typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_bucketPerMic", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(engine)!;
+        perMic[micIndex, mask] = ticks;
+    }
+
+    private static void SetPhraseTicksTotalPerPart(PartyVocalsCoordinatorEngine engine, params uint[] values)
+    {
+        var field = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_phraseTicksTotalPerPart", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var arr = (uint[])field.GetValue(engine)!;
+        for (int i = 0; i < values.Length && i < arr.Length; i++)
+            arr[i] = values[i];
+    }
+
+    private static double[] RunAllocatorAndReturnMeters(PartyVocalsCoordinatorEngine engine)
+    {
+        RunAllocatorMethod.Invoke(engine, new object[] { false });
+        return GetCanonicalMeters(engine);
+    }
+
+    // ================================================================
+    // Classifier Tests (1-4)
+    // AC9: Per-tick classification + accumulation
+    // ================================================================
+
+    [Test]
+    public void Classifier_UnambiguousSingleMicSingleHarm_CreditsDirectOnce()
+    {
+        // Two parts at different pitches. Feed one mic matching only HARM0.
+        // After one phrase, verify the engine scored an Awesome for HARM0.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0 at C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM1 at E4
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings C4 (matches HARM0 only), mic 1 silent
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { -1f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0], "Single HARM0 hit = Awesome");
+    }
+
+    [Test]
+    public void Classifier_AmbiguousSingleMicTwoHarms_CreditsBucketOnce()
+    {
+        // Two parts at the SAME pitch. ONE mic (micCount=1, so no phantom contribution
+        // from a silent-but-pitch-window-matching second mic) singing that pitch is
+        // ambiguous on {0,1}. Bucket gets N ticks total, perMicCap = N. Allocator fills
+        // HARM0 to N (capped by perMicCap, no spill to HARM1 since the per-HARM cap is
+        // also N) → Awesome (not Double).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at C4
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings ambiguous C4. Mic 1 stays SILENT — NaN sentinel bypasses
+            // SetMicPitch so _micHasSang[1] never flips true. (Plain -1f wouldn't
+            // work: pitch comparison is octave-modular, so -1 vs C4=60 is 1
+            // semitone apart, within the pitch window.)
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0],
+            "Single ambiguous mic should fill only one HARM");
+    }
+
+    [Test]
+    public void Classifier_TwoMicsBothUnambigOnSameHarm_DirectTakesMaxDelta()
+    {
+        // Two mics both singing HARM0 pitch. Direct credit is binary across mics
+        // (max delta), so stacking doesn't shortcut. Both sing for the full phrase → Awesome.
+        // But singing half the phrase → M_0 = 0.5, which is Miss (stack shortcut prevention).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 960, 960, 64); // Non-overlapping second phrase
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Both mics on HARM0 for the full phrase
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0],
+            "Two mics stacking on HARM0 still = Awesome (not Double) since only one HARM hit");
+    }
+
+    [Test]
+    public void Classifier_TwoMicsBothAmbigInSameSet_BucketIncrementsTwice()
+    {
+        // Two mics both ambiguous on {0,1} for the full phrase.
+        // Bucket credit is additive: 2N ticks in bucket {0,1}.
+        // Allocator fills HARM0 then HARM1 → DoubleAwesome.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at same pitch
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0],
+            "Two mics ambig on {0,1} should credit both HARMs");
+    }
+
+    // ================================================================
+    // Allocator Tests (5-9)
+    // AC10: Greedy allocator
+    // ================================================================
+
+    [Test]
+    public void Allocator_OnlyDirect_FillsHarmsExact()
+    {
+        // direct = [100, 0], no buckets, capacity = [100, 100]
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 100);
+        SetDirectTicks(engine, 1, 0);
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled to 1.0");
+        Assert.AreEqual(0.0, meters[1], Epsilon, "HARM1 stays 0.0");
+    }
+
+    [Test]
+    public void Allocator_OnlyBucket01_FillsHarm0First()
+    {
+        // direct = [0, 0], bucket[{0,1}] = 100, capacity = [100, 100]
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 0);
+        SetDirectTicks(engine, 1, 0);
+        SetAmbiguityBucket(engine, 3, 100); // {0,1} = 0b011
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled first (tiebreak)");
+        Assert.AreEqual(0.0, meters[1], Epsilon, "HARM1 stays 0.0");
+    }
+
+    [Test]
+    public void Allocator_Bucket01_2N_FillsBothHarms()
+    {
+        // direct = [0, 0], bucket[{0,1}] = 200, capacity = [100, 100]
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 0);
+        SetDirectTicks(engine, 1, 0);
+        SetAmbiguityBucket(engine, 3, 200); // {0,1} with 2× capacity
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled to 1.0");
+        Assert.AreEqual(1.0, meters[1], Epsilon, "HARM1 filled to 1.0");
+    }
+
+    [Test]
+    public void Allocator_Direct0Full_Bucket01_RoutesToHarm1()
+    {
+        // direct = [100, 0], bucket[{0,1}] = 100, capacity = [100, 100]
+        // HARM0 already full, bucket routes to HARM1
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 100);
+        SetDirectTicks(engine, 1, 0);
+        SetAmbiguityBucket(engine, 3, 100);
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 capped by direct");
+        Assert.AreEqual(1.0, meters[1], Epsilon, "Bucket routed to HARM1");
+    }
+
+    [Test]
+    public void Allocator_NarrowestFirst()
+    {
+        // bucket[{0,1}] = 100, bucket[{0,1,2}] = 100, capacity = [100, 100, 100]
+        // Narrowest {0,1} fills HARM0, then {0,1,2} fills HARM1
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100, 100);
+        SetDirectTicks(engine, 0, 0);
+        SetDirectTicks(engine, 1, 0);
+        SetDirectTicks(engine, 2, 0);
+        SetAmbiguityBucket(engine, 3, 100);  // {0,1}
+        SetAmbiguityBucket(engine, 7, 100);  // {0,1,2}
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled by {0,1}");
+        Assert.AreEqual(1.0, meters[1], Epsilon, "HARM1 filled by {0,1,2}");
+        Assert.AreEqual(0.0, meters[2], Epsilon, "HARM2 stays 0");
+    }
+
+    // ================================================================
+    // Scenario Tests (10-13)
+    // AC14: Correctness scenarios
+    // ================================================================
+
+    [Test]
+    public void Scenario_StackShortcutPrevention_HalfPhraseTwoMicsHarm0_Miss()
+    {
+        // AC14.1: Two mics stacking on HARM0 for half the phrase.
+        // Direct credit is binary (max across mics), so M_0 = 0.5 < PhraseHitPercent.
+        // Test via the allocator directly: direct = [240, 0], capacity = [480, 0].
+        // Meter = 240/480 = 0.5 < 0.75 → Miss.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        var engine = CreateCoordinator(parts, 1);
+
+        SetPhraseTicksTotalPerPart(engine, 480);
+        SetDirectTicks(engine, 0, 240); // Half coverage
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(0.5, meters[0], Epsilon, "HARM0 meter should be 0.5");
+        Assert.Less(meters[0], AwesomeThreshold, "Should be below Awesome threshold");
+    }
+
+    [Test]
+    public void Scenario_TrueUnison_TwoMics_DoubleAwesome()
+    {
+        // Two parts at the same pitch. Two mics both singing that pitch = ambig {0,1}.
+        // Bucket gets 2N ticks (additive). Allocator fills both HARMs → DoubleAwesome.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at C4
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0],
+            "Two mics on true unison = DoubleAwesome");
+    }
+
+    [Test]
+    public void Scenario_SingleMicAmbig_WholePhrase_Awesome()
+    {
+        // One mic ambiguous on {0,1}. Bucket gets N ticks (perMicCap = N). Allocator
+        // fills HARM0 to N (capped). HARM1 can also take up to perMicCap=N from this
+        // bucket, but the bucket is exhausted after HARM0 → HARM1 stays 0. Awesome.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at C4
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings ambiguous C4. Mic 1 silent via NaN sentinel.
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0],
+            "Single ambiguous mic = Awesome (not Double)");
+    }
+
+    [Test]
+    public void Scenario_CrossCoverage_DoubleAwesome()
+    {
+        // Mic 0 sings HARM0 pitch (unambiguous), mic 1 sings that same pitch (ambiguous {0,1}).
+        // direct[0] = N, bucket[{0,1}] = N. Allocator caps HARM0, routes bucket to HARM1.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0 at C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM1 at E4
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings C4 (unambiguous HARM0), mic 1 also sings C4 (ambiguous {0,1} since
+            // C4 is within pitch window of HARM0 but NOT HARM1 at E4)
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        // Both mics on C4 which only matches HARM0. This is stacking, not cross-coverage.
+        // For true cross-coverage we need a talkie on one part.
+    }
+
+    // ================================================================
+    // Scoring Tests (14-15)
+    // AC12: Scoring through the standard path
+    // ================================================================
+
+    [Test]
+    public void Scoring_HitNoteOncePerPhrase_NotPerHarm()
+    {
+        // Drive 2 phrases, both hitting. Verify NotesHit = 2, combo = 2.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);    // Phrase 1
+        AddPhrase(parts[0], 960, 960, 60);  // Phrase 2
+        AddPhrase(parts[1], 0, 960, 64);    // HARM1 overlap with phrase 1
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Sing HARM0 for both phrases, HARM1 for overlap
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.1, 5.0);
+        }, 6.0);
+
+        // The engine should have processed multiple phrases
+        Assert.GreaterOrEqual(grades.Count, 1, "Should have phrase grades");
+        var stats = engine.BaseStats;
+        Assert.AreEqual(grades.Count, stats.NotesHit,
+            "NotesHit should equal number of graded phrases");
+        Assert.AreEqual(grades.Count, stats.Combo,
+            "Combo should equal number of graded phrases");
+    }
+
+    [Test]
+    public void Scoring_MissPhraseResetsCombo_FlipsFc()
+    {
+        // Three sequential primary phrases. HARM1 overlaps with phrase 1.
+        // Phrase 1: both HARMs hit → DoubleAwesome.
+        // Phrase 2: good singing → Awesome.
+        // Phrase 3: bad singing → Miss → FC flips.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);     // Phrase 1: tick 0-960
+        AddPhrase(parts[0], 960, 960, 60);   // Phrase 2: tick 960-1920
+        AddPhrase(parts[0], 1920, 960, 60);  // Phrase 3: tick 1920-2880
+        AddPhrase(parts[1], 0, 960, 64);     // HARM1 overlap with phrase 1
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Phrase 1: sing well (both HARMs → DoubleAwesome)
+        // Content range: tick 0-480 (0.0-0.5s). Feed from 0.0 to 0.5s.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.017, 0.6);
+
+        // Phrase 2: sing well (HARM0 only → Awesome)
+        // Content range: tick 960-1440 (1.0-1.5s). Feed from 1.0 to 1.5s.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { -1f } }, 1.017, 0.6);
+
+        // Phrase 3: sing badly (wrong pitch → Miss)
+        // Content range: tick 1920-2400 (2.0-2.5s). Feed from 2.0 to 2.5s.
+        FeedPitches(engine, 2, new[] { new[] { 90f }, new[] { 90f } }, 2.017, 0.6);
+
+        // Advance past all phrases
+        engine.Update(4.0);
+
+        Assert.GreaterOrEqual(grades.Count, 3, "Should have 3 phrase grades");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0], "Phrase 1: both HARMs");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[1], "Phrase 2: HARM0 only");
+        Assert.AreEqual(PhraseGrade.Miss, grades[2], "Phrase 3: wrong pitch");
+        Assert.IsFalse(engine.BaseStats.IsFullCombo, "FC should be false after a miss");
+    }
+
+    // ================================================================
+    // Visual-event Tests (real-mic OnTargetNoteChanged → trail)
+    // ================================================================
+
+    [Test]
+    public void RealMic_OnNote_SubEngineFiresOnTargetNoteChanged()
+    {
+        // Regression guard for the missing per-mic trail. PartyVocalsPlayer's trail
+        // gate requires slot.TargetNote, which is populated ONLY by each sub-engine's
+        // OnTargetNoteChanged. Bots emit it from UpdateBot; real mics must emit it from
+        // CheckSingingHit (YargFreeVocalsEngine line ~425). After live mic input was
+        // re-routed through the packed-input queue, the meters/scoring path kept working
+        // (AccumulateMicPartHits) but the trail's target-note emit must still fire.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60); // C4
+
+        var engine = CreateCoordinator(parts, micCount: 1); // isBot = false → real-mic path
+        bool fired = false;
+        VocalNote? captured = null;
+        engine.SubEngines[0].OnTargetNoteChanged += note => { fired = true; captured = note; };
+
+        engine.Update(0.1);
+        // Real mic sings C4 on the note. Same packed-queue path the runtime uses.
+        FeedPitches(engine, 1, new[] { new[] { 60f } }, 0.1, 1.0);
+
+        Assert.IsTrue(fired,
+            "Real-mic sub-engine must fire OnTargetNoteChanged while on a note (drives the per-mic trail)");
+        Assert.IsNotNull(captured, "Emitted target note should be non-null");
+    }
+
+    [Test]
+    public void RealMic_TwoMics_BothSubEnginesFireOnTargetNoteChanged()
+    {
+        // Faithful to the reported repro: two real mics, two HARM parts. Each mic's own
+        // sub-engine must fire OnTargetNoteChanged so its needle's trail can render.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0 C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM1 E4
+
+        var engine = CreateCoordinator(parts, micCount: 2); // isBot = false
+        var fired = new bool[2];
+        engine.SubEngines[0].OnTargetNoteChanged += _ => fired[0] = true;
+        engine.SubEngines[1].OnTargetNoteChanged += _ => fired[1] = true;
+
+        engine.Update(0.1);
+        // Mic 0 sings C4 (HARM0), mic 1 sings E4 (HARM1) — each on its own line.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.1, 1.0);
+
+        Assert.IsTrue(fired[0], "Mic 0 sub-engine must fire OnTargetNoteChanged");
+        Assert.IsTrue(fired[1], "Mic 1 sub-engine must fire OnTargetNoteChanged");
+    }
+
+    [Test]
+    public void RealMic_TwoMics_MicOneLagging_StillFiresOnTargetNoteChanged()
+    {
+        // Robustness guard for the runtime queue ORDER from PartyVocalsPlayer.RouteMicInputs:
+        // mic 0's input is queued, then mic 1's at an EARLIER timestamp (mic 1 lagging),
+        // which BaseEngine.QueueInput snaps forward. This was a suspected cause of the
+        // missing trail (echoing bugfix #10) but turned out NOT to be — the emit survives
+        // frame-granularity disorder. Kept as a guard so the per-mic emit stays robust to it.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 0, 960, 64);
+
+        var engine = CreateCoordinator(parts, micCount: 2);
+        var fired = new bool[2];
+        engine.SubEngines[0].OnTargetNoteChanged += _ => fired[0] = true;
+        engine.SubEngines[1].OnTargetNoteChanged += _ => fired[1] = true;
+
+        engine.Update(0.1);
+        const double fps = 60.0;
+        int frames = (int)(0.9 * fps);
+        for (int f = 1; f <= frames; f++)
+        {
+            double t0 = 0.1 + f / fps;
+            double t1 = 0.1 + (f - 0.5) / fps; // mic 1 half a frame behind mic 0
+            var in0 = new GameInput(t0, PartyVocalsInput.Pack(0, VocalsAction.Pitch), 60f);
+            engine.QueueInput(ref in0);
+            var in1 = new GameInput(t1, PartyVocalsInput.Pack(1, VocalsAction.Pitch), 64f);
+            engine.QueueInput(ref in1); // queued after in0 but earlier time
+            engine.Update(t0);
+        }
+
+        Assert.IsTrue(fired[0], "Mic 0 fires OnTargetNoteChanged");
+        Assert.IsTrue(fired[1], "Mic 1 (lagging) must STILL fire OnTargetNoteChanged for its trail");
+    }
+
+    [Test]
+    public void RealMic_OnNote_GetMicHittingPartsNonZero()
+    {
+        // The trail's hitting-gate also requires LastOnNoteTime, refreshed from
+        // coordinator.GetMicHittingParts(mic). The fill meters use a DIFFERENT path
+        // (CanonicalMeters from the allocator/deltas), so meters filling does NOT prove
+        // this bitmask is non-zero. If it reads 0 while the mic is on a note, the trail
+        // dies even though the target-note emit fired and the meters moved.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60); // C4, child note spans ticks 0..480 (0..0.5s)
+
+        var engine = CreateCoordinator(parts, micCount: 1);
+        engine.Update(0.1);
+        // Sing C4 squarely inside the note window.
+        FeedPitches(engine, 1, new[] { new[] { 60f } }, 0.1, 0.3);
+
+        Assert.AreNotEqual(0u, engine.GetMicHittingParts(0),
+            "GetMicHittingParts must be non-zero while on a note (refreshes the trail's LastOnNoteTime)");
+    }
+
+    // ================================================================
+    // Event + Throttle Tests (16-17)
+    // AC11: Grading and event emission, AC13: HUD reads
+    // ================================================================
+
+    [Test]
+    public void OnPartyVocalsPhrase_FiresOncePerPhrase_WithGradeAndMeters()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 0, 960, 64);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "Should fire once per phrase");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0], "Both HARMs covered = DoubleAwesome");
+    }
+
+    [Test]
+    public void Throttle_CanonicalMetersRefreshAt100ms()
+    {
+        // During a phrase, meters update on the 100ms throttle.
+        // After <100ms: meters stay at initial value.
+        // After >=100ms: meters refresh.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 1920, 60); // Long phrase = 2.0s
+        AddPhrase(parts[1], 1920, 960, 64);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        // Feed for ~50ms (3 frames at 60fps)
+        for (int i = 0; i < 3; i++)
+        {
+            double t = 0.1 + (i + 1) / ApproximateVocalFps;
+            int packed0 = PartyVocalsInput.Pack(0, VocalsAction.Pitch);
+            var in0 = new GameInput(t, packed0, 60f);
+            engine.QueueInput(ref in0);
+            int packed1 = PartyVocalsInput.Pack(1, VocalsAction.Pitch);
+            var in1 = new GameInput(t, packed1, -1f);
+            engine.QueueInput(ref in1);
+            engine.Update(t);
+        }
+
+        var metersEarly = GetCanonicalMeters(engine);
+        // After only ~50ms, the 100ms throttle hasn't fired yet, so meters may still be 0
+        // (they could also have been updated if the throttle fires — this is timing-sensitive)
+        // We verify the meters are in a valid range [0,1]
+        Assert.GreaterOrEqual(metersEarly[0], 0.0, "Meter should be >= 0");
+        Assert.LessOrEqual(metersEarly[0], 1.0, "Meter should be <= 1");
+
+        // Feed for another ~100ms (7 more frames) to pass the 100ms throttle
+        double startTime = 0.1 + 4.0 / ApproximateVocalFps;
+        for (int i = 0; i < 7; i++)
+        {
+            double t = startTime + (i + 1) / ApproximateVocalFps;
+            int packed0 = PartyVocalsInput.Pack(0, VocalsAction.Pitch);
+            var in0 = new GameInput(t, packed0, 60f);
+            engine.QueueInput(ref in0);
+            int packed1 = PartyVocalsInput.Pack(1, VocalsAction.Pitch);
+            var in1 = new GameInput(t, packed1, -1f);
+            engine.QueueInput(ref in1);
+            engine.Update(t);
+        }
+
+        var metersLater = GetCanonicalMeters(engine);
+        Assert.Greater(metersLater[0], 0.0, "Meters should have positive value after >100ms of singing");
+        Assert.LessOrEqual(metersLater[0], 1.0, "Meter should not exceed 1.0");
+    }
+
+    // ================================================================
+    // Per-phrase state reset regression (issue: coordinator's ResetPhraseState
+    // was not clearing _micPartHits, leaving stale accumulation across phrase
+    // boundaries. Fixed by clearing all per-phrase arrays in ResetPhraseState.)
+    // ================================================================
+
+    [Test]
+    public void StateReset_PhraseBoundary_ClearsMicPartHitsAndPhraseTicksTotal()
+    {
+        // Two sequential HARM0-only phrases with DIFFERENT tick lengths, so a
+        // stale PhraseTicksTotal carried over from phrase 1 would be detectable
+        // when phrase 2 starts (the `??=` at top of UpdateHitLogic only assigns
+        // if PhraseTicksTotal is null — a stale non-null value would persist).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);     // Phrase 1: ticks 0-960 (1.0s)
+        AddPhrase(parts[0], 1920, 480, 60);  // Phrase 2: ticks 1920-2400 (0.5s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Phrase 1: sing HARM0 well to populate _micPartHits and PhraseTicksTotal.
+        engine.Update(0.05);
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { -1f } }, 0.05, 0.5);
+        // Advance past phrase 1's TickEnd (tick 960 → t=1.0s).
+        engine.Update(1.1);
+
+        Assert.AreEqual(1, grades.Count, "Phrase 1 should have graded");
+
+        // Inspect _micPartHits via reflection — ResetPhraseState must have cleared it.
+        // Without the fix, phrase 1's per-mic accumulation would still be sitting in
+        // the array, leaking into phrase 2's stats.
+        var micPartHitsField = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_micPartHits", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var micPartHits = (double[,])micPartHitsField.GetValue(engine)!;
+        double sumAfterPhrase1 = 0;
+        foreach (var v in micPartHits) sumAfterPhrase1 += v;
+        Assert.AreEqual(0.0, sumAfterPhrase1, Epsilon,
+            "_micPartHits must be cleared between phrases (regression: prior coordinator " +
+            "override skipped the base's Array.Clear of _micPartHits).");
+
+        // Drive into phrase 2 with no mic activity. PhraseTicksTotal must be
+        // re-derived for phrase 2 (480 ticks) — if the prior bug were present,
+        // it would still hold phrase 1's value (960) because `??=` doesn't
+        // overwrite a non-null value.
+        // Feed silent pitch to both mics via the queue
+        int packed0 = PartyVocalsInput.Pack(0, VocalsAction.Pitch);
+        var in0 = new GameInput(2.04, packed0, -1f);
+        engine.QueueInput(ref in0);
+        int packed1 = PartyVocalsInput.Pack(1, VocalsAction.Pitch);
+        var in1 = new GameInput(2.04, packed1, -1f);
+        engine.QueueInput(ref in1);
+        engine.Update(2.05); // within phrase 2 (tick 1920-2400 → t=2.0-2.5s)
+
+        // PhraseTicksTotal reflects the sum of lyric child-note ticks in the phrase.
+        // AddPhrase uses tickLength/2 for the lyric, so phrase 1 = 480, phrase 2 = 240.
+        // If the bug regressed (PhraseTicksTotal never nulled at phrase 1 end), the
+        // `??=` at top of UpdateHitLogic would leave it at 480 forever.
+        Assert.IsTrue(engine.PhraseTicksTotal.HasValue,
+            "PhraseTicksTotal should be populated for phrase 2");
+        Assert.AreEqual(240u, engine.PhraseTicksTotal!.Value,
+            "PhraseTicksTotal must reflect phrase 2's lyric ticks (240), not phrase 1's (480). " +
+            "Regression: prior coordinator override skipped the base's PhraseTicksTotal = null.");
+        Assert.AreNotEqual(480u, engine.PhraseTicksTotal!.Value,
+            "Explicit guard against the specific regression — phrase 1's stale value.");
+
+        // Finish phrase 2 with no singing → grade Miss.
+        engine.Update(3.0);
+        Assert.AreEqual(2, grades.Count, "Phrase 2 should have graded");
+        Assert.AreEqual(PhraseGrade.Miss, grades[1], "Phrase 2 with no singing = Miss");
+    }
+
+    // ================================================================
+    // Regression tests for issues found during real-game testing
+    // (post-merge of the per-phrase reset fix).
+    // ================================================================
+
+    [Test]
+    public void StatsPercent_AccumulatesTicksHitAndTicksMissed()
+    {
+        // Prior bug: coordinator's ProcessPhraseEnd skipped the
+        // EngineStats.TicksHit/TicksMissed accumulation that the base does. With
+        // both fields at 0, VocalsStats.Percent (TicksHit/TotalTicks) defaults to
+        // 1.0 (100%) when TotalTicks == 0 — making the end-of-song accuracy display
+        // show 100% even when the player missed phrases.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);    // Phrase 1: ticks 0-960
+        AddPhrase(parts[0], 960, 960, 60);  // Phrase 2: ticks 960-1920
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Phrase 1: sing well → Hit.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.05, 0.5);
+        engine.Update(1.1);
+
+        // Phrase 2: sing wrong pitch → Miss.
+        FeedPitches(engine, 2, new[] { new[] { 90f }, new[] { float.NaN } }, 1.05, 0.5);
+        engine.Update(2.1);
+
+        var stats = (VocalsStats) engine.BaseStats;
+        Assert.Greater(stats.TicksHit, 0u,
+            "TicksHit must accumulate on Hit phrases (regression: was 0).");
+        Assert.Greater(stats.TicksMissed, 0u,
+            "TicksMissed must accumulate on Miss phrases (regression: was 0).");
+        Assert.Less(stats.Percent, 1.0f,
+            "Percent must reflect real accuracy < 100% when there are misses " +
+            "(regression: VocalsStats.Percent defaults to 1.0 when TotalTicks == 0).");
+    }
+
+    [Test]
+    public void OnPhraseHit_FiresOnMissForIsFcFlip()
+    {
+        // Prior bug: coordinator never fired OnPhraseHit. VocalsPlayer.cs:486-489
+        // subscribes to OnPhraseHit to flip IsFc = false on !fullPoints — without
+        // this firing, the FC tile stays lit through misses.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+        bool hitEventFired = false;
+        bool hitEventFullPoints = true;
+        engine.OnPhraseHit += (percent, fullPoints, isLast) =>
+        {
+            hitEventFired = true;
+            hitEventFullPoints = fullPoints;
+        };
+
+        // Sing wrong pitch → Miss.
+        FeedPitches(engine, 2, new[] { new[] { 90f }, new[] { float.NaN } }, 0.05, 0.5);
+        engine.Update(1.1);
+
+        Assert.IsTrue(hitEventFired, "OnPhraseHit must fire on the coordinator path.");
+        Assert.IsFalse(hitEventFullPoints, "fullPoints must be false on Miss (drives IsFc flip).");
+    }
+
+    [Test]
+    public void StackingShortcut_TwoMicsTalkieHalfPhrase_GradeMiss()
+    {
+        // The bug the per-mic-span cap was added to fix.
+        // 2 mics both ambiguous on {0,1} for HALF a phrase (talkies + harmonized
+        // talkies are the typical real-game case). Under the prior additive-bucket
+        // model: bucket = 2 × N/2 = N, allocator filled HARM0 to 100% → Awesome.
+        // Equivalent unambiguous singing (2 mics on HARM1 half phrase) graded Miss.
+        // Inconsistency was the shortcut.
+        // Under per-mic-span cap: bucket = N, perMicCap = N/2. Each HARM can receive
+        // at most N/2 → both HARMs at 50% → below threshold → Miss. Consistent.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddTalkiePhrase(parts[0], 0, 960);
+        AddTalkiePhrase(parts[1], 0, 960);
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Both mics making noise for ONLY HALF the phrase (0.0-0.25s of a 0.0-0.5s
+        // content window) — they then go silent for the second half. Under the new
+        // model this is a Miss.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 0.25);
+        engine.Update(1.1); // past phrase end
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Miss, grades[0],
+            "Two mics on harmonized talkies for HALF the phrase must grade Miss " +
+            "(stacking shortcut prevention via per-mic-span cap).");
+    }
+
+    [Test]
+    public void TrueUnison_TwoMicsTalkieFullPhrase_DoubleAwesome()
+    {
+        // Companion to the stacking-shortcut test: 2 mics ambiguous on a harmonized
+        // talkie for the FULL phrase should still grade DoubleAwesome. Bucket = 2N,
+        // perMicCap = N. Each HARM receives up to N (= capacity). Both filled.
+        // Verifies the per-mic-span cap doesn't break Goal G1 (true unison → Double).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddTalkiePhrase(parts[0], 0, 960);
+        AddTalkiePhrase(parts[1], 0, 960);
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Both mics making noise for the WHOLE phrase content window.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 0.55);
+        engine.Update(1.1);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0],
+            "Two mics on harmonized talkies for the FULL phrase = DoubleAwesome " +
+            "(per-mic-span cap permits both HARMs when each mic vouches for a full span).");
+    }
+
+    [Test]
+    public void EmptyPhrase_TreatedAsHit_NoSpuriousMiss()
+    {
+        // Prior bug: phraseTicksTotal == 0 (lyric-less phrase) went through the
+        // allocator → all-zero meters → grade Miss → MissNote. The base treats
+        // empty phrases as a free Hit. Coordinator now short-circuits to match.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        // Phrase with non-zero tick length but no child lyric notes (phraseTicksTotal == 0).
+        var emptyNote = new VocalNote(NoteFlags.None, false, 0.0, 2.0, 0, 960);
+        parts[0].NotePhrases.Add(new VocalsPhrase(
+            0.0, 2.0, 0, 960, emptyNote, new List<LyricEvent>()));
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        engine.Update(1.5); // past the empty phrase's TickEnd
+
+        Assert.AreEqual(1, grades.Count, "Empty phrase should still emit a grade event");
+        Assert.AreNotEqual(PhraseGrade.Miss, grades[0],
+            "Empty phrase should NOT grade as Miss (base treats it as Hit).");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit,
+            "Empty phrase should count as a NotesHit (HitNote was called).");
+    }
+
+    [Test]
+    public void PartInCurrentPhrase_ReflectsPerPartPresence()
+    {
+        // Three parts: HARM0 at tick 0-960, HARM2 at tick 0-960, HARM1 has no phrase.
+        // After running through the phrase, PartInCurrentPhrase(0) and (2) should be true,
+        // PartInCurrentPhrase(1) should be false.
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(), CreateVocalsPart(true), CreateVocalsPart(true)
+        };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0
+        AddPhrase(parts[2], 0, 960, 67); // HARM2
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        // Drive into the phrase so _phraseTicksTotalPerPart gets populated.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.1, 0.3);
+
+        Assert.IsTrue(engine.PartInCurrentPhrase(0), "HARM0 has notes in this phrase");
+        Assert.IsFalse(engine.PartInCurrentPhrase(1), "HARM1 has no notes in this phrase");
+        Assert.IsTrue(engine.PartInCurrentPhrase(2), "HARM2 has notes in this phrase");
+        Assert.IsFalse(engine.PartInCurrentPhrase(-1), "Negative index → false");
+        Assert.IsFalse(engine.PartInCurrentPhrase(99), "Out-of-range index → false");
+    }
+
+    [Test]
+    public void Bot_HitsPercussionNote()
+    {
+        // A Party Vocals bot should hit percussion notes. The coordinator scores percussion
+        // via HasHit, which is only set by a queued Hit input (MutateStateWithInput). Bots
+        // queue no inputs and the coordinator's UpdateBot is a no-op, so a bot currently
+        // never scores percussion (live mics do). Repro for the reported bug.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960); // percussion at tick 480 (t=0.5s)
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), EngineParams, isBot: true, micCount: 1);
+
+        int percussionHits = 0;
+        engine.OnNoteHit += (_, note) => { if (note.IsPercussion) percussionHits++; };
+
+        int totalFrames = (int) (2.0 * ApproximateVocalFps);
+        for (int f = 0; f < totalFrames; f++)
+            engine.Update((f + 1) / ApproximateVocalFps);
+
+        Assert.That(percussionHits, Is.EqualTo(1),
+            "A Party Vocals bot should hit the percussion note.");
+    }
+
+    [Test]
+    public void PartInNextPhrase_ReflectsNextPhrasePerPartPresence()
+    {
+        // Master (parts[0]) has TWO phrases: tick 0-960 and tick 1920-2880.
+        // While in the first phrase, "next phrase" is the tick 1920-2880 window.
+        //   HARM0: present in next (its own second phrase).
+        //   HARM1: present in next (charted at 1920-2880).
+        //   HARM2: present only in the FIRST phrase (0-960) → absent in next.
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(), CreateVocalsPart(true), CreateVocalsPart(true)
+        };
+        AddPhrase(parts[0], 0, 960, 60);     // HARM0 phrase 1
+        AddPhrase(parts[0], 1920, 960, 60);  // HARM0 phrase 2 (the "next" master phrase)
+        AddPhrase(parts[1], 1920, 960, 64);  // HARM1 only in the next phrase
+        AddPhrase(parts[2], 0, 960, 67);     // HARM2 only in the first phrase
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1); // NoteIndex = 0 (first phrase)
+
+        Assert.IsTrue(engine.PartInNextPhrase(0), "HARM0 has a note in the next phrase");
+        Assert.IsTrue(engine.PartInNextPhrase(1), "HARM1 has a note in the next phrase");
+        Assert.IsFalse(engine.PartInNextPhrase(2), "HARM2 is only in the current phrase");
+        Assert.IsFalse(engine.PartInNextPhrase(-1), "Negative index → false");
+        Assert.IsFalse(engine.PartInNextPhrase(99), "Out-of-range index → false");
+    }
+
+    [Test]
+    public void CurrentPhraseProgress_TracksTickSpanOfCurrentPhrase()
+    {
+        // Phrase spans tick 0-960 = t 0.0..1.0 (480 tpqn @120bpm). At t=0.5 the engine is
+        // halfway through the phrase span, so progress ≈ 0.5 — driven by the SPAN, not by
+        // how much was sung.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.5);
+
+        Assert.That(engine.CurrentPhraseProgress, Is.EqualTo(0.5).Within(0.05),
+            "Progress should reflect position within the phrase's tick span");
+    }
+
+    [Test]
+    public void CurrentPhraseDurationSeconds_ReflectsPhraseSpan()
+    {
+        // AddPhrase hardcodes the parent phrase note's Time=0.0 / TimeLength=2.0 (the same
+        // tick-vs-time helper artifact the percussion tests note), so TimeEnd-Time = 2.0s
+        // here. In real charts the parent note's time span is accurate; this just verifies
+        // the accessor returns TimeEnd - Time of the current phrase.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        Assert.That(engine.CurrentPhraseDurationSeconds, Is.EqualTo(2.0).Within(0.001),
+            "Duration should be the current phrase's time span (TimeEnd - Time)");
+    }
+
+    [Test]
+    public void Bot_ThreeMicsThreeHarms_EachBotHitsItsPart()
+    {
+        // Regression guard: bot Party Vocals builds one sub-engine per HARM part
+        // (micCount == part count). Each bot sub-engine must self-drive via UpdateBot
+        // and hit its assigned part, so the coordinator credits every part and the
+        // phrase grades as a hit. This path was never exercised by existing tests
+        // (CreateCoordinator passes isBot=false and feeds pitches manually); here we
+        // drive a real bot coordinator with no SetMicPitch calls.
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: true),
+            CreateVocalsPart(isHarmony: true),
+            CreateVocalsPart(isHarmony: true),
+        };
+        AddPhrase(parts[0], 0, 960, 60); // HARM1 C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM2 E4
+        AddPhrase(parts[2], 0, 960, 67); // HARM3 G4
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), EngineParams, isBot: true, micCount: 3);
+
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Drive the bots through the phrase at ~60fps; bots self-generate pitch, so
+        // we deliberately do NOT call SetMicPitch.
+        int totalFrames = (int) (2.0 * ApproximateVocalFps);
+        for (int f = 0; f < totalFrames; f++)
+            engine.Update((f + 1) / ApproximateVocalFps);
+
+        Assert.AreEqual(1, grades.Count, "Bot phrase should be graded once");
+        Assert.AreNotEqual(PhraseGrade.Miss, grades[0],
+            "Bots should hit their assigned parts, not miss");
+        Assert.Greater(((VocalsStats)engine.BaseStats).TicksHit, 0u,
+            "Bot hits should accumulate TicksHit");
+    }
+
+    // ================================================================
+    // Coordinator Percussion Scoring Tests (18-22)
+    // percussion.AC1: Any mic tap scores
+    // percussion.AC2: No double-count
+    // percussion.AC5: No false hit
+    // ================================================================
+
+    [Test]
+    public void Percussion_TapWithDueNote_ScoresPercussionNote_AC1_1()
+    {
+        // AC1.1: A tap with a due percussion note scores it.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960); // Percussion note at tick 480 (t=0.5s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitFired = false;
+        engine.OnNoteHit += (noteIndex, note) => hitFired = true;
+
+        // Drive to the note's time
+        engine.Update(0.5);
+
+        // Queue a single Hit input within the note's hit window
+        var hitInput = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+
+        // Advance to process the hit (phrase ends at tick 1440 = t=1.5s)
+        engine.Update(1.6);
+
+        // The percussion note should have been scored
+        Assert.IsTrue(hitFired, "OnNoteHit should have fired for the percussion note");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit, "NotesHit should increase by 1");
+    }
+
+    [Test]
+    public void Percussion_EarlyTapWithinHitWindow_ScoresPercussionNote_WindowRepro()
+    {
+        // RED repro for docs/bugs/party-vocals-percussion-broken.md (Problem 2).
+        // A tap landing 0.03s EARLY on a short, realistically-timed percussion note is
+        // well inside the engine's ±0.05s hit window. Solo (YargVocalsEngine) scores it
+        // via IsNoteInWindow (front/back tolerance). The coordinator gates on the raw
+        // span CurrentTime >= percussion.Time, which gives ZERO early tolerance, so the
+        // tap is dropped. This is why runtime taps reach the engine (logs A+B fire) but
+        // never score (log C never fires).
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        // Percussion at tick 4800 = t=5.0s (480 tpqn @120bpm). The raw span is [5.0, 5.5];
+        // the engine hit window is [4.95, 5.05].
+        AddPercussionPhrase(parts[0], 4800, 960);
+
+        var engine = CreateCoordinator(parts, 2);
+        int percussionHits = 0;
+        engine.OnNoteHit += (_, note) => { if (note.IsPercussion) percussionHits++; };
+
+        engine.Update(4.9);
+        // Tap at t=4.97: inside the hit window [4.95, 5.05], but BEFORE the raw span
+        // [5.0, 5.5] the old code required (CurrentTime >= percussion.Time).
+        var hit = GameInput.Create(4.97, VocalsAction.Hit, true);
+        engine.QueueInput(ref hit);
+        engine.Update(6.5); // process the tap, then advance past phrase end
+
+        Assert.AreEqual(1, percussionHits,
+            "An early tap within the hit window should score the percussion note, " +
+            "matching solo YargVocalsEngine. The coordinator's raw [Time, TimeEnd] gate drops it.");
+    }
+
+    [Test]
+    public void Percussion_TapScoresNextDueNote_AC1_2()
+    {
+        // AC1.2: The note scored is the next due percussion note per GetNextPercussionNote windowing.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960);  // First percussion note at tick 480 (t=0.5s)
+        AddPercussionPhrase(parts[0], 1920, 960); // Second percussion note at tick 1920 (t=2.0s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitNoteIndex = -1;
+        engine.OnNoteHit += (noteIndex, note) => hitNoteIndex = noteIndex;
+
+        // Drive to the first note's time
+        engine.Update(0.5);
+
+        // Queue a single Hit input within the first note's hit window
+        var hitInput = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+
+        // Advance to process the hit (first phrase ends at tick 1440 = t=1.5s)
+        engine.Update(1.6);
+
+        // The first note (index 0) should have been scored, not the second
+        Assert.AreEqual(0, hitNoteIndex, "First note (index 0) should have been scored");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit, "Only one note should have been scored");
+    }
+
+    [Test]
+    public void Percussion_TwoMicsSameNote_ScoreOnce_AC2_1()
+    {
+        // AC2.1: Multiple mics tapping the same due percussion note score it exactly once.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960); // Percussion note at tick 480 (t=0.5s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitFired = false;
+        engine.OnNoteHit += (noteIndex, note) => hitFired = true;
+
+        // Drive to the note's time
+        engine.Update(0.5);
+
+        // Queue Hit inputs from both mics (coordinator aggregates into single HasHit)
+        var hitInput1 = GameInput.Create(0.5, VocalsAction.Hit, true);
+        var hitInput2 = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput1);
+        engine.QueueInput(ref hitInput2);
+
+        // Advance to process the hits (phrase ends at tick 1440 = t=1.5s)
+        engine.Update(1.6);
+
+        // The note should have been scored exactly once (HasHit is shared across mics)
+        Assert.IsTrue(hitFired, "OnNoteHit should have fired");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit, "Note should be scored exactly once, not twice");
+    }
+
+    [Test]
+    public void Percussion_TapWithNoDueNote_NoScore_AC5_1()
+    {
+        // AC5.1: A tap with no due percussion note does not score; HasHit is consumed.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 960, 960, 60); // Regular note (not percussion) at tick 960-1920
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitFired = false;
+        engine.OnNoteHit += (noteIndex, note) => hitFired = true;
+
+        // Drive to time but no percussion note is due yet
+        engine.Update(0.5);
+
+        // Queue a Hit input
+        var hitInput = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+
+        // Advance to process the hit (need to advance past phrase end)
+        engine.Update(1.5); // Phrase ends at tick 480 (t=1.0s)
+
+        // No note should have been scored
+        Assert.IsFalse(hitFired, "OnNoteHit should not fire when no percussion note is due");
+        Assert.AreEqual(0, engine.BaseStats.NotesHit, "NotesHit should not increase");
+    }
+
+    // ================================================================
+    // Tests for mic packing and input demux (Subcomponent A)
+    // ================================================================
+
+    private static void QueueAndUpdate(PartyVocalsCoordinatorEngine engine, GameInput input)
+    {
+        engine.QueueInput(ref input);
+        engine.Update(0.5);
+    }
+
+    [Test]
+    public void PitchRouting_PackedInput_RoutesToCorrectMic_AC32()
+    {
+        // AC32: Pitch input packed for mic k routes to sub-engine k
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60); // Note at tick 0-960
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue pitch for mic 0
+        var packedPitch0 = new GameInput(0.5, PartyVocalsInput.Pack(0, VocalsAction.Pitch), 100f);
+        QueueAndUpdate(engine, packedPitch0);
+
+        // Queue pitch for mic 1
+        var packedPitch1 = new GameInput(0.5, PartyVocalsInput.Pack(1, VocalsAction.Pitch), 200f);
+        QueueAndUpdate(engine, packedPitch1);
+
+        // Verify pitch values reached correct sub-engines
+        Assert.AreEqual(100f, engine.GetMicPitch(0), Epsilon);
+        Assert.AreEqual(200f, engine.GetMicPitch(1), Epsilon);
+    }
+
+    [Test]
+    public void PitchRouting_UnpackedInput_DegradesToMic0_AC32()
+    {
+        // AC32: Unpacked input (no mic bits) routes to mic 0
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue unpacked pitch (mic 0 equivalent)
+        var unpackedPitch = GameInput.Create(0.5, VocalsAction.Pitch, 300f);
+        QueueAndUpdate(engine, unpackedPitch);
+
+        // Verify it routes to mic 0
+        Assert.AreEqual(300f, engine.GetMicPitch(0), Epsilon);
+        Assert.AreEqual(0f, engine.GetMicPitch(1), Epsilon);
+    }
+
+    [Test]
+    public void PitchRouting_OutOfRangeMic_DroppedWithoutException_AC32()
+    {
+        // AC32: Pitch packed for mic >= _micCount is dropped
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue pitch for out-of-range mic (2, but we only have 2 mics: 0,1)
+        var packedPitchOutOfRange = new GameInput(0.5, PartyVocalsInput.Pack(2, VocalsAction.Pitch), 400f);
+        QueueAndUpdate(engine, packedPitchOutOfRange);
+
+        // Verify no state changed
+        Assert.AreEqual(0f, engine.GetMicPitch(0), Epsilon);
+        Assert.AreEqual(0f, engine.GetMicPitch(1), Epsilon);
+    }
+
+    [Test]
+    public void Hit_StarPower_PackedInput_SetsCoordinatorFlags_AC32()
+    {
+        // AC32: Hit/StarPower packed inputs set coordinator-level flags
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue packed StarPower
+        var packedSP = new GameInput(1.0, PartyVocalsInput.Pack(1, VocalsAction.StarPower), true);
+        engine.QueueInput(ref packedSP);
+        engine.Update(1.0);
+
+        Assert.IsTrue(engine.IsStarPowerInputActive);
+    }
+
+    [Test]
+    public void ActionPack_RoundTrip_RecoversOriginalValues_AC32()
+    {
+        // AC32: Pack -> UnpackMic/UnpackAction round-trip preserves original values
+        for (int mic = 0; mic <= 6; mic++)
+        {
+            foreach (VocalsAction action in Enum.GetValues<VocalsAction>())
+            {
+                int packed = PartyVocalsInput.Pack(mic, action);
+                int unpackedMic = PartyVocalsInput.UnpackMic(packed);
+                VocalsAction unpackedAction = PartyVocalsInput.UnpackAction(packed);
+
+                Assert.AreEqual(mic, unpackedMic);
+                Assert.AreEqual(action, unpackedAction);
+            }
+        }
+    }
+
+    [Test]
+    public void SangFlag_SetByPitch_DidMicSingThisTick_AC32()
+    {
+        // AC32: _micSangThisTick set by Pitch, exposed via accessors
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Initially all flags should be false
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+        Assert.IsFalse(engine.DidMicSingThisTick(1));
+
+        // Queue pitch for mic 1
+        var packedPitch1 = new GameInput(0.5, PartyVocalsInput.Pack(1, VocalsAction.Pitch), 200f);
+        QueueAndUpdate(engine, packedPitch1);
+
+        // Only mic 1 should have sang
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+        Assert.IsTrue(engine.DidMicSingThisTick(1));
+
+        // Reset flags
+        engine.ResetMicSangFlags();
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+        Assert.IsFalse(engine.DidMicSingThisTick(1));
+    }
+
+    [Test]
+    public void SangFlag_HitOrStarPower_DoesNotSetSangFlag_AC32()
+    {
+        // AC32: Hit/StarPower inputs do not set sang flag
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue Hit
+        var packedHit = new GameInput(0.5, PartyVocalsInput.Pack(0, VocalsAction.Hit), true);
+        QueueAndUpdate(engine, packedHit);
+
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+
+        // Queue StarPower
+        var packedSP = new GameInput(1.0, PartyVocalsInput.Pack(1, VocalsAction.StarPower), true);
+        QueueAndUpdate(engine, packedSP);
+
+        Assert.IsFalse(engine.DidMicSingThisTick(1));
+    }
+
+    // ================================================================
+    // Hit routing invariant (AC34 structural)
+    // Hit reaches coordinator only — sub-engines receive no queued Hit,
+    // so sub-engine CheckPercussionHit cannot fire from input.
+    // ================================================================
+
+    [Test]
+    public void Hit_RoutesToCoordinatorOnly_SubEnginesNotFedInput_AC34()
+    {
+        // Verify that Hit inputs queued to the coordinator set only the coordinator's
+        // HasHit — sub-engines do not have their MutateStateWithInput called (they
+        // receive no queued input; they're driven via Update + SetMicPitch).
+        // This is the structural invariant that prevents double percussion scoring.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 0, 960, 64);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        // Queue Hit inputs from two different mics
+        for (int m = 0; m < 2; m++)
+        {
+            var hit = new GameInput(0.15, PartyVocalsInput.Pack(m, VocalsAction.Hit), true);
+            engine.QueueInput(ref hit);
+        }
+        engine.Update(0.2);
+
+        // The coordinator consumed HasHit during CheckPercussionHit (no percussion
+        // in this chart, so it was a no-op). The key invariant is that the coordinator
+        // demux routed Hit to coordinator.HasHit, not to any sub-engine's input queue.
+        // Sub-engines have no input queue — they are driven solely via Update(time).
+        // Verify by checking the sub-engines' MutateStateWithInput was never called:
+        // their input queue count must be zero.
+        var subEnginesField = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_subEngines", BindingFlags.NonPublic | BindingFlags.Instance);
+        var subEngines = (YargFreeVocalsEngine[])subEnginesField.GetValue(engine)!;
+
+        foreach (var sub in subEngines)
+        {
+            var inputQueueField = typeof(BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats>)
+                .GetField("InputQueue", BindingFlags.NonPublic | BindingFlags.Instance);
+            var queue = (System.Collections.Generic.Queue<GameInput>)inputQueueField.GetValue(sub)!;
+            Assert.AreEqual(0, queue.Count,
+                "Sub-engine input queue must be empty — sub-engines receive no queued input");
+        }
+    }
+
+    // ================================================================
+    // Sing-to-activate star power tests (overdrive.AC1, AC2)
+    // ================================================================
+
+    private static void BankStarPower(PartyVocalsCoordinatorEngine engine, uint ticks)
+    {
+        engine.EngineStats.StarPowerTickAmount += ticks;
+    }
+
+    /// overdrive.AC1.1: A hit (sing-to-activate noise) deploys SP when flag is on and SP is banked.
+    [Test]
+    public void SingToActivate_DeploysStarPower_WhenSingingAndSpBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+
+        // Queue a Hit action (mirrors how solo engine triggers sing-to-activate
+        // via HasHit in CheckPercussionHit's else branch)
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "Sing-to-activate should deploy SP on hit when SP is banked");
+    }
+
+    /// overdrive.AC1.2: No deploy when CanStarPowerActivate is false.
+    [Test]
+    public void SingToActivate_DoesNotDeploy_WhenSpNotBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        engine.Update(0.1);
+        Assert.That(engine.CanStarPowerActivate, Is.False);
+
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.False,
+            "SP must not activate when CanStarPowerActivate is false");
+    }
+
+    /// overdrive.AC1.3: No deploy when sing-to-activate is off.
+    [Test]
+    public void SingToActivate_DoesNotDeploy_WhenFlagOff()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2, EngineParamsNoSingToActivate);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.False,
+            "SP must not activate via hit when SingToActivateStarPower is off");
+    }
+
+    /// SP earning: singing a star power phrase should award SP ticks to the coordinator.
+    [Test]
+    public void SingingSpPhrase_AwardsStarPower_ToCoordinator()
+    {
+        // Create a part with a single phrase that has StarPower flags.
+        var part = CreateVocalsPart();
+        uint phraseTick = 0;
+        uint phraseTickLength = 960; // 2 beats at 480 ticks/beat
+        int midiPitch = 60; // C4
+
+        var note = new VocalNote(NoteFlags.StarPower, false, 0.0, 2.0, phraseTick, phraseTickLength);
+        var lyricNote = new VocalNote(midiPitch, 0, VocalNoteType.Lyric, 0.0, 1.0, phraseTick, phraseTickLength / 2);
+        note.AddChildNote(lyricNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.None, "La", 0.0, phraseTick) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, phraseTick, phraseTickLength, note, lyrics));
+
+        var parts = new List<VocalsPart> { part };
+        var engine = CreateCoordinator(parts, 1);
+
+        // Verify the note track has SP flag via reflection (Notes is protected)
+        var notesField = typeof(BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats>)
+            .GetField("Notes", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(notesField, "Should find Notes field via reflection");
+        var notes = (System.Collections.Generic.List<VocalNote>)notesField!.GetValue(engine)!;
+        Assert.That(notes[0].IsStarPower, Is.True, "Phrase should have StarPower flag");
+
+        engine.Update(0.1);
+
+        // Feed pitch inputs matching the note for the entire phrase duration
+        float[] micPitches = { midiPitch };
+        FeedPitches(engine, 1, new[] { micPitches }, 0.1, 2.5);
+
+        // Process past phrase end
+        engine.Update(3.0);
+
+        // The coordinator should have earned star power
+        Assert.That(engine.EngineStats.StarPowerTickAmount, Is.GreaterThan(0),
+            "Coordinator should have earned star power from singing a SP phrase");
+        Assert.That(engine.EngineStats.StarPowerPhrasesHit, Is.EqualTo(1),
+            "Should have recorded exactly one SP phrase hit");
+    }
+
+    /// SP earning regression: a per-mic sub-engine that MISSES a star power phrase
+    /// must not strip the StarPower flag off the shared VocalNote before the
+    /// coordinator scores that phrase.
+    ///
+    /// The coordinator and every sub-engine are built from the same note track, so
+    /// they share the same VocalNote objects. The coordinator drives all sub-engines
+    /// (including their phrase-end logic) *before* running its own phrase-end. A
+    /// sub-engine that misses calls MissNote -> StripStarPower, clearing the flag on
+    /// the shared note; the coordinator then reads IsStarPower == false and awards
+    /// nothing — even though it graded the phrase a hit. This is why a real singer
+    /// never earned SP while a bot (whose sub-engines always hit, never strip) did.
+    ///
+    /// Repro: two mics on one SP phrase. Mic 0 sings it (coordinator aggregate hits);
+    /// mic 1 is silent (its sub-engine misses and strips). Expect SP still awarded.
+    [Test]
+    public void SubEngineMiss_DoesNotStripStarPower_FromCoordinatorScoring()
+    {
+        var part = CreateVocalsPart();
+        uint phraseTick = 0;
+        uint phraseTickLength = 960;
+        int midiPitch = 60; // C4
+
+        var note = new VocalNote(NoteFlags.StarPower, false, 0.0, 2.0, phraseTick, phraseTickLength);
+        var lyricNote = new VocalNote(midiPitch, 0, VocalNoteType.Lyric, 0.0, 1.0, phraseTick, phraseTickLength / 2);
+        note.AddChildNote(lyricNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.None, "La", 0.0, phraseTick) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, phraseTick, phraseTickLength, note, lyrics));
+
+        var parts = new List<VocalsPart> { part };
+        var engine = CreateCoordinator(parts, 2); // two mics
+
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        engine.Update(0.1);
+
+        // Mic 0 sings the SP phrase; mic 1 stays silent (NaN sentinel = no input),
+        // so mic 1's sub-engine misses the phrase and runs StripStarPower.
+        FeedPitches(engine, 2,
+            new[] { new[] { (float) midiPitch }, new[] { float.NaN } },
+            0.1, 2.5);
+
+        engine.Update(3.0);
+
+        // Guard: the coordinator must actually grade the phrase a hit, so a failure
+        // below isolates the SP-award bug rather than a scoring miss.
+        Assert.That(grades, Has.Some.Not.EqualTo(PhraseGrade.Miss),
+            "Mic 0 sang the phrase, so the coordinator should grade it a hit");
+
+        Assert.That(engine.EngineStats.StarPowerTickAmount, Is.GreaterThan(0u),
+            "Coordinator must earn SP on a phrase it grades a hit, even though a silent " +
+            "mic's sub-engine missed it (the sub-engine's MissNote stripped the shared " +
+            "StarPower flag before the coordinator scored the phrase).");
+        Assert.That(engine.EngineStats.StarPowerPhrasesHit, Is.EqualTo(1),
+            "Should record exactly one SP phrase hit");
+    }
+
+    /// overdrive.AC2.1: Manual button deploy still works.
+    [Test]
+    public void ManualDeploy_ActivatesStarPower_WhenSpBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+        Assert.That(engine.CanStarPowerActivate, Is.True);
+
+        int packed = PartyVocalsInput.Pack(0, VocalsAction.StarPower);
+        var input = new GameInput(0.15, packed, true);
+        engine.QueueInput(ref input);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "Manual StarPower button should deploy SP when banked");
+    }
+
+    /// Bot deploy: a Party Vocals *bot* must self-activate star power once it has
+    /// enough banked, exactly like the solo bot (YargVocalsEngine.UpdateBot toggles
+    /// IsStarPowerInputActive). The coordinator's UpdateBot is a no-op and the per-mic
+    /// sub-engines only toggle their own (dead-data) IsStarPowerInputActive, so the
+    /// authoritative coordinator never set it for a bot — the bot never deployed.
+    [Test]
+    public void BotCoordinator_DeploysStarPower_WhenBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        // A phrase so the coordinator's UpdateHitLogic doesn't early-return on "no notes".
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), EngineParams, isBot: true, micCount: 1);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+        Assert.That(engine.CanStarPowerActivate, Is.True, "precondition: a half bar is banked");
+
+        // No input is fed — a bot must self-activate.
+        engine.Update(0.5);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "A Party Vocals bot with banked SP should deploy it (like the solo bot). The " +
+            "coordinator never toggled IsStarPowerInputActive for bots, so it never fired.");
+    }
+
+    /// <summary>
+    /// AC.6: Star-power deploys exactly once per qualifying input. Asserting the activation
+    /// COUNT (not just IsStarPowerActive) is strictly stronger — it proves a fresh deploy
+    /// occurred for this input, not just that SP was already active from a prior tick.
+    /// Approach (A) owns the singing/percussion/SP flow in the subclass (the base path
+    /// never runs), so the inherited-base double-fire hazard is avoided by design.
+    /// </summary>
+    [Test]
+    public void Coordinator_DeploysStarPower_OncePerBank()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        // Precondition: no activations yet.
+        Assert.That(engine.BaseStats.StarPowerActivationCount, Is.EqualTo(0),
+            "precondition: no SP activations yet");
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+
+        // Trigger sing-to-activate via a Hit input (mirrors solo engine's path).
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.BaseStats.StarPowerActivationCount, Is.EqualTo(1),
+            "Exactly one fresh SP deploy should occur for this qualifying input — " +
+            "not zero (missed deploy) and not >1 (double-activation hazard).");
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "SP should be active after deploy");
+    }
+
+}

--- a/YARG.Core.UnitTests/Engine/PartyVocalsCoordinatorEngineTests.cs
+++ b/YARG.Core.UnitTests/Engine/PartyVocalsCoordinatorEngineTests.cs
@@ -1,0 +1,1698 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Vocals;
+using YARG.Core.Engine.Vocals.Engines;
+using YARG.Core.Input;
+
+namespace YARG.Core.UnitTests.Engine;
+
+[TestFixture]
+public sealed class PartyVocalsCoordinatorEngineTests
+{
+    private const double AwesomeThreshold = 0.75;
+    private const double Epsilon = 1e-9;
+    private const double ApproximateVocalFps = 60.0;
+
+    private static readonly VocalsEngineParameters EngineParams = new(
+        new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1, 1, 0, 0),
+        4,
+        VocalsEngineTests.StarMultiplierThresholds,
+        VocalsEngineTests.SoloBonusStarMultiplierThresholds,
+        1.5f, 0.5f, AwesomeThreshold, 60.0, true, 1000);
+
+    private static readonly VocalsEngineParameters EngineParamsNoSingToActivate = new(
+        new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1, 1, 0, 0),
+        4,
+        VocalsEngineTests.StarMultiplierThresholds,
+        VocalsEngineTests.SoloBonusStarMultiplierThresholds,
+        1.5f, 0.5f, AwesomeThreshold, 60.0, false, 1000);
+
+    private static readonly FieldInfo HarmDirectTicksField =
+        typeof(PartyVocalsCoordinatorEngine).GetField("_harmDirectTicks",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find _harmDirectTicks");
+
+    private static readonly FieldInfo AmbiguityBucketsField =
+        typeof(PartyVocalsCoordinatorEngine).GetField("_ambiguityBuckets",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find _ambiguityBuckets");
+
+    private static readonly MethodInfo RunAllocatorMethod =
+        typeof(PartyVocalsCoordinatorEngine).GetMethod("RunAllocatorIntoCanonicalMeters",
+            BindingFlags.NonPublic | BindingFlags.Instance)
+        ?? throw new InvalidOperationException("Could not find RunAllocatorIntoCanonicalMeters");
+
+    // ================================================================
+    // Helpers
+    // ================================================================
+
+    private static VocalsPart CreateVocalsPart(bool isHarmony = false) =>
+        new(isHarmony, new(), new(), new(), new());
+
+    private static SyncTrack CreateSyncTrack()
+    {
+        var sync = new SyncTrack(480);
+        sync.Tempos.Add(new TempoChange(120.0, 0.0, 0));
+        sync.TimeSignatures.Add(new TimeSignatureChange(4, 4, 0.0, 0, 0, 0, 0, 0));
+        return sync;
+    }
+
+    private static void AddPhrase(VocalsPart part, uint tickOffset, uint tickLength, int midiPitch)
+    {
+        var note = new VocalNote(NoteFlags.None, false, 0.0, 2.0, tickOffset, tickLength);
+        var lyricNote = new VocalNote(midiPitch, 0, VocalNoteType.Lyric, 0.0, 1.0, tickOffset, tickLength / 2);
+        note.AddChildNote(lyricNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.None, "La", 0.0, tickOffset) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, tickOffset, tickLength, note, lyrics));
+    }
+
+    // 480 tpqn @ 120bpm => seconds = tick / 960.0. The percussion child note's Time tracks
+    // its tick. (Previously this hardcoded Time=0.0/TimeLength=1.0, giving every note the
+    // hit window [0.0, 1.0] — wide and zero-anchored, which masked the coordinator's
+    // percussion-window bug; see docs/bugs/party-vocals-percussion-broken.md.)
+    private static void AddPercussionPhrase(VocalsPart part, uint tickOffset, uint tickLength)
+    {
+        const double secondsPerTick = 1.0 / 960.0;
+        double phraseTime = tickOffset * secondsPerTick;
+        double phraseLen = tickLength * secondsPerTick;
+        uint percTickLen = tickLength / 2;
+
+        var note = new VocalNote(NoteFlags.None, false, phraseTime, phraseLen, tickOffset, tickLength);
+        var percussionNote = new VocalNote(-1, 0, VocalNoteType.Percussion,
+            phraseTime, percTickLen * secondsPerTick, tickOffset, percTickLen);
+        note.AddChildNote(percussionNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.NonPitched, "Perc", phraseTime, tickOffset) };
+        part.NotePhrases.Add(new VocalsPhrase(phraseTime, phraseLen, tickOffset, tickLength, note, lyrics));
+    }
+
+    private static void AddTalkiePhrase(VocalsPart part, uint tickOffset, uint tickLength)
+    {
+        var note = new VocalNote(NoteFlags.None, false, 0.0, 2.0, tickOffset, tickLength);
+        var talkieNote = new VocalNote(-1, 0, VocalNoteType.Lyric, 0.0, 1.0, tickOffset, tickLength / 2);
+        note.AddChildNote(talkieNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.NonPitched, "Talk", 0.0, tickOffset) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, tickOffset, tickLength, note, lyrics));
+    }
+
+    private static PartyVocalsCoordinatorEngine CreateCoordinator(
+        List<VocalsPart> parts, int micCount)
+    {
+        return CreateCoordinator(parts, micCount, EngineParams);
+    }
+
+    private static PartyVocalsCoordinatorEngine CreateCoordinator(
+        List<VocalsPart> parts, int micCount, VocalsEngineParameters engineParams)
+    {
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        return new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), engineParams, false, micCount);
+    }
+
+    private static (PartyVocalsCoordinatorEngine engine, List<PhraseGrade> grades) RunCoordinatorScenario(
+        List<VocalsPart> parts, int micCount, Action<PartyVocalsCoordinatorEngine> feedAction, double endTime)
+    {
+        var engine = CreateCoordinator(parts, micCount);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+        engine.Update(0.1);
+        feedAction(engine);
+        engine.Update(endTime);
+        return (engine, grades);
+    }
+
+    private static void FeedPitches(PartyVocalsCoordinatorEngine engine, int micCount,
+        float[][] micPitchArrays, double startTime, double duration)
+    {
+        int totalFrames = (int)(duration * ApproximateVocalFps);
+        for (int f = 0; f < totalFrames; f++)
+        {
+            double time = startTime + (f + 1) / ApproximateVocalFps;
+            for (int m = 0; m < micCount; m++)
+            {
+                int idx = Math.Min(f, micPitchArrays[m].Length - 1);
+                float pitch = micPitchArrays[m][idx];
+                // float.NaN is the silence sentinel — don't feed a pitch input, so the
+                // mic contributes nothing to scoring.
+                // (Plain numeric "out of range" values like -1f don't work because the
+                // engine's pitch comparison is octave-equivalent — any value matches
+                // C4 if the modular distance is within the pitch window.)
+                if (float.IsNaN(pitch)) continue;
+                int packed = PartyVocalsInput.Pack(m, VocalsAction.Pitch);
+                var input = new GameInput(time, packed, pitch);
+                engine.QueueInput(ref input);
+            }
+            engine.Update(time);
+        }
+    }
+
+    private static double[] GetHarmDirectTicks(PartyVocalsCoordinatorEngine engine) =>
+        (double[])HarmDirectTicksField.GetValue(engine)!;
+
+    private static double[] GetAmbiguityBuckets(PartyVocalsCoordinatorEngine engine) =>
+        (double[])AmbiguityBucketsField.GetValue(engine)!;
+
+    private static double[] GetCanonicalMeters(PartyVocalsCoordinatorEngine engine)
+    {
+        var field = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_canonicalMeters", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        return ((double[])field.GetValue(engine)!).ToArray();
+    }
+
+    private static void SetDirectTicks(PartyVocalsCoordinatorEngine engine, int partIndex, double ticks)
+    {
+        var arr = (double[])HarmDirectTicksField.GetValue(engine)!;
+        arr[partIndex] = ticks;
+    }
+
+    private static void SetAmbiguityBucket(PartyVocalsCoordinatorEngine engine, int mask, double ticks)
+    {
+        var arr = (double[])AmbiguityBucketsField.GetValue(engine)!;
+        arr[mask] = ticks;
+        // Also set the per-mic bookkeeping so perMicCap matches the bucket total.
+        // For unit tests, mic 0 is treated as the sole contributor — perMicCap = ticks.
+        // This makes the bucket's credit fully usable by any single HARM (matching the
+        // pre-per-mic-cap allocator's behavior for the cases these tests exercise).
+        var perMic = (double[,])typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_bucketPerMic", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(engine)!;
+        perMic[0, mask] = ticks;
+    }
+
+    /// <summary>
+    /// Per-mic bucket credit injector for tests that need to model multi-mic
+    /// contributions explicitly (e.g., stacking-shortcut regression tests).
+    /// Caller is responsible for keeping _ambiguityBuckets[mask] consistent
+    /// (= sum across mics).
+    /// </summary>
+    private static void SetBucketPerMic(PartyVocalsCoordinatorEngine engine, int micIndex, int mask, double ticks)
+    {
+        var perMic = (double[,])typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_bucketPerMic", BindingFlags.NonPublic | BindingFlags.Instance)!
+            .GetValue(engine)!;
+        perMic[micIndex, mask] = ticks;
+    }
+
+    private static void SetPhraseTicksTotalPerPart(PartyVocalsCoordinatorEngine engine, params uint[] values)
+    {
+        var field = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_phraseTicksTotalPerPart", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var arr = (uint[])field.GetValue(engine)!;
+        for (int i = 0; i < values.Length && i < arr.Length; i++)
+            arr[i] = values[i];
+    }
+
+    private static double[] RunAllocatorAndReturnMeters(PartyVocalsCoordinatorEngine engine)
+    {
+        RunAllocatorMethod.Invoke(engine, new object[] { false });
+        return GetCanonicalMeters(engine);
+    }
+
+    // ================================================================
+    // Classifier Tests (1-4)
+    // AC9: Per-tick classification + accumulation
+    // ================================================================
+
+    [Test]
+    public void Classifier_UnambiguousSingleMicSingleHarm_CreditsDirectOnce()
+    {
+        // Two parts at different pitches. Feed one mic matching only HARM0.
+        // After one phrase, verify the engine scored an Awesome for HARM0.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0 at C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM1 at E4
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings C4 (matches HARM0 only), mic 1 silent
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { -1f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0], "Single HARM0 hit = Awesome");
+    }
+
+    [Test]
+    public void Classifier_AmbiguousSingleMicTwoHarms_CreditsBucketOnce()
+    {
+        // Two parts at the SAME pitch. ONE mic (micCount=1, so no phantom contribution
+        // from a silent-but-pitch-window-matching second mic) singing that pitch is
+        // ambiguous on {0,1}. Bucket gets N ticks total, perMicCap = N. Allocator fills
+        // HARM0 to N (capped by perMicCap, no spill to HARM1 since the per-HARM cap is
+        // also N) → Awesome (not Double).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at C4
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings ambiguous C4. Mic 1 stays SILENT — NaN sentinel bypasses
+            // SetMicPitch so _micHasSang[1] never flips true. (Plain -1f wouldn't
+            // work: pitch comparison is octave-modular, so -1 vs C4=60 is 1
+            // semitone apart, within the pitch window.)
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0],
+            "Single ambiguous mic should fill only one HARM");
+    }
+
+    [Test]
+    public void Classifier_TwoMicsBothUnambigOnSameHarm_DirectTakesMaxDelta()
+    {
+        // Two mics both singing HARM0 pitch. Direct credit is binary across mics
+        // (max delta), so stacking doesn't shortcut. Both sing for the full phrase → Awesome.
+        // But singing half the phrase → M_0 = 0.5, which is Miss (stack shortcut prevention).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 960, 960, 64); // Non-overlapping second phrase
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Both mics on HARM0 for the full phrase
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0],
+            "Two mics stacking on HARM0 still = Awesome (not Double) since only one HARM hit");
+    }
+
+    [Test]
+    public void Classifier_TwoMicsBothAmbigInSameSet_BucketIncrementsTwice()
+    {
+        // Two mics both ambiguous on {0,1} for the full phrase.
+        // Bucket credit is additive: 2N ticks in bucket {0,1}.
+        // Allocator fills HARM0 then HARM1 → DoubleAwesome.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at same pitch
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0],
+            "Two mics ambig on {0,1} should credit both HARMs");
+    }
+
+    // ================================================================
+    // Allocator Tests (5-9)
+    // AC10: Greedy allocator
+    // ================================================================
+
+    [Test]
+    public void Allocator_OnlyDirect_FillsHarmsExact()
+    {
+        // direct = [100, 0], no buckets, capacity = [100, 100]
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 100);
+        SetDirectTicks(engine, 1, 0);
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled to 1.0");
+        Assert.AreEqual(0.0, meters[1], Epsilon, "HARM1 stays 0.0");
+    }
+
+    [Test]
+    public void Allocator_OnlyBucket01_FillsHarm0First()
+    {
+        // direct = [0, 0], bucket[{0,1}] = 100, capacity = [100, 100]
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 0);
+        SetDirectTicks(engine, 1, 0);
+        SetAmbiguityBucket(engine, 3, 100); // {0,1} = 0b011
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled first (tiebreak)");
+        Assert.AreEqual(0.0, meters[1], Epsilon, "HARM1 stays 0.0");
+    }
+
+    [Test]
+    public void Allocator_Bucket01_2N_FillsBothHarms()
+    {
+        // direct = [0, 0], bucket[{0,1}] = 200, capacity = [100, 100]
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 0);
+        SetDirectTicks(engine, 1, 0);
+        SetAmbiguityBucket(engine, 3, 200); // {0,1} with 2× capacity
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled to 1.0");
+        Assert.AreEqual(1.0, meters[1], Epsilon, "HARM1 filled to 1.0");
+    }
+
+    [Test]
+    public void Allocator_Direct0Full_Bucket01_RoutesToHarm1()
+    {
+        // direct = [100, 0], bucket[{0,1}] = 100, capacity = [100, 100]
+        // HARM0 already full, bucket routes to HARM1
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100);
+        SetDirectTicks(engine, 0, 100);
+        SetDirectTicks(engine, 1, 0);
+        SetAmbiguityBucket(engine, 3, 100);
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 capped by direct");
+        Assert.AreEqual(1.0, meters[1], Epsilon, "Bucket routed to HARM1");
+    }
+
+    [Test]
+    public void Allocator_NarrowestFirst()
+    {
+        // bucket[{0,1}] = 100, bucket[{0,1,2}] = 100, capacity = [100, 100, 100]
+        // Narrowest {0,1} fills HARM0, then {0,1,2} fills HARM1
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true), CreateVocalsPart(true) };
+        var engine = CreateCoordinator(parts, 2);
+
+        SetPhraseTicksTotalPerPart(engine, 100, 100, 100);
+        SetDirectTicks(engine, 0, 0);
+        SetDirectTicks(engine, 1, 0);
+        SetDirectTicks(engine, 2, 0);
+        SetAmbiguityBucket(engine, 3, 100);  // {0,1}
+        SetAmbiguityBucket(engine, 7, 100);  // {0,1,2}
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(1.0, meters[0], Epsilon, "HARM0 filled by {0,1}");
+        Assert.AreEqual(1.0, meters[1], Epsilon, "HARM1 filled by {0,1,2}");
+        Assert.AreEqual(0.0, meters[2], Epsilon, "HARM2 stays 0");
+    }
+
+    // ================================================================
+    // Scenario Tests (10-13)
+    // AC14: Correctness scenarios
+    // ================================================================
+
+    [Test]
+    public void Scenario_StackShortcutPrevention_HalfPhraseTwoMicsHarm0_Miss()
+    {
+        // AC14.1: Two mics stacking on HARM0 for half the phrase.
+        // Direct credit is binary (max across mics), so M_0 = 0.5 < PhraseHitPercent.
+        // Test via the allocator directly: direct = [240, 0], capacity = [480, 0].
+        // Meter = 240/480 = 0.5 < 0.75 → Miss.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        var engine = CreateCoordinator(parts, 1);
+
+        SetPhraseTicksTotalPerPart(engine, 480);
+        SetDirectTicks(engine, 0, 240); // Half coverage
+
+        var meters = RunAllocatorAndReturnMeters(engine);
+
+        Assert.AreEqual(0.5, meters[0], Epsilon, "HARM0 meter should be 0.5");
+        Assert.Less(meters[0], AwesomeThreshold, "Should be below Awesome threshold");
+    }
+
+    [Test]
+    public void Scenario_TrueUnison_TwoMics_DoubleAwesome()
+    {
+        // Two parts at the same pitch. Two mics both singing that pitch = ambig {0,1}.
+        // Bucket gets 2N ticks (additive). Allocator fills both HARMs → DoubleAwesome.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at C4
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0],
+            "Two mics on true unison = DoubleAwesome");
+    }
+
+    [Test]
+    public void Scenario_SingleMicAmbig_WholePhrase_Awesome()
+    {
+        // One mic ambiguous on {0,1}. Bucket gets N ticks (perMicCap = N). Allocator
+        // fills HARM0 to N (capped). HARM1 can also take up to perMicCap=N from this
+        // bucket, but the bucket is exhausted after HARM0 → HARM1 stays 0. Awesome.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // Both at C4
+        AddPhrase(parts[1], 0, 960, 60);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings ambiguous C4. Mic 1 silent via NaN sentinel.
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[0],
+            "Single ambiguous mic = Awesome (not Double)");
+    }
+
+    [Test]
+    public void Scenario_CrossCoverage_DoubleAwesome()
+    {
+        // Mic 0 sings HARM0 pitch (unambiguous), mic 1 sings that same pitch (ambiguous {0,1}).
+        // direct[0] = N, bucket[{0,1}] = N. Allocator caps HARM0, routes bucket to HARM1.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0 at C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM1 at E4
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Mic 0 sings C4 (unambiguous HARM0), mic 1 also sings C4 (ambiguous {0,1} since
+            // C4 is within pitch window of HARM0 but NOT HARM1 at E4)
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        // Both mics on C4 which only matches HARM0. This is stacking, not cross-coverage.
+        // For true cross-coverage we need a talkie on one part.
+    }
+
+    // ================================================================
+    // Scoring Tests (14-15)
+    // AC12: Scoring through the standard path
+    // ================================================================
+
+    [Test]
+    public void Scoring_HitNoteOncePerPhrase_NotPerHarm()
+    {
+        // Drive 2 phrases, both hitting. Verify NotesHit = 2, combo = 2.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);    // Phrase 1
+        AddPhrase(parts[0], 960, 960, 60);  // Phrase 2
+        AddPhrase(parts[1], 0, 960, 64);    // HARM1 overlap with phrase 1
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            // Sing HARM0 for both phrases, HARM1 for overlap
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.1, 5.0);
+        }, 6.0);
+
+        // The engine should have processed multiple phrases
+        Assert.GreaterOrEqual(grades.Count, 1, "Should have phrase grades");
+        var stats = engine.BaseStats;
+        Assert.AreEqual(grades.Count, stats.NotesHit,
+            "NotesHit should equal number of graded phrases");
+        Assert.AreEqual(grades.Count, stats.Combo,
+            "Combo should equal number of graded phrases");
+    }
+
+    [Test]
+    public void Scoring_MissPhraseResetsCombo_FlipsFc()
+    {
+        // Three sequential primary phrases. HARM1 overlaps with phrase 1.
+        // Phrase 1: both HARMs hit → DoubleAwesome.
+        // Phrase 2: good singing → Awesome.
+        // Phrase 3: bad singing → Miss → FC flips.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);     // Phrase 1: tick 0-960
+        AddPhrase(parts[0], 960, 960, 60);   // Phrase 2: tick 960-1920
+        AddPhrase(parts[0], 1920, 960, 60);  // Phrase 3: tick 1920-2880
+        AddPhrase(parts[1], 0, 960, 64);     // HARM1 overlap with phrase 1
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Phrase 1: sing well (both HARMs → DoubleAwesome)
+        // Content range: tick 0-480 (0.0-0.5s). Feed from 0.0 to 0.5s.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.017, 0.6);
+
+        // Phrase 2: sing well (HARM0 only → Awesome)
+        // Content range: tick 960-1440 (1.0-1.5s). Feed from 1.0 to 1.5s.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { -1f } }, 1.017, 0.6);
+
+        // Phrase 3: sing badly (wrong pitch → Miss)
+        // Content range: tick 1920-2400 (2.0-2.5s). Feed from 2.0 to 2.5s.
+        FeedPitches(engine, 2, new[] { new[] { 90f }, new[] { 90f } }, 2.017, 0.6);
+
+        // Advance past all phrases
+        engine.Update(4.0);
+
+        Assert.GreaterOrEqual(grades.Count, 3, "Should have 3 phrase grades");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0], "Phrase 1: both HARMs");
+        Assert.AreEqual(PhraseGrade.Awesome, grades[1], "Phrase 2: HARM0 only");
+        Assert.AreEqual(PhraseGrade.Miss, grades[2], "Phrase 3: wrong pitch");
+        Assert.IsFalse(engine.BaseStats.IsFullCombo, "FC should be false after a miss");
+    }
+
+    // ================================================================
+    // Visual-event Tests (real-mic OnTargetNoteChanged → trail)
+    // ================================================================
+
+    [Test]
+    public void RealMic_OnNote_SubEngineFiresOnTargetNoteChanged()
+    {
+        // Regression guard for the missing per-mic trail. PartyVocalsPlayer's trail
+        // gate requires slot.TargetNote, which is populated ONLY by each sub-engine's
+        // OnTargetNoteChanged. Bots emit it from UpdateBot; real mics must emit it from
+        // CheckSingingHit (YargFreeVocalsEngine line ~425). After live mic input was
+        // re-routed through the packed-input queue, the meters/scoring path kept working
+        // (AccumulateMicPartHits) but the trail's target-note emit must still fire.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60); // C4
+
+        var engine = CreateCoordinator(parts, micCount: 1); // isBot = false → real-mic path
+        bool fired = false;
+        VocalNote? captured = null;
+        engine.SubEngines[0].OnTargetNoteChanged += note => { fired = true; captured = note; };
+
+        engine.Update(0.1);
+        // Real mic sings C4 on the note. Same packed-queue path the runtime uses.
+        FeedPitches(engine, 1, new[] { new[] { 60f } }, 0.1, 1.0);
+
+        Assert.IsTrue(fired,
+            "Real-mic sub-engine must fire OnTargetNoteChanged while on a note (drives the per-mic trail)");
+        Assert.IsNotNull(captured, "Emitted target note should be non-null");
+    }
+
+    [Test]
+    public void RealMic_TwoMics_BothSubEnginesFireOnTargetNoteChanged()
+    {
+        // Faithful to the reported repro: two real mics, two HARM parts. Each mic's own
+        // sub-engine must fire OnTargetNoteChanged so its needle's trail can render.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0 C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM1 E4
+
+        var engine = CreateCoordinator(parts, micCount: 2); // isBot = false
+        var fired = new bool[2];
+        engine.SubEngines[0].OnTargetNoteChanged += _ => fired[0] = true;
+        engine.SubEngines[1].OnTargetNoteChanged += _ => fired[1] = true;
+
+        engine.Update(0.1);
+        // Mic 0 sings C4 (HARM0), mic 1 sings E4 (HARM1) — each on its own line.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.1, 1.0);
+
+        Assert.IsTrue(fired[0], "Mic 0 sub-engine must fire OnTargetNoteChanged");
+        Assert.IsTrue(fired[1], "Mic 1 sub-engine must fire OnTargetNoteChanged");
+    }
+
+    [Test]
+    public void RealMic_TwoMics_MicOneLagging_StillFiresOnTargetNoteChanged()
+    {
+        // Robustness guard for the runtime queue ORDER from PartyVocalsPlayer.RouteMicInputs:
+        // mic 0's input is queued, then mic 1's at an EARLIER timestamp (mic 1 lagging),
+        // which BaseEngine.QueueInput snaps forward. This was a suspected cause of the
+        // missing trail (echoing bugfix #10) but turned out NOT to be — the emit survives
+        // frame-granularity disorder. Kept as a guard so the per-mic emit stays robust to it.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 0, 960, 64);
+
+        var engine = CreateCoordinator(parts, micCount: 2);
+        var fired = new bool[2];
+        engine.SubEngines[0].OnTargetNoteChanged += _ => fired[0] = true;
+        engine.SubEngines[1].OnTargetNoteChanged += _ => fired[1] = true;
+
+        engine.Update(0.1);
+        const double fps = 60.0;
+        int frames = (int)(0.9 * fps);
+        for (int f = 1; f <= frames; f++)
+        {
+            double t0 = 0.1 + f / fps;
+            double t1 = 0.1 + (f - 0.5) / fps; // mic 1 half a frame behind mic 0
+            var in0 = new GameInput(t0, PartyVocalsInput.Pack(0, VocalsAction.Pitch), 60f);
+            engine.QueueInput(ref in0);
+            var in1 = new GameInput(t1, PartyVocalsInput.Pack(1, VocalsAction.Pitch), 64f);
+            engine.QueueInput(ref in1); // queued after in0 but earlier time
+            engine.Update(t0);
+        }
+
+        Assert.IsTrue(fired[0], "Mic 0 fires OnTargetNoteChanged");
+        Assert.IsTrue(fired[1], "Mic 1 (lagging) must STILL fire OnTargetNoteChanged for its trail");
+    }
+
+    [Test]
+    public void RealMic_OnNote_GetMicHittingPartsNonZero()
+    {
+        // The trail's hitting-gate also requires LastOnNoteTime, refreshed from
+        // coordinator.GetMicHittingParts(mic). The fill meters use a DIFFERENT path
+        // (CanonicalMeters from the allocator/deltas), so meters filling does NOT prove
+        // this bitmask is non-zero. If it reads 0 while the mic is on a note, the trail
+        // dies even though the target-note emit fired and the meters moved.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60); // C4, child note spans ticks 0..480 (0..0.5s)
+
+        var engine = CreateCoordinator(parts, micCount: 1);
+        engine.Update(0.1);
+        // Sing C4 squarely inside the note window.
+        FeedPitches(engine, 1, new[] { new[] { 60f } }, 0.1, 0.3);
+
+        Assert.AreNotEqual(0u, engine.GetMicHittingParts(0),
+            "GetMicHittingParts must be non-zero while on a note (refreshes the trail's LastOnNoteTime)");
+    }
+
+    // ================================================================
+    // Event + Throttle Tests (16-17)
+    // AC11: Grading and event emission, AC13: HUD reads
+    // ================================================================
+
+    [Test]
+    public void OnPartyVocalsPhrase_FiresOncePerPhrase_WithGradeAndMeters()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 0, 960, 64);
+
+        var (engine, grades) = RunCoordinatorScenario(parts, 2, e =>
+        {
+            FeedPitches(e, 2, new[] { new[] { 60f }, new[] { 64f } }, 0.1, 2.0);
+        }, 4.0);
+
+        Assert.AreEqual(1, grades.Count, "Should fire once per phrase");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0], "Both HARMs covered = DoubleAwesome");
+    }
+
+    [Test]
+    public void Throttle_CanonicalMetersRefreshAt100ms()
+    {
+        // During a phrase, meters update on the 100ms throttle.
+        // After <100ms: meters stay at initial value.
+        // After >=100ms: meters refresh.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 1920, 60); // Long phrase = 2.0s
+        AddPhrase(parts[1], 1920, 960, 64);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        // Feed for ~50ms (3 frames at 60fps)
+        for (int i = 0; i < 3; i++)
+        {
+            double t = 0.1 + (i + 1) / ApproximateVocalFps;
+            int packed0 = PartyVocalsInput.Pack(0, VocalsAction.Pitch);
+            var in0 = new GameInput(t, packed0, 60f);
+            engine.QueueInput(ref in0);
+            int packed1 = PartyVocalsInput.Pack(1, VocalsAction.Pitch);
+            var in1 = new GameInput(t, packed1, -1f);
+            engine.QueueInput(ref in1);
+            engine.Update(t);
+        }
+
+        var metersEarly = GetCanonicalMeters(engine);
+        // After only ~50ms, the 100ms throttle hasn't fired yet, so meters may still be 0
+        // (they could also have been updated if the throttle fires — this is timing-sensitive)
+        // We verify the meters are in a valid range [0,1]
+        Assert.GreaterOrEqual(metersEarly[0], 0.0, "Meter should be >= 0");
+        Assert.LessOrEqual(metersEarly[0], 1.0, "Meter should be <= 1");
+
+        // Feed for another ~100ms (7 more frames) to pass the 100ms throttle
+        double startTime = 0.1 + 4.0 / ApproximateVocalFps;
+        for (int i = 0; i < 7; i++)
+        {
+            double t = startTime + (i + 1) / ApproximateVocalFps;
+            int packed0 = PartyVocalsInput.Pack(0, VocalsAction.Pitch);
+            var in0 = new GameInput(t, packed0, 60f);
+            engine.QueueInput(ref in0);
+            int packed1 = PartyVocalsInput.Pack(1, VocalsAction.Pitch);
+            var in1 = new GameInput(t, packed1, -1f);
+            engine.QueueInput(ref in1);
+            engine.Update(t);
+        }
+
+        var metersLater = GetCanonicalMeters(engine);
+        Assert.Greater(metersLater[0], 0.0, "Meters should have positive value after >100ms of singing");
+        Assert.LessOrEqual(metersLater[0], 1.0, "Meter should not exceed 1.0");
+    }
+
+    // ================================================================
+    // Per-phrase state reset regression (issue: coordinator's ResetPhraseState
+    // was not clearing _micPartHits, leaving stale accumulation across phrase
+    // boundaries. Fixed by clearing all per-phrase arrays in ResetPhraseState.)
+    // ================================================================
+
+    [Test]
+    public void StateReset_PhraseBoundary_ClearsMicPartHitsAndPhraseTicksTotal()
+    {
+        // Two sequential HARM0-only phrases with DIFFERENT tick lengths, so a
+        // stale PhraseTicksTotal carried over from phrase 1 would be detectable
+        // when phrase 2 starts (the `??=` at top of UpdateHitLogic only assigns
+        // if PhraseTicksTotal is null — a stale non-null value would persist).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);     // Phrase 1: ticks 0-960 (1.0s)
+        AddPhrase(parts[0], 1920, 480, 60);  // Phrase 2: ticks 1920-2400 (0.5s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Phrase 1: sing HARM0 well to populate _micPartHits and PhraseTicksTotal.
+        engine.Update(0.05);
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { -1f } }, 0.05, 0.5);
+        // Advance past phrase 1's TickEnd (tick 960 → t=1.0s).
+        engine.Update(1.1);
+
+        Assert.AreEqual(1, grades.Count, "Phrase 1 should have graded");
+
+        // Inspect _micPartHits via reflection — ResetPhraseState must have cleared it.
+        // Without the fix, phrase 1's per-mic accumulation would still be sitting in
+        // the array, leaking into phrase 2's stats.
+        var micPartHitsField = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_micPartHits", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var micPartHits = (double[,])micPartHitsField.GetValue(engine)!;
+        double sumAfterPhrase1 = 0;
+        foreach (var v in micPartHits) sumAfterPhrase1 += v;
+        Assert.AreEqual(0.0, sumAfterPhrase1, Epsilon,
+            "_micPartHits must be cleared between phrases (regression: prior coordinator " +
+            "override skipped the base's Array.Clear of _micPartHits).");
+
+        // Drive into phrase 2 with no mic activity. PhraseTicksTotal must be
+        // re-derived for phrase 2 (480 ticks) — if the prior bug were present,
+        // it would still hold phrase 1's value (960) because `??=` doesn't
+        // overwrite a non-null value.
+        // Feed silent pitch to both mics via the queue
+        int packed0 = PartyVocalsInput.Pack(0, VocalsAction.Pitch);
+        var in0 = new GameInput(2.04, packed0, -1f);
+        engine.QueueInput(ref in0);
+        int packed1 = PartyVocalsInput.Pack(1, VocalsAction.Pitch);
+        var in1 = new GameInput(2.04, packed1, -1f);
+        engine.QueueInput(ref in1);
+        engine.Update(2.05); // within phrase 2 (tick 1920-2400 → t=2.0-2.5s)
+
+        // PhraseTicksTotal reflects the sum of lyric child-note ticks in the phrase.
+        // AddPhrase uses tickLength/2 for the lyric, so phrase 1 = 480, phrase 2 = 240.
+        // If the bug regressed (PhraseTicksTotal never nulled at phrase 1 end), the
+        // `??=` at top of UpdateHitLogic would leave it at 480 forever.
+        Assert.IsTrue(engine.PhraseTicksTotal.HasValue,
+            "PhraseTicksTotal should be populated for phrase 2");
+        Assert.AreEqual(240u, engine.PhraseTicksTotal!.Value,
+            "PhraseTicksTotal must reflect phrase 2's lyric ticks (240), not phrase 1's (480). " +
+            "Regression: prior coordinator override skipped the base's PhraseTicksTotal = null.");
+        Assert.AreNotEqual(480u, engine.PhraseTicksTotal!.Value,
+            "Explicit guard against the specific regression — phrase 1's stale value.");
+
+        // Finish phrase 2 with no singing → grade Miss.
+        engine.Update(3.0);
+        Assert.AreEqual(2, grades.Count, "Phrase 2 should have graded");
+        Assert.AreEqual(PhraseGrade.Miss, grades[1], "Phrase 2 with no singing = Miss");
+    }
+
+    // ================================================================
+    // Regression tests for issues found during real-game testing
+    // (post-merge of the per-phrase reset fix).
+    // ================================================================
+
+    [Test]
+    public void StatsPercent_AccumulatesTicksHitAndTicksMissed()
+    {
+        // Prior bug: coordinator's ProcessPhraseEnd skipped the
+        // EngineStats.TicksHit/TicksMissed accumulation that the base does. With
+        // both fields at 0, VocalsStats.Percent (TicksHit/TotalTicks) defaults to
+        // 1.0 (100%) when TotalTicks == 0 — making the end-of-song accuracy display
+        // show 100% even when the player missed phrases.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);    // Phrase 1: ticks 0-960
+        AddPhrase(parts[0], 960, 960, 60);  // Phrase 2: ticks 960-1920
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Phrase 1: sing well → Hit.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.05, 0.5);
+        engine.Update(1.1);
+
+        // Phrase 2: sing wrong pitch → Miss.
+        FeedPitches(engine, 2, new[] { new[] { 90f }, new[] { float.NaN } }, 1.05, 0.5);
+        engine.Update(2.1);
+
+        var stats = (VocalsStats) engine.BaseStats;
+        Assert.Greater(stats.TicksHit, 0u,
+            "TicksHit must accumulate on Hit phrases (regression: was 0).");
+        Assert.Greater(stats.TicksMissed, 0u,
+            "TicksMissed must accumulate on Miss phrases (regression: was 0).");
+        Assert.Less(stats.Percent, 1.0f,
+            "Percent must reflect real accuracy < 100% when there are misses " +
+            "(regression: VocalsStats.Percent defaults to 1.0 when TotalTicks == 0).");
+    }
+
+    [Test]
+    public void OnPhraseHit_FiresOnMissForIsFcFlip()
+    {
+        // Prior bug: coordinator never fired OnPhraseHit. VocalsPlayer.cs:486-489
+        // subscribes to OnPhraseHit to flip IsFc = false on !fullPoints — without
+        // this firing, the FC tile stays lit through misses.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+        bool hitEventFired = false;
+        bool hitEventFullPoints = true;
+        engine.OnPhraseHit += (percent, fullPoints, isLast) =>
+        {
+            hitEventFired = true;
+            hitEventFullPoints = fullPoints;
+        };
+
+        // Sing wrong pitch → Miss.
+        FeedPitches(engine, 2, new[] { new[] { 90f }, new[] { float.NaN } }, 0.05, 0.5);
+        engine.Update(1.1);
+
+        Assert.IsTrue(hitEventFired, "OnPhraseHit must fire on the coordinator path.");
+        Assert.IsFalse(hitEventFullPoints, "fullPoints must be false on Miss (drives IsFc flip).");
+    }
+
+    [Test]
+    public void StackingShortcut_TwoMicsTalkieHalfPhrase_GradeMiss()
+    {
+        // The bug the per-mic-span cap was added to fix.
+        // 2 mics both ambiguous on {0,1} for HALF a phrase (talkies + harmonized
+        // talkies are the typical real-game case). Under the prior additive-bucket
+        // model: bucket = 2 × N/2 = N, allocator filled HARM0 to 100% → Awesome.
+        // Equivalent unambiguous singing (2 mics on HARM1 half phrase) graded Miss.
+        // Inconsistency was the shortcut.
+        // Under per-mic-span cap: bucket = N, perMicCap = N/2. Each HARM can receive
+        // at most N/2 → both HARMs at 50% → below threshold → Miss. Consistent.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddTalkiePhrase(parts[0], 0, 960);
+        AddTalkiePhrase(parts[1], 0, 960);
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Both mics making noise for ONLY HALF the phrase (0.0-0.25s of a 0.0-0.5s
+        // content window) — they then go silent for the second half. Under the new
+        // model this is a Miss.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 0.25);
+        engine.Update(1.1); // past phrase end
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.Miss, grades[0],
+            "Two mics on harmonized talkies for HALF the phrase must grade Miss " +
+            "(stacking shortcut prevention via per-mic-span cap).");
+    }
+
+    [Test]
+    public void TrueUnison_TwoMicsTalkieFullPhrase_DoubleAwesome()
+    {
+        // Companion to the stacking-shortcut test: 2 mics ambiguous on a harmonized
+        // talkie for the FULL phrase should still grade DoubleAwesome. Bucket = 2N,
+        // perMicCap = N. Each HARM receives up to N (= capacity). Both filled.
+        // Verifies the per-mic-span cap doesn't break Goal G1 (true unison → Double).
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddTalkiePhrase(parts[0], 0, 960);
+        AddTalkiePhrase(parts[1], 0, 960);
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Both mics making noise for the WHOLE phrase content window.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { 60f } }, 0.0, 0.55);
+        engine.Update(1.1);
+
+        Assert.AreEqual(1, grades.Count, "One phrase grade");
+        Assert.AreEqual(PhraseGrade.DoubleAwesome, grades[0],
+            "Two mics on harmonized talkies for the FULL phrase = DoubleAwesome " +
+            "(per-mic-span cap permits both HARMs when each mic vouches for a full span).");
+    }
+
+    [Test]
+    public void EmptyPhrase_TreatedAsHit_NoSpuriousMiss()
+    {
+        // Prior bug: phraseTicksTotal == 0 (lyric-less phrase) went through the
+        // allocator → all-zero meters → grade Miss → MissNote. The base treats
+        // empty phrases as a free Hit. Coordinator now short-circuits to match.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        // Phrase with non-zero tick length but no child lyric notes (phraseTicksTotal == 0).
+        var emptyNote = new VocalNote(NoteFlags.None, false, 0.0, 2.0, 0, 960);
+        parts[0].NotePhrases.Add(new VocalsPhrase(
+            0.0, 2.0, 0, 960, emptyNote, new List<LyricEvent>()));
+
+        var engine = CreateCoordinator(parts, 2);
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        engine.Update(1.5); // past the empty phrase's TickEnd
+
+        Assert.AreEqual(1, grades.Count, "Empty phrase should still emit a grade event");
+        Assert.AreNotEqual(PhraseGrade.Miss, grades[0],
+            "Empty phrase should NOT grade as Miss (base treats it as Hit).");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit,
+            "Empty phrase should count as a NotesHit (HitNote was called).");
+    }
+
+    [Test]
+    public void PartInCurrentPhrase_ReflectsPerPartPresence()
+    {
+        // Three parts: HARM0 at tick 0-960, HARM2 at tick 0-960, HARM1 has no phrase.
+        // After running through the phrase, PartInCurrentPhrase(0) and (2) should be true,
+        // PartInCurrentPhrase(1) should be false.
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(), CreateVocalsPart(true), CreateVocalsPart(true)
+        };
+        AddPhrase(parts[0], 0, 960, 60); // HARM0
+        AddPhrase(parts[2], 0, 960, 67); // HARM2
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        // Drive into the phrase so _phraseTicksTotalPerPart gets populated.
+        FeedPitches(engine, 2, new[] { new[] { 60f }, new[] { float.NaN } }, 0.1, 0.3);
+
+        Assert.IsTrue(engine.PartInCurrentPhrase(0), "HARM0 has notes in this phrase");
+        Assert.IsFalse(engine.PartInCurrentPhrase(1), "HARM1 has no notes in this phrase");
+        Assert.IsTrue(engine.PartInCurrentPhrase(2), "HARM2 has notes in this phrase");
+        Assert.IsFalse(engine.PartInCurrentPhrase(-1), "Negative index → false");
+        Assert.IsFalse(engine.PartInCurrentPhrase(99), "Out-of-range index → false");
+    }
+
+    [Test]
+    public void Bot_HitsPercussionNote()
+    {
+        // A Party Vocals bot should hit percussion notes. The coordinator scores percussion
+        // via HasHit, which is only set by a queued Hit input (MutateStateWithInput). Bots
+        // queue no inputs and the coordinator's UpdateBot is a no-op, so a bot currently
+        // never scores percussion (live mics do). Repro for the reported bug.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960); // percussion at tick 480 (t=0.5s)
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), EngineParams, isBot: true, micCount: 1);
+
+        int percussionHits = 0;
+        engine.OnNoteHit += (_, note) => { if (note.IsPercussion) percussionHits++; };
+
+        int totalFrames = (int) (2.0 * ApproximateVocalFps);
+        for (int f = 0; f < totalFrames; f++)
+            engine.Update((f + 1) / ApproximateVocalFps);
+
+        Assert.That(percussionHits, Is.EqualTo(1),
+            "A Party Vocals bot should hit the percussion note.");
+    }
+
+    [Test]
+    public void PartInNextPhrase_ReflectsNextPhrasePerPartPresence()
+    {
+        // Master (parts[0]) has TWO phrases: tick 0-960 and tick 1920-2880.
+        // While in the first phrase, "next phrase" is the tick 1920-2880 window.
+        //   HARM0: present in next (its own second phrase).
+        //   HARM1: present in next (charted at 1920-2880).
+        //   HARM2: present only in the FIRST phrase (0-960) → absent in next.
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(), CreateVocalsPart(true), CreateVocalsPart(true)
+        };
+        AddPhrase(parts[0], 0, 960, 60);     // HARM0 phrase 1
+        AddPhrase(parts[0], 1920, 960, 60);  // HARM0 phrase 2 (the "next" master phrase)
+        AddPhrase(parts[1], 1920, 960, 64);  // HARM1 only in the next phrase
+        AddPhrase(parts[2], 0, 960, 67);     // HARM2 only in the first phrase
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1); // NoteIndex = 0 (first phrase)
+
+        Assert.IsTrue(engine.PartInNextPhrase(0), "HARM0 has a note in the next phrase");
+        Assert.IsTrue(engine.PartInNextPhrase(1), "HARM1 has a note in the next phrase");
+        Assert.IsFalse(engine.PartInNextPhrase(2), "HARM2 is only in the current phrase");
+        Assert.IsFalse(engine.PartInNextPhrase(-1), "Negative index → false");
+        Assert.IsFalse(engine.PartInNextPhrase(99), "Out-of-range index → false");
+    }
+
+    [Test]
+    public void CurrentPhraseProgress_TracksTickSpanOfCurrentPhrase()
+    {
+        // Phrase spans tick 0-960 = t 0.0..1.0 (480 tpqn @120bpm). At t=0.5 the engine is
+        // halfway through the phrase span, so progress ≈ 0.5 — driven by the SPAN, not by
+        // how much was sung.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.5);
+
+        Assert.That(engine.CurrentPhraseProgress, Is.EqualTo(0.5).Within(0.05),
+            "Progress should reflect position within the phrase's tick span");
+    }
+
+    [Test]
+    public void CurrentPhraseDurationSeconds_ReflectsPhraseSpan()
+    {
+        // AddPhrase hardcodes the parent phrase note's Time=0.0 / TimeLength=2.0 (the same
+        // tick-vs-time helper artifact the percussion tests note), so TimeEnd-Time = 2.0s
+        // here. In real charts the parent note's time span is accurate; this just verifies
+        // the accessor returns TimeEnd - Time of the current phrase.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        Assert.That(engine.CurrentPhraseDurationSeconds, Is.EqualTo(2.0).Within(0.001),
+            "Duration should be the current phrase's time span (TimeEnd - Time)");
+    }
+
+    [Test]
+    public void Bot_ThreeMicsThreeHarms_EachBotHitsItsPart()
+    {
+        // Regression guard: bot Party Vocals builds one sub-engine per HARM part
+        // (micCount == part count). Each bot sub-engine must self-drive via UpdateBot
+        // and hit its assigned part, so the coordinator credits every part and the
+        // phrase grades as a hit. This path was never exercised by existing tests
+        // (CreateCoordinator passes isBot=false and feeds pitches manually); here we
+        // drive a real bot coordinator with no SetMicPitch calls.
+        var parts = new List<VocalsPart>
+        {
+            CreateVocalsPart(isHarmony: true),
+            CreateVocalsPart(isHarmony: true),
+            CreateVocalsPart(isHarmony: true),
+        };
+        AddPhrase(parts[0], 0, 960, 60); // HARM1 C4
+        AddPhrase(parts[1], 0, 960, 64); // HARM2 E4
+        AddPhrase(parts[2], 0, 960, 67); // HARM3 G4
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), EngineParams, isBot: true, micCount: 3);
+
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        // Drive the bots through the phrase at ~60fps; bots self-generate pitch, so
+        // we deliberately do NOT call SetMicPitch.
+        int totalFrames = (int) (2.0 * ApproximateVocalFps);
+        for (int f = 0; f < totalFrames; f++)
+            engine.Update((f + 1) / ApproximateVocalFps);
+
+        Assert.AreEqual(1, grades.Count, "Bot phrase should be graded once");
+        Assert.AreNotEqual(PhraseGrade.Miss, grades[0],
+            "Bots should hit their assigned parts, not miss");
+        Assert.Greater(((VocalsStats)engine.BaseStats).TicksHit, 0u,
+            "Bot hits should accumulate TicksHit");
+    }
+
+    // ================================================================
+    // Coordinator Percussion Scoring Tests (18-22)
+    // percussion.AC1: Any mic tap scores
+    // percussion.AC2: No double-count
+    // percussion.AC5: No false hit
+    // ================================================================
+
+    [Test]
+    public void Percussion_TapWithDueNote_ScoresPercussionNote_AC1_1()
+    {
+        // AC1.1: A tap with a due percussion note scores it.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960); // Percussion note at tick 480 (t=0.5s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitFired = false;
+        engine.OnNoteHit += (noteIndex, note) => hitFired = true;
+
+        // Drive to the note's time
+        engine.Update(0.5);
+
+        // Queue a single Hit input within the note's hit window
+        var hitInput = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+
+        // Advance to process the hit (phrase ends at tick 1440 = t=1.5s)
+        engine.Update(1.6);
+
+        // The percussion note should have been scored
+        Assert.IsTrue(hitFired, "OnNoteHit should have fired for the percussion note");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit, "NotesHit should increase by 1");
+    }
+
+    [Test]
+    public void Percussion_EarlyTapWithinHitWindow_ScoresPercussionNote_WindowRepro()
+    {
+        // RED repro for docs/bugs/party-vocals-percussion-broken.md (Problem 2).
+        // A tap landing 0.03s EARLY on a short, realistically-timed percussion note is
+        // well inside the engine's ±0.05s hit window. Solo (YargVocalsEngine) scores it
+        // via IsNoteInWindow (front/back tolerance). The coordinator gates on the raw
+        // span CurrentTime >= percussion.Time, which gives ZERO early tolerance, so the
+        // tap is dropped. This is why runtime taps reach the engine (logs A+B fire) but
+        // never score (log C never fires).
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        // Percussion at tick 4800 = t=5.0s (480 tpqn @120bpm). The raw span is [5.0, 5.5];
+        // the engine hit window is [4.95, 5.05].
+        AddPercussionPhrase(parts[0], 4800, 960);
+
+        var engine = CreateCoordinator(parts, 2);
+        int percussionHits = 0;
+        engine.OnNoteHit += (_, note) => { if (note.IsPercussion) percussionHits++; };
+
+        engine.Update(4.9);
+        // Tap at t=4.97: inside the hit window [4.95, 5.05], but BEFORE the raw span
+        // [5.0, 5.5] the old code required (CurrentTime >= percussion.Time).
+        var hit = GameInput.Create(4.97, VocalsAction.Hit, true);
+        engine.QueueInput(ref hit);
+        engine.Update(6.5); // process the tap, then advance past phrase end
+
+        Assert.AreEqual(1, percussionHits,
+            "An early tap within the hit window should score the percussion note, " +
+            "matching solo YargVocalsEngine. The coordinator's raw [Time, TimeEnd] gate drops it.");
+    }
+
+    [Test]
+    public void Percussion_TapScoresNextDueNote_AC1_2()
+    {
+        // AC1.2: The note scored is the next due percussion note per GetNextPercussionNote windowing.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960);  // First percussion note at tick 480 (t=0.5s)
+        AddPercussionPhrase(parts[0], 1920, 960); // Second percussion note at tick 1920 (t=2.0s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitNoteIndex = -1;
+        engine.OnNoteHit += (noteIndex, note) => hitNoteIndex = noteIndex;
+
+        // Drive to the first note's time
+        engine.Update(0.5);
+
+        // Queue a single Hit input within the first note's hit window
+        var hitInput = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+
+        // Advance to process the hit (first phrase ends at tick 1440 = t=1.5s)
+        engine.Update(1.6);
+
+        // The first note (index 0) should have been scored, not the second
+        Assert.AreEqual(0, hitNoteIndex, "First note (index 0) should have been scored");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit, "Only one note should have been scored");
+    }
+
+    [Test]
+    public void Percussion_TwoMicsSameNote_ScoreOnce_AC2_1()
+    {
+        // AC2.1: Multiple mics tapping the same due percussion note score it exactly once.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPercussionPhrase(parts[0], 480, 960); // Percussion note at tick 480 (t=0.5s)
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitFired = false;
+        engine.OnNoteHit += (noteIndex, note) => hitFired = true;
+
+        // Drive to the note's time
+        engine.Update(0.5);
+
+        // Queue Hit inputs from both mics (coordinator aggregates into single HasHit)
+        var hitInput1 = GameInput.Create(0.5, VocalsAction.Hit, true);
+        var hitInput2 = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput1);
+        engine.QueueInput(ref hitInput2);
+
+        // Advance to process the hits (phrase ends at tick 1440 = t=1.5s)
+        engine.Update(1.6);
+
+        // The note should have been scored exactly once (HasHit is shared across mics)
+        Assert.IsTrue(hitFired, "OnNoteHit should have fired");
+        Assert.AreEqual(1, engine.BaseStats.NotesHit, "Note should be scored exactly once, not twice");
+    }
+
+    [Test]
+    public void Percussion_TapWithNoDueNote_NoScore_AC5_1()
+    {
+        // AC5.1: A tap with no due percussion note does not score; HasHit is consumed.
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 960, 960, 60); // Regular note (not percussion) at tick 960-1920
+
+        var engine = CreateCoordinator(parts, 2);
+        var hitFired = false;
+        engine.OnNoteHit += (noteIndex, note) => hitFired = true;
+
+        // Drive to time but no percussion note is due yet
+        engine.Update(0.5);
+
+        // Queue a Hit input
+        var hitInput = GameInput.Create(0.5, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+
+        // Advance to process the hit (need to advance past phrase end)
+        engine.Update(1.5); // Phrase ends at tick 480 (t=1.0s)
+
+        // No note should have been scored
+        Assert.IsFalse(hitFired, "OnNoteHit should not fire when no percussion note is due");
+        Assert.AreEqual(0, engine.BaseStats.NotesHit, "NotesHit should not increase");
+    }
+
+    // ================================================================
+    // Tests for mic packing and input demux (Subcomponent A)
+    // ================================================================
+
+    private static void QueueAndUpdate(PartyVocalsCoordinatorEngine engine, GameInput input)
+    {
+        engine.QueueInput(ref input);
+        engine.Update(0.5);
+    }
+
+    [Test]
+    public void PitchRouting_PackedInput_RoutesToCorrectMic_AC32()
+    {
+        // AC32: Pitch input packed for mic k routes to sub-engine k
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60); // Note at tick 0-960
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue pitch for mic 0
+        var packedPitch0 = new GameInput(0.5, PartyVocalsInput.Pack(0, VocalsAction.Pitch), 100f);
+        QueueAndUpdate(engine, packedPitch0);
+
+        // Queue pitch for mic 1
+        var packedPitch1 = new GameInput(0.5, PartyVocalsInput.Pack(1, VocalsAction.Pitch), 200f);
+        QueueAndUpdate(engine, packedPitch1);
+
+        // Verify pitch values reached correct sub-engines
+        Assert.AreEqual(100f, engine.GetMicPitch(0), Epsilon);
+        Assert.AreEqual(200f, engine.GetMicPitch(1), Epsilon);
+    }
+
+    [Test]
+    public void PitchRouting_UnpackedInput_DegradesToMic0_AC32()
+    {
+        // AC32: Unpacked input (no mic bits) routes to mic 0
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue unpacked pitch (mic 0 equivalent)
+        var unpackedPitch = GameInput.Create(0.5, VocalsAction.Pitch, 300f);
+        QueueAndUpdate(engine, unpackedPitch);
+
+        // Verify it routes to mic 0
+        Assert.AreEqual(300f, engine.GetMicPitch(0), Epsilon);
+        Assert.AreEqual(0f, engine.GetMicPitch(1), Epsilon);
+    }
+
+    [Test]
+    public void PitchRouting_OutOfRangeMic_DroppedWithoutException_AC32()
+    {
+        // AC32: Pitch packed for mic >= _micCount is dropped
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue pitch for out-of-range mic (2, but we only have 2 mics: 0,1)
+        var packedPitchOutOfRange = new GameInput(0.5, PartyVocalsInput.Pack(2, VocalsAction.Pitch), 400f);
+        QueueAndUpdate(engine, packedPitchOutOfRange);
+
+        // Verify no state changed
+        Assert.AreEqual(0f, engine.GetMicPitch(0), Epsilon);
+        Assert.AreEqual(0f, engine.GetMicPitch(1), Epsilon);
+    }
+
+    [Test]
+    public void Hit_StarPower_PackedInput_SetsCoordinatorFlags_AC32()
+    {
+        // AC32: Hit/StarPower packed inputs set coordinator-level flags
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue packed StarPower
+        var packedSP = new GameInput(1.0, PartyVocalsInput.Pack(1, VocalsAction.StarPower), true);
+        engine.QueueInput(ref packedSP);
+        engine.Update(1.0);
+
+        Assert.IsTrue(engine.IsStarPowerInputActive);
+    }
+
+    [Test]
+    public void ActionPack_RoundTrip_RecoversOriginalValues_AC32()
+    {
+        // AC32: Pack -> UnpackMic/UnpackAction round-trip preserves original values
+        for (int mic = 0; mic <= 6; mic++)
+        {
+            foreach (VocalsAction action in Enum.GetValues<VocalsAction>())
+            {
+                int packed = PartyVocalsInput.Pack(mic, action);
+                int unpackedMic = PartyVocalsInput.UnpackMic(packed);
+                VocalsAction unpackedAction = PartyVocalsInput.UnpackAction(packed);
+
+                Assert.AreEqual(mic, unpackedMic);
+                Assert.AreEqual(action, unpackedAction);
+            }
+        }
+    }
+
+    [Test]
+    public void SangFlag_SetByPitch_DidMicSingThisTick_AC32()
+    {
+        // AC32: _micSangThisTick set by Pitch, exposed via accessors
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Initially all flags should be false
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+        Assert.IsFalse(engine.DidMicSingThisTick(1));
+
+        // Queue pitch for mic 1
+        var packedPitch1 = new GameInput(0.5, PartyVocalsInput.Pack(1, VocalsAction.Pitch), 200f);
+        QueueAndUpdate(engine, packedPitch1);
+
+        // Only mic 1 should have sang
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+        Assert.IsTrue(engine.DidMicSingThisTick(1));
+
+        // Reset flags
+        engine.ResetMicSangFlags();
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+        Assert.IsFalse(engine.DidMicSingThisTick(1));
+    }
+
+    [Test]
+    public void SangFlag_HitOrStarPower_DoesNotSetSangFlag_AC32()
+    {
+        // AC32: Hit/StarPower inputs do not set sang flag
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var engine = CreateCoordinator(parts, 2);
+
+        // Queue Hit
+        var packedHit = new GameInput(0.5, PartyVocalsInput.Pack(0, VocalsAction.Hit), true);
+        QueueAndUpdate(engine, packedHit);
+
+        Assert.IsFalse(engine.DidMicSingThisTick(0));
+
+        // Queue StarPower
+        var packedSP = new GameInput(1.0, PartyVocalsInput.Pack(1, VocalsAction.StarPower), true);
+        QueueAndUpdate(engine, packedSP);
+
+        Assert.IsFalse(engine.DidMicSingThisTick(1));
+    }
+
+    // ================================================================
+    // Hit routing invariant (AC34 structural)
+    // Hit reaches coordinator only — sub-engines receive no queued Hit,
+    // so sub-engine CheckPercussionHit cannot fire from input.
+    // ================================================================
+
+    [Test]
+    public void Hit_RoutesToCoordinatorOnly_SubEnginesNotFedInput_AC34()
+    {
+        // Verify that Hit inputs queued to the coordinator set only the coordinator's
+        // HasHit — sub-engines do not have their MutateStateWithInput called (they
+        // receive no queued input; they're driven via Update + SetMicPitch).
+        // This is the structural invariant that prevents double percussion scoring.
+        var parts = new List<VocalsPart> { CreateVocalsPart(), CreateVocalsPart(true) };
+        AddPhrase(parts[0], 0, 960, 60);
+        AddPhrase(parts[1], 0, 960, 64);
+
+        var engine = CreateCoordinator(parts, 2);
+        engine.Update(0.1);
+
+        // Queue Hit inputs from two different mics
+        for (int m = 0; m < 2; m++)
+        {
+            var hit = new GameInput(0.15, PartyVocalsInput.Pack(m, VocalsAction.Hit), true);
+            engine.QueueInput(ref hit);
+        }
+        engine.Update(0.2);
+
+        // The coordinator consumed HasHit during CheckPercussionHit (no percussion
+        // in this chart, so it was a no-op). The key invariant is that the coordinator
+        // demux routed Hit to coordinator.HasHit, not to any sub-engine's input queue.
+        // Sub-engines have no input queue — they are driven solely via Update(time).
+        // Verify by checking the sub-engines' MutateStateWithInput was never called:
+        // their input queue count must be zero.
+        var subEnginesField = typeof(PartyVocalsCoordinatorEngine)
+            .GetField("_subEngines", BindingFlags.NonPublic | BindingFlags.Instance);
+        var subEngines = (YargFreeVocalsEngine[])subEnginesField.GetValue(engine)!;
+
+        foreach (var sub in subEngines)
+        {
+            var inputQueueField = typeof(BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats>)
+                .GetField("InputQueue", BindingFlags.NonPublic | BindingFlags.Instance);
+            var queue = (System.Collections.Generic.Queue<GameInput>)inputQueueField.GetValue(sub)!;
+            Assert.AreEqual(0, queue.Count,
+                "Sub-engine input queue must be empty — sub-engines receive no queued input");
+        }
+    }
+
+    // ================================================================
+    // Sing-to-activate star power tests (overdrive.AC1, AC2)
+    // ================================================================
+
+    private static void BankStarPower(PartyVocalsCoordinatorEngine engine, uint ticks)
+    {
+        engine.EngineStats.StarPowerTickAmount += ticks;
+    }
+
+    /// overdrive.AC1.1: A hit (sing-to-activate noise) deploys SP when flag is on and SP is banked.
+    [Test]
+    public void SingToActivate_DeploysStarPower_WhenSingingAndSpBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+
+        // Queue a Hit action (mirrors how solo engine triggers sing-to-activate
+        // via HasHit in CheckPercussionHit's else branch)
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "Sing-to-activate should deploy SP on hit when SP is banked");
+    }
+
+    /// overdrive.AC1.2: No deploy when CanStarPowerActivate is false.
+    [Test]
+    public void SingToActivate_DoesNotDeploy_WhenSpNotBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        engine.Update(0.1);
+        Assert.That(engine.CanStarPowerActivate, Is.False);
+
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.False,
+            "SP must not activate when CanStarPowerActivate is false");
+    }
+
+    /// overdrive.AC1.3: No deploy when sing-to-activate is off.
+    [Test]
+    public void SingToActivate_DoesNotDeploy_WhenFlagOff()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2, EngineParamsNoSingToActivate);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.False,
+            "SP must not activate via hit when SingToActivateStarPower is off");
+    }
+
+    /// SP earning: singing a star power phrase should award SP ticks to the coordinator.
+    [Test]
+    public void SingingSpPhrase_AwardsStarPower_ToCoordinator()
+    {
+        // Create a part with a single phrase that has StarPower flags.
+        var part = CreateVocalsPart();
+        uint phraseTick = 0;
+        uint phraseTickLength = 960; // 2 beats at 480 ticks/beat
+        int midiPitch = 60; // C4
+
+        var note = new VocalNote(NoteFlags.StarPower, false, 0.0, 2.0, phraseTick, phraseTickLength);
+        var lyricNote = new VocalNote(midiPitch, 0, VocalNoteType.Lyric, 0.0, 1.0, phraseTick, phraseTickLength / 2);
+        note.AddChildNote(lyricNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.None, "La", 0.0, phraseTick) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, phraseTick, phraseTickLength, note, lyrics));
+
+        var parts = new List<VocalsPart> { part };
+        var engine = CreateCoordinator(parts, 1);
+
+        // Verify the note track has SP flag via reflection (Notes is protected)
+        var notesField = typeof(BaseEngine<VocalNote, VocalsEngineParameters, VocalsStats>)
+            .GetField("Notes", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(notesField, "Should find Notes field via reflection");
+        var notes = (System.Collections.Generic.List<VocalNote>)notesField!.GetValue(engine)!;
+        Assert.That(notes[0].IsStarPower, Is.True, "Phrase should have StarPower flag");
+
+        engine.Update(0.1);
+
+        // Feed pitch inputs matching the note for the entire phrase duration
+        float[] micPitches = { midiPitch };
+        FeedPitches(engine, 1, new[] { micPitches }, 0.1, 2.5);
+
+        // Process past phrase end
+        engine.Update(3.0);
+
+        // The coordinator should have earned star power
+        Assert.That(engine.EngineStats.StarPowerTickAmount, Is.GreaterThan(0),
+            "Coordinator should have earned star power from singing a SP phrase");
+        Assert.That(engine.EngineStats.StarPowerPhrasesHit, Is.EqualTo(1),
+            "Should have recorded exactly one SP phrase hit");
+    }
+
+    /// SP earning regression: a per-mic sub-engine that MISSES a star power phrase
+    /// must not strip the StarPower flag off the shared VocalNote before the
+    /// coordinator scores that phrase.
+    ///
+    /// The coordinator and every sub-engine are built from the same note track, so
+    /// they share the same VocalNote objects. The coordinator drives all sub-engines
+    /// (including their phrase-end logic) *before* running its own phrase-end. A
+    /// sub-engine that misses calls MissNote -> StripStarPower, clearing the flag on
+    /// the shared note; the coordinator then reads IsStarPower == false and awards
+    /// nothing — even though it graded the phrase a hit. This is why a real singer
+    /// never earned SP while a bot (whose sub-engines always hit, never strip) did.
+    ///
+    /// Repro: two mics on one SP phrase. Mic 0 sings it (coordinator aggregate hits);
+    /// mic 1 is silent (its sub-engine misses and strips). Expect SP still awarded.
+    [Test]
+    public void SubEngineMiss_DoesNotStripStarPower_FromCoordinatorScoring()
+    {
+        var part = CreateVocalsPart();
+        uint phraseTick = 0;
+        uint phraseTickLength = 960;
+        int midiPitch = 60; // C4
+
+        var note = new VocalNote(NoteFlags.StarPower, false, 0.0, 2.0, phraseTick, phraseTickLength);
+        var lyricNote = new VocalNote(midiPitch, 0, VocalNoteType.Lyric, 0.0, 1.0, phraseTick, phraseTickLength / 2);
+        note.AddChildNote(lyricNote);
+        var lyrics = new List<LyricEvent> { new(LyricSymbolFlags.None, "La", 0.0, phraseTick) };
+        part.NotePhrases.Add(new VocalsPhrase(0.0, 2.0, phraseTick, phraseTickLength, note, lyrics));
+
+        var parts = new List<VocalsPart> { part };
+        var engine = CreateCoordinator(parts, 2); // two mics
+
+        var grades = new List<PhraseGrade>();
+        engine.OnPartyVocalsPhrase += (grade, meters, isLast) => grades.Add(grade);
+
+        engine.Update(0.1);
+
+        // Mic 0 sings the SP phrase; mic 1 stays silent (NaN sentinel = no input),
+        // so mic 1's sub-engine misses the phrase and runs StripStarPower.
+        FeedPitches(engine, 2,
+            new[] { new[] { (float) midiPitch }, new[] { float.NaN } },
+            0.1, 2.5);
+
+        engine.Update(3.0);
+
+        // Guard: the coordinator must actually grade the phrase a hit, so a failure
+        // below isolates the SP-award bug rather than a scoring miss.
+        Assert.That(grades, Has.Some.Not.EqualTo(PhraseGrade.Miss),
+            "Mic 0 sang the phrase, so the coordinator should grade it a hit");
+
+        Assert.That(engine.EngineStats.StarPowerTickAmount, Is.GreaterThan(0u),
+            "Coordinator must earn SP on a phrase it grades a hit, even though a silent " +
+            "mic's sub-engine missed it (the sub-engine's MissNote stripped the shared " +
+            "StarPower flag before the coordinator scored the phrase).");
+        Assert.That(engine.EngineStats.StarPowerPhrasesHit, Is.EqualTo(1),
+            "Should record exactly one SP phrase hit");
+    }
+
+    /// overdrive.AC2.1: Manual button deploy still works.
+    [Test]
+    public void ManualDeploy_ActivatesStarPower_WhenSpBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+        Assert.That(engine.CanStarPowerActivate, Is.True);
+
+        int packed = PartyVocalsInput.Pack(0, VocalsAction.StarPower);
+        var input = new GameInput(0.15, packed, true);
+        engine.QueueInput(ref input);
+        engine.Update(0.2);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "Manual StarPower button should deploy SP when banked");
+    }
+
+    /// Bot deploy: a Party Vocals *bot* must self-activate star power once it has
+    /// enough banked, exactly like the solo bot (YargVocalsEngine.UpdateBot toggles
+    /// IsStarPowerInputActive). The coordinator's UpdateBot is a no-op and the per-mic
+    /// sub-engines only toggle their own (dead-data) IsStarPowerInputActive, so the
+    /// authoritative coordinator never set it for a bot — the bot never deployed.
+    [Test]
+    public void BotCoordinator_DeploysStarPower_WhenBanked()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        // A phrase so the coordinator's UpdateHitLogic doesn't early-return on "no notes".
+        AddPhrase(parts[0], 0, 960, 60);
+
+        var primaryChart = parts[0].CloneAsInstrumentDifficulty();
+        var engine = new PartyVocalsCoordinatorEngine(
+            primaryChart, parts, CreateSyncTrack(), EngineParams, isBot: true, micCount: 1);
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+        Assert.That(engine.CanStarPowerActivate, Is.True, "precondition: a half bar is banked");
+
+        // No input is fed — a bot must self-activate.
+        engine.Update(0.5);
+
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "A Party Vocals bot with banked SP should deploy it (like the solo bot). The " +
+            "coordinator never toggled IsStarPowerInputActive for bots, so it never fired.");
+    }
+
+    /// <summary>
+    /// AC.6: Star-power deploys exactly once per qualifying input. Asserting the activation
+    /// COUNT (not just IsStarPowerActive) is strictly stronger — it proves a fresh deploy
+    /// occurred for this input, not just that SP was already active from a prior tick.
+    /// Approach (A) owns the singing/percussion/SP flow in the subclass (the base path
+    /// never runs), so the inherited-base double-fire hazard is avoided by design.
+    /// </summary>
+    [Test]
+    public void Coordinator_DeploysStarPower_OncePerBank()
+    {
+        var parts = new List<VocalsPart> { CreateVocalsPart() };
+        AddTalkiePhrase(parts[0], 0, 960);
+        var engine = CreateCoordinator(parts, 2);
+
+        // Precondition: no activations yet.
+        Assert.That(engine.BaseStats.StarPowerActivationCount, Is.EqualTo(0),
+            "precondition: no SP activations yet");
+
+        BankStarPower(engine, engine.TicksPerHalfSpBar + 100);
+        engine.Update(0.1);
+
+        // Trigger sing-to-activate via a Hit input (mirrors solo engine's path).
+        var hitInput = GameInput.Create(0.15, VocalsAction.Hit, true);
+        engine.QueueInput(ref hitInput);
+        engine.Update(0.2);
+
+        Assert.That(engine.BaseStats.StarPowerActivationCount, Is.EqualTo(1),
+            "Exactly one fresh SP deploy should occur for this qualifying input — " +
+            "not zero (missed deploy) and not >1 (double-activation hazard).");
+        Assert.That(engine.EngineStats.IsStarPowerActive, Is.True,
+            "SP should be active after deploy");
+    }
+
+}

--- a/YARG.Core/Audio/AudioHelpers.cs
+++ b/YARG.Core/Audio/AudioHelpers.cs
@@ -106,7 +106,8 @@ namespace YARG.Core.Audio
                 Instrument.FiveLaneDrums => DrumsStems,
 
                 Instrument.Vocals or
-                Instrument.Harmony => VocalsStems,
+                Instrument.Harmony or
+                Instrument.PartyVocals => VocalsStems,
 
                 _ => throw new Exception("Unreachable.")
             };

--- a/YARG.Core/Audio/AudioHelpers.cs
+++ b/YARG.Core/Audio/AudioHelpers.cs
@@ -88,7 +88,8 @@ namespace YARG.Core.Audio
                 Instrument.FiveLaneDrums => DrumsStems,
 
                 Instrument.Vocals or
-                Instrument.Harmony => VocalsStems,
+                Instrument.Harmony or
+                Instrument.PartyVocals => VocalsStems,
 
                 _ => throw new Exception("Unreachable.")
             };

--- a/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
+++ b/YARG.Core/Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs
@@ -16,7 +16,7 @@ namespace YARG.Core.Chart
             return instrument switch
             {
                 Instrument.Vocals => LoadSoloVocals(instrument),
-                Instrument.Harmony => LoadHarmonyVocals(instrument),
+                Instrument.Harmony or Instrument.PartyVocals => LoadHarmonyVocals(instrument),
                 _ => throw new ArgumentException($"Instrument {instrument} is not a drums instrument!", nameof(instrument))
             };
         }

--- a/YARG.Core/Chart/Loaders/UltraStar/UltraStarLoader.cs
+++ b/YARG.Core/Chart/Loaders/UltraStar/UltraStarLoader.cs
@@ -339,7 +339,7 @@ namespace YARG.Core.Chart.Loaders.UltraStar
 
         public VocalsTrack LoadVocalsTrack(Instrument instrument)
         {
-            if (instrument != Instrument.Vocals && instrument != Instrument.Harmony)
+            if (instrument != Instrument.Vocals && instrument != Instrument.Harmony && instrument != Instrument.PartyVocals)
             {
                 throw new ArgumentException("UltraStar only supports Vocals and HarmonyVocals.", nameof(instrument));
             }
@@ -350,7 +350,7 @@ namespace YARG.Core.Chart.Loaders.UltraStar
             {
                 parts.Add(BuildVocalsPart(_partNotes[0], false));
             }
-            else if (instrument == Instrument.Harmony)
+            else if (instrument == Instrument.Harmony || instrument == Instrument.PartyVocals)
             {
                 bool isDuet = _metadata.TryGetValue("PARTS", out var p) && p == "2";
 

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -302,7 +302,10 @@ namespace YARG.Core.Chart
             return instrument switch
             {
                 Instrument.Vocals => Vocals,
+                // PartyVocals uses the harmony track when available; falls back to
+                // solo vocals for songs with no harmony parts (effectively HARM1-only).
                 Instrument.Harmony => Harmony,
+                Instrument.PartyVocals => Harmony.Parts[0].NotePhrases.Count > 0 ? Harmony : Vocals,
                 _ => throw new ArgumentException($"Instrument {instrument} is not a vocals instrument!")
             };
         }

--- a/YARG.Core/Chart/SongChart.cs
+++ b/YARG.Core/Chart/SongChart.cs
@@ -299,7 +299,10 @@ namespace YARG.Core.Chart
             return instrument switch
             {
                 Instrument.Vocals => Vocals,
+                // PartyVocals uses the harmony track when available; falls back to
+                // solo vocals for songs with no harmony parts (effectively HARM1-only).
                 Instrument.Harmony => Harmony,
+                Instrument.PartyVocals => Harmony.Parts[0].NotePhrases.Count > 0 ? Harmony : Vocals,
                 _ => throw new ArgumentException($"Instrument {instrument} is not a vocals instrument!")
             };
         }

--- a/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
+++ b/YARG.Core/Chart/Tracks/Vocals/VocalsPartExtensions.cs
@@ -17,6 +17,9 @@
                 {
                     if (note.Type == VocalNoteType.Percussion)
                     {
+                        // Preserve percussion notes — UnpitchedOnly only affects pitched notes.
+                        // NoVocalPercussion is the modifier that removes percussion.
+                        newPhraseParent.AddChildNote(note);
                         continue;
                     }
 

--- a/YARG.Core/Engine/EngineManager.UnisonEvent.cs
+++ b/YARG.Core/Engine/EngineManager.UnisonEvent.cs
@@ -239,7 +239,7 @@ namespace YARG.Core.Engine
             var tickTolerance = (chart.Resolution / 4) - 1;
 
             // Since vocals can't have unisons, we may as well pull the ripcord early
-            if (instrumentDifficulty.Instrument is Instrument.Vocals or Instrument.Harmony)
+            if (instrumentDifficulty.Instrument is Instrument.Vocals or Instrument.Harmony or Instrument.PartyVocals)
             {
                 return new List<UnisonPhrase>();
             }

--- a/YARG.Core/Engine/Vocals/Engines/PartyVocalsCoordinatorEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/PartyVocalsCoordinatorEngine.cs
@@ -1,0 +1,859 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YARG.Core.Chart;
+using YARG.Core.Input;
+
+namespace YARG.Core.Engine.Vocals.Engines
+{
+    /// <summary>
+    /// Per-HARM result for one phrase, delivered via
+    /// <see cref="PartyVocalsCoordinatorEngine.OnPartyVocalsPhrase"/>. Only parts that actually have
+    /// notes in the phrase ("available parts") are included, in ascending <see cref="PartIndex"/>
+    /// order (lowest HARM number first). A part is "Awesome" when <see cref="Meter"/> &gt;= the
+    /// engine's PhraseHitPercent threshold. Top-level (not nested) so Unity-side callers can reach
+    /// it via `using YARG.Core.Engine.Vocals.Engines;`.
+    /// </summary>
+    public readonly struct PartyPartResult
+    {
+        // 0 = HARM1, 1 = HARM2, 2 = HARM3 (ordinal position in the song's part list).
+        public int PartIndex { get; }
+        public double Meter { get; } // raw canonical meter; >= PhraseHitPercent = Awesome
+
+        public PartyPartResult(int partIndex, double meter)
+        {
+            PartIndex = partIndex;
+            Meter = meter;
+        }
+    }
+
+    public sealed class PartyVocalsCoordinatorEngine : VocalsEngine
+    {
+        public static InstrumentDifficulty<VocalNote> BuildMergedTrack(
+            IReadOnlyList<VocalsPart> allParts, InstrumentDifficulty<VocalNote> baseTrack)
+        {
+            var merged = new List<VocalNote>();
+            var seen = new HashSet<(uint tick, uint tickEnd)>();
+
+            foreach (var part in allParts)
+            {
+                foreach (var phrase in part.NotePhrases)
+                {
+                    var note = phrase.PhraseParentNote;
+                    if (seen.Add((note.Tick, note.TickEnd)))
+                    {
+                        merged.Add(note);
+                    }
+                }
+            }
+
+            merged.Sort((a, b) => a.Tick.CompareTo(b.Tick));
+
+            // StarPower Phrase events live per-part, so the merged track must union
+            // them too — otherwise TotalStarPowerPhrases counts only HARM1's phrases
+            // while StarPowerPhrasesHit counts hits across all parts.
+            var mergedPhrases = new List<Phrase>();
+            var seenPhrases = new HashSet<(uint tick, uint tickEnd, PhraseType type)>();
+            foreach (var part in allParts)
+            {
+                foreach (var phrase in part.OtherPhrases)
+                {
+                    if (seenPhrases.Add((phrase.Tick, phrase.TickEnd, phrase.Type)))
+                    {
+                        mergedPhrases.Add(phrase);
+                    }
+                }
+            }
+            mergedPhrases.Sort((a, b) => a.Tick.CompareTo(b.Tick));
+
+            return new InstrumentDifficulty<VocalNote>(
+                baseTrack.Instrument, Difficulty.Expert,
+                merged, mergedPhrases, new(baseTrack.TextEvents));
+        }
+
+        // Multi-mic state owned directly by the coordinator (was hoisted into
+        // YargFreeVocalsEngine in Phase 3 so the subclass could see them).
+        private readonly int _micCount;
+        private readonly VocalsPart[] _allParts;
+        private readonly bool[] _partHasContent;
+        private readonly double[] _canonicalMeters;
+        private readonly uint[] _phraseTicksTotalPerPart;
+        private readonly double[,] _micPartHits;
+        private readonly double[,] _lastWindowSnapshot;
+        private readonly double[] _cumulativeAssignedTicks;
+        private readonly double[] _lastTickMicDeltas;
+
+        // Per-mic bitmask of which parts each mic is currently hitting THIS TICK.
+        // Populated by reading each sub-engine's GetMicHittingParts after driving its tick,
+        // and read per-tick by the ambiguity classifier for scoring. This is a single-tick
+        // transient (the sub-engine resets it every AccumulateMicPartHits call), so it is
+        // NOT suitable for the visual layer, which reads one frame later — see below.
+        private readonly uint[] _micCurrentlyHittingParts;
+
+        // Per-mic bitmask of parts each mic hit at ANY point during the current visual frame.
+        // OR-accumulated across ticks and reset per frame (ResetMicSangFlags), mirroring
+        // _micSangThisTick. The visual-facing GetMicHittingParts returns this so the per-mic
+        // trail's on-note gate sees a stable per-frame signal instead of the single-tick
+        // transient above (which is 0 on most ticks and killed the trail).
+        private readonly uint[] _micHittingPartsThisFrame;
+
+        // Unified per-mic "sang this tick" flag - source of truth for needle visibility
+        private readonly bool[] _micSangThisTick;
+
+        // Coordinator-specific ambiguity scoring state
+        private readonly double[] _harmDirectTicks;
+        private readonly double[] _ambiguityBuckets;
+        private readonly double[,] _bucketPerMic;
+        private readonly uint[] _micHitMaskScratch;
+        private readonly int[] _bucketOrder;
+        private double _lastMeterRefreshTime;
+        private const double METER_UPDATE_INTERVAL_SECONDS = 0.1;
+
+        // Sub-engines (one per mic, composition)
+        private readonly YargFreeVocalsEngine[] _subEngines;
+
+        // Per-phrase tracking for the coordinator's own phrase-end logic
+        private uint? _coordinatorPhraseTicksTotal;
+
+        // Percussion notes this coordinator has already scored or missed. Tracked locally
+        // instead of via VocalNote.WasHit/WasMissed: the note objects are shared with the
+        // sub-engines and other players' engines, so setting hit/miss state on them leaks
+        // across engines (the same hazard the SP-earning bug documents). This set is the
+        // coordinator's private "consumed" ledger, fed to GetNextPercussionNote so a note
+        // isn't re-offered after it's resolved. Cleared on Reset (rewind/practice).
+        private readonly HashSet<VocalNote> _resolvedPercussion = new();
+
+        public PartyVocalsCoordinatorEngine(
+            InstrumentDifficulty<VocalNote> noteTrack,
+            IReadOnlyList<VocalsPart> allParts,
+            SyncTrack syncTrack,
+            VocalsEngineParameters engineParameters,
+            bool isBot,
+            int micCount,
+            int botPartIndex = 0)
+            : base(noteTrack, syncTrack, engineParameters, isBot)
+        {
+            int partCount = allParts.Count;
+
+            _micCount = micCount;
+            _allParts = allParts.ToArray();
+            _partHasContent = new bool[partCount];
+            _canonicalMeters = new double[partCount];
+            _phraseTicksTotalPerPart = new uint[partCount];
+            _micPartHits = new double[micCount, partCount];
+            _lastWindowSnapshot = new double[micCount, partCount];
+            _cumulativeAssignedTicks = new double[partCount];
+            _lastTickMicDeltas = new double[micCount];
+            _micCurrentlyHittingParts = new uint[micCount];
+            _micHittingPartsThisFrame = new uint[micCount];
+            _micSangThisTick = new bool[micCount];
+
+            _harmDirectTicks = new double[partCount];
+            _ambiguityBuckets = new double[1 << partCount];
+            _bucketPerMic = new double[micCount, 1 << partCount];
+            _micHitMaskScratch = new uint[micCount];
+            _bucketOrder = ComputeBucketOrder(partCount);
+
+            // Build one sub-engine per mic (composition).
+            //
+            // NOTE (shared mutable note state): every sub-engine is constructed with the
+            // SAME `noteTrack` the coordinator scores on, so coordinator.Notes and each
+            // subEngine.Notes are the *same* VocalNote objects. CloneAsInstrumentDifficulty
+            // also reuses note references across players, so a bot and a live player share
+            // these objects too. Engine operations that mutate note flags (StripStarPower
+            // on miss, SetHitState) therefore leak between engines.
+            //
+            // `isSubEngine: true` is a targeted fix for the worst symptom: it stops a
+            // sub-engine's miss from stripping the StarPower flag off a phrase the
+            // coordinator hit (which made real singers earn no SP while bots did). It does
+            // NOT fix the residual cross-player leak (one player's coordinator missing an
+            // SP phrase can still strip it for another player sharing the same notes).
+            //
+            // The more correct fix is to give each engine its own copy of the notes (or
+            // make notes immutable), eliminating the whole class of cross-engine leakage.
+            // That touches shared, hot data across all instruments, so it's a broader change
+            // worth discussing with the wider project rather than doing here.
+            _subEngines = new YargFreeVocalsEngine[micCount];
+            for (int i = 0; i < micCount; i++)
+            {
+                _subEngines[i] = new YargFreeVocalsEngine(
+                    noteTrack,
+                    allParts,
+                    syncTrack,
+                    engineParameters,
+                    isBot,
+                    botPartIndex: i,
+                    isSubEngine: true);
+            }
+
+            for (int j = 0; j < partCount; j++)
+            {
+                _partHasContent[j] = allParts[j].NotePhrases.Count > 0;
+            }
+
+            // Forward visual events from the primary sub-engine (mic 0) to the
+            // coordinator so the existing VocalsPlayer — which subscribes to the
+            // coordinator's events — receives needle/sing/hit feedback. The
+            // sub-engines do the actual pitch matching and fire these events on
+            // their own delegates; without forwarding, the coordinator never fires
+            // them and the HUD shows no feedback.
+            _subEngines[0].OnTargetNoteChanged += note => OnTargetNoteChanged?.Invoke(note);
+            _subEngines[0].OnSing += singing => OnSing?.Invoke(singing);
+            _subEngines[0].OnHit += hit => OnHit?.Invoke(hit);
+
+            GetWaitCountdowns(PartyVocalsCountdownNotes.ExcludingPercussion(allParts.ToList()));
+        }
+
+        public override void Reset(bool keepCurrentButtons = false)
+        {
+            // Drop the local percussion ledger so notes are hittable again after a
+            // rewind/practice seek (mirrors how WasHit/WasMissed clear on note reset).
+            _resolvedPercussion.Clear();
+
+            // Reset every sub-engine so practice/rewind starts fresh — without this,
+            // sub-engines retain advanced NoteIndex, CurrentTime, LastSingTick, and
+            // per-part accumulators from before the seek.
+            // (Null check: BaseEngine's constructor calls Reset() before our fields are set.)
+            if (_subEngines != null)
+            {
+                foreach (var sub in _subEngines)
+                {
+                    sub.Reset(keepCurrentButtons);
+                }
+
+                // Clear all coordinator-owned phrase/visual state.
+                ResetPhraseState();
+            }
+
+            base.Reset(keepCurrentButtons);
+        }
+
+        public IReadOnlyList<YargFreeVocalsEngine> SubEngines => _subEngines;
+
+        /// <summary>
+        /// The harmony part index the primary mic is currently matching (0=HARM1, 1=HARM2,
+        /// 2=HARM3). Drives particle/trail color in the HUD. For ambiguous matches (multiple
+        /// parts satisfied by the same pitch), the lowest index wins — the sub-engine iterates
+        /// parts in ascending order and keeps the first best-percent match.
+        ///
+        /// When multi-mic support is added, the coordinator will disambiguate across mics:
+        /// e.g., if mic 0 and mic 1 both match HARM1+HARM2 at the same pitch, mic 0 claims
+        /// HARM1 (lower index) and mic 1 claims HARM2. This property would then return mic 0's
+        /// resolved part. The disambiguation strategy is a coordinator responsibility, not the
+        /// sub-engine's.
+        /// </summary>
+        public int DisplayedHarmonyIndex => _micCount > 0 ? _subEngines[0].CurrentTargetHarmonyIndex : 0;
+
+        public bool PartHasContent(int partIndex)
+        {
+            if (partIndex < 0 || partIndex >= _allParts.Length) return false;
+            return _partHasContent[partIndex];
+        }
+
+        public int PartCount => _allParts.Length;
+
+        public bool PartInCurrentPhrase(int partIndex) =>
+            partIndex >= 0 && partIndex < _phraseTicksTotalPerPart.Length
+            && _phraseTicksTotalPerPart[partIndex] > 0u;
+
+        // True if the part has a (non-percussion) note in the NEXT master phrase. Used by
+        // the HUD count-in drain so a meter can warn the player a phrase before their line
+        // returns. Computed on demand (the next phrase hasn't started, so the per-tick
+        // _phraseTicksTotalPerPart array doesn't cover it).
+        public bool PartInNextPhrase(int partIndex)
+        {
+            if (partIndex < 0 || partIndex >= _allParts.Length) return false;
+            int next = NoteIndex + 1;
+            if (next < 0 || next >= Notes.Count) return false;
+            return GetTicksInPhraseForPart(_allParts[partIndex], Notes[next]) > 0u;
+        }
+
+        // Progress 0..1 through the CURRENT phrase's tick span. Drives the count-in drain.
+        // Uses the phrase span (Tick..TickEnd), NOT PhraseTicksTotal — that is the sung-hit
+        // tick total and would drain far too fast on sparse phrases.
+        public double CurrentPhraseProgress
+        {
+            get
+            {
+                if (NoteIndex < 0 || NoteIndex >= Notes.Count) return 0.0;
+                var phrase = Notes[NoteIndex];
+                uint span = phrase.TickEnd - phrase.Tick;
+                if (span == 0) return 0.0;
+                double p = ((double) CurrentTick - phrase.Tick) / span;
+                return p < 0.0 ? 0.0 : (p > 1.0 ? 1.0 : p);
+            }
+        }
+
+        // Duration of the current phrase in seconds. Lets the HUD convert a real-time
+        // count-in hold (e.g. 500ms) into a fraction of CurrentPhraseProgress.
+        public double CurrentPhraseDurationSeconds
+        {
+            get
+            {
+                if (NoteIndex < 0 || NoteIndex >= Notes.Count) return 0.0;
+                var phrase = Notes[NoteIndex];
+                return phrase.TimeEnd - phrase.Time;
+            }
+        }
+
+        public IReadOnlyList<double> CanonicalMeters => _canonicalMeters;
+
+        public double AwesomeThreshold => EngineParameters.PhraseHitPercent;
+
+        public uint GetMicHittingParts(int micIndex)
+        {
+            if (micIndex < 0 || micIndex >= _micCount) return 0u;
+            // Per-frame accumulation, not the single-tick transient: the visual layer reads
+            // this a frame after the engine ticked, so it must reflect any hit during the
+            // frame, not just the last tick's (which is usually 0).
+            return _micHittingPartsThisFrame[micIndex];
+        }
+
+        public float GetMicPitch(int micIndex)
+        {
+            if (micIndex < 0 || micIndex >= _micCount) return 0f;
+            return _subEngines[micIndex].GetCurrentPitch();
+        }
+
+        public void ResetMicSangFlags()
+        {
+            // Reset per-frame needle/trail signals together: both are accumulated across the
+            // frame's ticks and consumed by the visual layer after Update.
+            Array.Clear(_micSangThisTick, 0, _micSangThisTick.Length);
+            Array.Clear(_micHittingPartsThisFrame, 0, _micHittingPartsThisFrame.Length);
+        }
+        public bool DidMicSingThisTick(int mic) =>
+            mic >= 0 && mic < _micCount && _micSangThisTick[mic];
+
+        #region VocalsEngine Abstract Implementations
+
+        protected override void MutateStateWithInput(GameInput gameInput)
+        {
+            int mic = PartyVocalsInput.UnpackMic(gameInput.Action);
+            var action = PartyVocalsInput.UnpackAction(gameInput.Action);
+
+            switch (action)
+            {
+                case VocalsAction.Pitch:
+                    // Guarded sub-engine call — mirrors the silent-default pattern of
+                    // GetMicPitch/GetMicHittingParts (a malformed/replayed mic index is
+                    // dropped, not thrown). Do NOT call the coordinator's own
+                    // SetMicPitch(int,float) here: it throws on out-of-range.
+                    if (mic >= 0 && mic < _micCount)
+                    {
+                        _subEngines[mic].SetMicPitch(gameInput.Axis);
+                        _micSangThisTick[mic] = true; // unified needle sang-state (see below)
+                    }
+                    break;
+                case VocalsAction.Hit when gameInput.Button:
+                    HasHit = true; // coordinator-level; percussion scored here (standalone fix)
+                    break;
+                case VocalsAction.StarPower:
+                    IsStarPowerInputActive = gameInput.Button;
+                    break;
+            }
+        }
+
+        protected override void UpdateHitLogic(double time)
+        {
+            if (NoteIndex >= Notes.Count)
+            {
+                HasSang = false;
+                return;
+            }
+
+            // Bot self-activation. Mirrors YargVocalsEngine.UpdateBot: a bot toggles its
+            // own StarPower input so UpdateStarPower deploys once it has half a bar. The
+            // coordinator's UpdateBot is a no-op (sub-engines run their own), and the
+            // sub-engines only toggle their own dead-data IsStarPowerInputActive — so
+            // without this the authoritative coordinator never deployed SP for a bot.
+            if (IsBot)
+            {
+                IsStarPowerInputActive = CanStarPowerActivate && !IsStarPowerInputActive;
+            }
+
+            // Drive each sub-engine forward for this tick. Each sub-engine runs its
+            // full single-mic lifecycle (MutateStateWithInput → UpdateHitLogic →
+            // phrase-end). Sub-engine outputs nobody reads are dead data.
+            for (int i = 0; i < _micCount; i++)
+            {
+                _subEngines[i].Update(time);
+            }
+
+            // Mirror time variables from sub-engines (they all share the same SyncTrack,
+            // so any one would do — use the first).
+            CurrentTime = _subEngines[0].CurrentTime;
+            CurrentTick = _subEngines[0].CurrentTick;
+            // Mirror mic 0's pitch so VocalsPlayer can read it for the needle position.
+            // SetMicPitch sets the sub-engine's PitchSang, but the player reads the
+            // coordinator's PitchSang for the needle — without this it stays at 0.
+            PitchSang = _subEngines[0].PitchSang;
+
+            // Bots queue no Hit inputs and the coordinator's UpdateBot is a no-op, so a bot
+            // would never set HasHit and never score percussion (real mics do, via
+            // MutateStateWithInput). Arm HasHit here when a percussion note is due, mirroring
+            // the solo bot path (YargVocalsEngine.UpdateBot's percussion branch).
+            if (IsBot)
+            {
+                var botPercussion = GetNextPercussionNote(Notes[NoteIndex], CurrentTick, _resolvedPercussion.Contains);
+                if (botPercussion is not null && CurrentTime >= botPercussion.Time)
+                {
+                    HasHit = true;
+                }
+            }
+
+            // Score percussion taps at the band level. The coordinator aggregates
+            // any mic's Hit into a single HasHit (MutateStateWithInput), so this
+            // scores one band hit per tap with no double-count.
+            // Also handles sing-to-activate (mirrors YargVocalsEngine.cs:188-218).
+            CheckPercussionHit();
+
+            // Read per-tick credit from each sub-engine's LastTickPartDeltas and
+            // per-mic hitting-parts bitmask.
+            Array.Clear(_lastTickMicDeltas, 0, _lastTickMicDeltas.Length);
+            for (int i = 0; i < _micCount; i++)
+            {
+                var deltas = _subEngines[i].LastTickPartDeltas;
+                double totalDelta = 0;
+                for (int j = 0; j < deltas.Count && j < _allParts.Length; j++)
+                {
+                    totalDelta += deltas[j];
+                }
+                _lastTickMicDeltas[i] = totalDelta;
+
+                // Read the sub-engine's per-mic hitting-parts bitmask (single-tick).
+                _micCurrentlyHittingParts[i] = _subEngines[i].GetMicHittingParts();
+
+                // OR-accumulate into the per-frame signal the visual layer reads, so a hit
+                // on any tick this frame keeps the trail's on-note gate satisfied.
+                _micHittingPartsThisFrame[i] |= _micCurrentlyHittingParts[i];
+            }
+
+            var phrase = Notes[NoteIndex];
+
+            // Populate per-part tick totals for the current phrase. The coordinator's
+            // phrase total sums across ALL harmony parts — not just Parts[0]/HARM1 — so
+            // phrases that only have HARM2/HARM3 notes are not treated as empty.
+            uint allPartsTotal = 0;
+            for (int j = 0; j < _allParts.Length; j++)
+            {
+                _phraseTicksTotalPerPart[j] = GetTicksInPhraseForPart(_allParts[j]);
+                allPartsTotal += _phraseTicksTotalPerPart[j];
+            }
+
+            _coordinatorPhraseTicksTotal ??= allPartsTotal;
+            PhraseTicksTotal ??= _coordinatorPhraseTicksTotal;
+
+            // Run the coordinator's per-tick ambiguity classifier
+            AccumulateAmbiguityScoring();
+
+            // Speculative refresh on the 100ms throttle for live HUD
+            if (CurrentTime - _lastMeterRefreshTime >= METER_UPDATE_INTERVAL_SECONDS)
+            {
+                _lastMeterRefreshTime = CurrentTime;
+                RunAllocatorIntoCanonicalMeters(commit: false);
+            }
+
+            // Check for end of phrase
+            if (CurrentTick > phrase.TickEnd)
+            {
+                bool hasNotes = _coordinatorPhraseTicksTotal.Value != 0;
+                bool isLastPhrase = NoteIndex == Notes.Count - 1;
+                uint phraseTicksTotal = _coordinatorPhraseTicksTotal.Value;
+
+                if (phraseTicksTotal == 0)
+                {
+                    HitNote(phrase);
+                    // Fire OnPhraseHit so _phrasePercents stays aligned with
+                    // _phraseGrades/_phrasePartResults (populated by the
+                    // OnPartyVocalsPhrase handler below).
+                    OnPhraseHit?.Invoke(1.0, true, isLastPhrase);
+                    OnPartyVocalsPhrase?.Invoke(
+                        PhraseGrade.Awesome, Array.Empty<PartyPartResult>(), isLastPhrase);
+                }
+                else
+                {
+                    ProcessPhraseEnd(phrase, phraseTicksTotal, isLastPhrase);
+                }
+
+                // Reset per-phrase state
+                ResetPhraseState();
+
+                UpdateCarriedNote(phrase);
+            }
+        }
+
+        protected override void CheckForNoteHit()
+        {
+            // No-op: sub-engines handle their own hit detection.
+        }
+
+        protected override void UpdateBot(double songTime)
+        {
+            // No-op: each sub-engine runs its own UpdateBot via its own Update cycle.
+        }
+
+        protected override bool CanVocalNoteBeHit(VocalNote note, out float hitPercent)
+        {
+            hitPercent = 0f;
+            throw new NotImplementedException(
+                "CanVocalNoteBeHit is not called on the coordinator; sub-engines handle pitch matching.");
+        }
+
+        protected override bool CanNoteBeHit(VocalNote note) =>
+            throw new NotImplementedException();
+
+        // Vocals have no lanes (matches YargVocalsEngine).
+        protected override bool ProximalLaneForgivesInput(int inputNote, VocalNote laneNote) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        public delegate void PartyVocalsPhraseEvent(
+            PhraseGrade grade,
+            IReadOnlyList<PartyPartResult> parts,
+            bool isLastPhrase);
+
+        /// <summary>
+        /// Fires at the end of each phrase alongside OnPhraseHit. Provides the
+        /// final N-awesome grade and per-HARM canonical meter values. The coordinator
+        /// always emits both OnPhraseHit (standard vocals event) and OnPartyVocalsPhrase
+        /// (party-specific grade/parts) at phrase end. Declared here rather than on
+        /// VocalsEngine so the prototype's phrase-end event stays off the upstream base engine.
+        /// </summary>
+        public PartyVocalsPhraseEvent? OnPartyVocalsPhrase;
+
+        #region Phrase-End Logic
+
+        private void ProcessPhraseEnd(VocalNote phrase, uint phraseTicksTotal, bool isLastPhrase)
+        {
+            // Final allocation using all accumulated credit
+            RunAllocatorIntoCanonicalMeters(commit: true);
+
+            int partCount = _allParts.Length;
+            int awesomeCount = 0;
+            double bestMeter = 0;
+            for (int j = 0; j < partCount; j++)
+            {
+                if (_canonicalMeters[j] >= EngineParameters.PhraseHitPercent) awesomeCount++;
+                if (_canonicalMeters[j] > bestMeter) bestMeter = _canonicalMeters[j];
+            }
+
+            var grade = awesomeCount switch
+            {
+                0 => PhraseGrade.Miss,
+                1 => PhraseGrade.Awesome,
+                2 => PhraseGrade.DoubleAwesome,
+                _ => PhraseGrade.TripleAwesome,
+            };
+            bool hit = grade != PhraseGrade.Miss;
+
+            // Per-part results for parts that actually have notes in this phrase (available parts),
+            // ascending part order (lowest HARM number first = bottom of the summary bar).
+            var parts = new List<PartyPartResult>(partCount);
+            for (int j = 0; j < partCount; j++)
+            {
+                if (_phraseTicksTotalPerPart[j] > 0)
+                {
+                    parts.Add(new PartyPartResult(j, _canonicalMeters[j]));
+                }
+            }
+
+            if (hit)
+            {
+                EngineStats.TicksHit += phraseTicksTotal;
+                HitNote(phrase);
+            }
+            else
+            {
+                var ticksHit = (uint)Math.Round(PhraseTicksHit);
+                EngineStats.TicksHit += ticksHit;
+                EngineStats.TicksMissed += phraseTicksTotal - ticksHit;
+                MissNote(phrase, bestMeter);
+            }
+
+            OnPhraseHit?.Invoke(bestMeter / EngineParameters.PhraseHitPercent, hit, isLastPhrase);
+            OnPartyVocalsPhrase?.Invoke(grade, parts, isLastPhrase);
+        }
+
+        private void ResetPhraseState()
+        {
+            PhraseTicksHit = 0;
+            PhraseTicksTotal = null;
+            _coordinatorPhraseTicksTotal = null;
+
+            Array.Clear(_micPartHits, 0, _micPartHits.Length);
+            Array.Clear(_lastWindowSnapshot, 0, _lastWindowSnapshot.Length);
+            Array.Clear(_cumulativeAssignedTicks, 0, _cumulativeAssignedTicks.Length);
+            Array.Clear(_canonicalMeters, 0, _canonicalMeters.Length);
+            Array.Clear(_phraseTicksTotalPerPart, 0, _phraseTicksTotalPerPart.Length);
+            Array.Clear(_harmDirectTicks, 0, _harmDirectTicks.Length);
+            Array.Clear(_ambiguityBuckets, 0, _ambiguityBuckets.Length);
+            Array.Clear(_bucketPerMic, 0, _bucketPerMic.Length);
+            Array.Clear(_micCurrentlyHittingParts, 0, _micCurrentlyHittingParts.Length);
+            Array.Clear(_micHittingPartsThisFrame, 0, _micHittingPartsThisFrame.Length);
+            Array.Clear(_micSangThisTick, 0, _micSangThisTick.Length);
+
+            _lastMeterRefreshTime = CurrentTime;
+        }
+
+        #endregion
+
+        #region Ambiguity Scoring
+
+        private void AccumulateAmbiguityScoring()
+        {
+            int partCount = _phraseTicksTotalPerPart.Length;
+
+            // Classify: for each mic, build the mask of HARMs it could be hitting
+            for (int i = 0; i < _micCount; i++)
+            {
+                uint rawMask = _micCurrentlyHittingParts[i];
+                uint mask = 0u;
+                for (int j = 0; j < partCount; j++)
+                {
+                    if ((rawMask & (1u << j)) != 0u && _phraseTicksTotalPerPart[j] > 0u)
+                        mask |= 1u << j;
+                }
+                _micHitMaskScratch[i] = mask;
+            }
+
+            // Direct credit: binary across mics
+            for (int j = 0; j < partCount; j++)
+            {
+                double maxDelta = 0;
+                for (int i = 0; i < _micCount; i++)
+                {
+                    uint m = _micHitMaskScratch[i];
+                    if (PopCount(m) == 1 && (m & (1u << j)) != 0u)
+                    {
+                        double d = _lastTickMicDeltas[i];
+                        if (d > maxDelta) maxDelta = d;
+                    }
+                }
+                _harmDirectTicks[j] += maxDelta;
+            }
+
+            // Ambiguity bucket credit: additive across mics with per-mic-span cap.
+            // Use per-part delta (not summed) so the per-mic-span cap correctly
+            // limits each HARM to what one mic actually contributed per HARM.
+            for (int i = 0; i < _micCount; i++)
+            {
+                uint m = _micHitMaskScratch[i];
+                if (PopCount(m) >= 2)
+                {
+                    var deltas = _subEngines[i].LastTickPartDeltas;
+                    double partDelta = 0;
+                    int hitCount = 0;
+                    for (int j = 0; j < partCount && j < deltas.Count; j++)
+                    {
+                        if ((m & (1u << j)) != 0u)
+                        {
+                            partDelta += deltas[j];
+                            hitCount++;
+                        }
+                    }
+                    if (hitCount > 0) partDelta /= hitCount;
+
+                    _ambiguityBuckets[(int)m] += partDelta;
+                    _bucketPerMic[i, (int)m] += partDelta;
+                }
+            }
+        }
+
+        #endregion
+
+        #region Allocator
+
+        private void RunAllocatorIntoCanonicalMeters(bool commit)
+        {
+            int partCount = _phraseTicksTotalPerPart.Length;
+
+            Span<double> credited = stackalloc double[partCount];
+            for (int j = 0; j < partCount; j++)
+            {
+                uint cap = _phraseTicksTotalPerPart[j];
+                credited[j] = cap == 0 ? 0 : Math.Min(_harmDirectTicks[j], cap);
+            }
+
+            Span<double> bucketsCopy = stackalloc double[_ambiguityBuckets.Length];
+            for (int i = 0; i < _ambiguityBuckets.Length; i++) bucketsCopy[i] = _ambiguityBuckets[i];
+
+            Span<double> receivedFromBucket = stackalloc double[partCount];
+
+            foreach (int S in _bucketOrder)
+            {
+                if (bucketsCopy[S] <= 0) continue;
+
+                double perMicCap = 0;
+                for (int i = 0; i < _micCount; i++)
+                {
+                    double v = _bucketPerMic[i, S];
+                    if (v > perMicCap) perMicCap = v;
+                }
+
+                receivedFromBucket.Clear();
+
+                while (bucketsCopy[S] > 0)
+                {
+                    int chosen = -1;
+                    double chosenCredited = -1;
+                    for (int j = 0; j < partCount; j++)
+                    {
+                        if ((S & (1 << j)) == 0) continue;
+                        uint cap = _phraseTicksTotalPerPart[j];
+                        if (cap == 0 || credited[j] >= cap) continue;
+                        if (receivedFromBucket[j] >= perMicCap) continue;
+                        if (credited[j] > chosenCredited)
+                        {
+                            chosenCredited = credited[j];
+                            chosen = j;
+                        }
+                    }
+
+                    if (chosen < 0) break;
+
+                    double remainingCapacity = _phraseTicksTotalPerPart[chosen] - credited[chosen];
+                    double remainingPerMicCap = perMicCap - receivedFromBucket[chosen];
+                    double transfer = Math.Min(
+                        Math.Min(bucketsCopy[S], remainingCapacity),
+                        remainingPerMicCap);
+                    if (transfer <= 0) break;
+                    credited[chosen] += transfer;
+                    bucketsCopy[S] -= transfer;
+                    receivedFromBucket[chosen] += transfer;
+                }
+            }
+
+            for (int j = 0; j < partCount; j++)
+            {
+                uint cap = _phraseTicksTotalPerPart[j];
+                _canonicalMeters[j] = cap == 0 ? 0 : credited[j] / cap;
+            }
+
+            // Mirror best meter into PhraseTicksHit for HUD combo fill bar.
+            // The fill bar represents accumulated progress within a phrase and must be
+            // monotonically non-decreasing — the allocator's speculative refresh can
+            // momentarily compute a lower "best" if timing causes a part's direct
+            // ticks to be reclassified, so we clamp to the previous value.
+            if (PhraseTicksTotal is { } total && total > 0)
+            {
+                double best = 0;
+                for (int j = 0; j < partCount; j++)
+                    if (_canonicalMeters[j] > best) best = _canonicalMeters[j];
+                double newHit = best * total;
+                if (newHit > PhraseTicksHit)
+                {
+                    PhraseTicksHit = newHit;
+                }
+            }
+        }
+
+        private static int[] ComputeBucketOrder(int partCount)
+        {
+            var masks = new List<int>();
+            for (int m = 0; m < (1 << partCount); m++)
+            {
+                if (PopCount((uint)m) >= 2) masks.Add(m);
+            }
+            masks.Sort((a, b) =>
+            {
+                int pa = PopCount((uint)a);
+                int pb = PopCount((uint)b);
+                if (pa != pb) return pa - pb;
+                return a - b;
+            });
+            return masks.ToArray();
+        }
+
+        private static int PopCount(uint m)
+        {
+            return (int)(((m >> 0) & 1u) + ((m >> 1) & 1u) + ((m >> 2) & 1u));
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private uint GetTicksInPhraseForPart(VocalsPart part) =>
+            GetTicksInPhraseForPart(part, Notes[NoteIndex]);
+
+        private uint GetTicksInPhraseForPart(VocalsPart part, VocalNote masterPhrase)
+        {
+            uint masterStart = masterPhrase.Tick;
+            uint masterEnd = masterPhrase.TickEnd;
+
+            uint totalTime = 0;
+            foreach (var partPhrase in part.NotePhrases)
+            {
+                var phraseNote = partPhrase.PhraseParentNote;
+                if (phraseNote.Tick >= masterEnd || phraseNote.TickEnd <= masterStart) continue;
+
+                foreach (var noteInPhrase in phraseNote.ChildNotes)
+                {
+                    if (noteInPhrase.IsPercussion) continue;
+                    totalTime += phraseNote.GetTicksForNote(noteInPhrase);
+                }
+                break;
+            }
+            return totalTime;
+        }
+
+        #endregion
+
+        #region Percussion Scoring
+
+        private void CheckPercussionHit()
+        {
+            if (NoteIndex >= Notes.Count)
+            {
+                HasHit = false;
+                return;
+            }
+
+            var phrase = Notes[NoteIndex];
+            var percussion = GetNextPercussionNote(phrase, CurrentTick, _resolvedPercussion.Contains);
+            if (percussion is not null)
+            {
+                // Gate on the full hit window (front/back tolerance), mirroring solo
+                // YargVocalsEngine.CheckPercussionHit. The previous raw [Time, TimeEnd]
+                // span gave ZERO early tolerance (CurrentTime >= Time) and, for a short
+                // percussion note, almost no late tolerance — so real taps were dropped
+                // even though they reached the engine.
+                if (IsNoteInWindow(percussion, out var missed))
+                {
+                    if (HasHit)
+                    {
+                        // Consume locally (no note.SetHitState) so the shared note isn't
+                        // mutated, then score exactly as before.
+                        _resolvedPercussion.Add(percussion);
+                        AddScore(percussion);
+                        OnNoteHit?.Invoke(NoteIndex, percussion);
+                    }
+                }
+                else if (missed)
+                {
+                    // Back-end miss: the window has passed without a tap. Resolve the note
+                    // locally so it stops being "next due" (instead of lingering) and fire
+                    // the miss event, mirroring solo's MissNote(percussion) minus the
+                    // shared-note SetMissState.
+                    _resolvedPercussion.Add(percussion);
+                    OnNoteMissed?.Invoke(NoteIndex, percussion);
+                }
+            }
+            else
+            {
+                // Mirror YargVocalsEngine.cs:210-214: singing (or any noise) can
+                // result in a percussion hit call, so check sing-to-activate here.
+                if (HasHit && CanStarPowerActivate && EngineParameters.SingToActivateStarPower)
+                {
+                    ActivateStarPower();
+                }
+            }
+
+            HasHit = false;
+        }
+
+        #endregion
+    }
+}

--- a/YARG.Core/Engine/Vocals/Engines/PartyVocalsCoordinatorEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/PartyVocalsCoordinatorEngine.cs
@@ -1,0 +1,817 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YARG.Core.Chart;
+using YARG.Core.Input;
+
+namespace YARG.Core.Engine.Vocals.Engines
+{
+    /// <summary>
+    /// Per-HARM result for one phrase, delivered via
+    /// <see cref="PartyVocalsCoordinatorEngine.OnPartyVocalsPhrase"/>. Only parts that actually have
+    /// notes in the phrase ("available parts") are included, in ascending <see cref="PartIndex"/>
+    /// order (lowest HARM number first). A part is "Awesome" when <see cref="Meter"/> &gt;= the
+    /// engine's PhraseHitPercent threshold. Top-level (not nested) so Unity-side callers can reach
+    /// it via `using YARG.Core.Engine.Vocals.Engines;`.
+    /// </summary>
+    public readonly struct PartyPartResult
+    {
+        // 0 = HARM1, 1 = HARM2, 2 = HARM3 (ordinal position in the song's part list).
+        public int PartIndex { get; }
+        public double Meter { get; } // raw canonical meter; >= PhraseHitPercent = Awesome
+
+        public PartyPartResult(int partIndex, double meter)
+        {
+            PartIndex = partIndex;
+            Meter = meter;
+        }
+    }
+
+    public sealed class PartyVocalsCoordinatorEngine : VocalsEngine
+    {
+        // Multi-mic state owned directly by the coordinator (was hoisted into
+        // YargFreeVocalsEngine in Phase 3 so the subclass could see them).
+        private readonly int _micCount;
+        private readonly VocalsPart[] _allParts;
+        private readonly bool[] _partHasContent;
+        private readonly double[] _canonicalMeters;
+        private readonly uint[] _phraseTicksTotalPerPart;
+        private readonly double[,] _micPartHits;
+        private readonly double[,] _lastWindowSnapshot;
+        private readonly double[] _cumulativeAssignedTicks;
+        private readonly double[] _lastTickMicDeltas;
+
+        // Per-mic bitmask of which parts each mic is currently hitting THIS TICK.
+        // Populated by reading each sub-engine's GetMicHittingParts after driving its tick,
+        // and read per-tick by the ambiguity classifier for scoring. This is a single-tick
+        // transient (the sub-engine resets it every AccumulateMicPartHits call), so it is
+        // NOT suitable for the visual layer, which reads one frame later — see below.
+        private readonly uint[] _micCurrentlyHittingParts;
+
+        // Per-mic bitmask of parts each mic hit at ANY point during the current visual frame.
+        // OR-accumulated across ticks and reset per frame (ResetMicSangFlags), mirroring
+        // _micSangThisTick. The visual-facing GetMicHittingParts returns this so the per-mic
+        // trail's on-note gate sees a stable per-frame signal instead of the single-tick
+        // transient above (which is 0 on most ticks and killed the trail).
+        private readonly uint[] _micHittingPartsThisFrame;
+
+        // Unified per-mic "sang this tick" flag - source of truth for needle visibility
+        private readonly bool[] _micSangThisTick;
+
+        // Coordinator-specific ambiguity scoring state
+        private readonly double[] _harmDirectTicks;
+        private readonly double[] _ambiguityBuckets;
+        private readonly double[,] _bucketPerMic;
+        private readonly uint[] _micHitMaskScratch;
+        private readonly int[] _bucketOrder;
+        private double _lastMeterRefreshTime;
+        private const double METER_UPDATE_INTERVAL_SECONDS = 0.1;
+
+        // Sub-engines (one per mic, composition)
+        private readonly YargFreeVocalsEngine[] _subEngines;
+
+        // Per-phrase tracking for the coordinator's own phrase-end logic
+        private uint? _coordinatorPhraseTicksTotal;
+
+        // Percussion notes this coordinator has already scored or missed. Tracked locally
+        // instead of via VocalNote.WasHit/WasMissed: the note objects are shared with the
+        // sub-engines and other players' engines, so setting hit/miss state on them leaks
+        // across engines (the same hazard the SP-earning bug documents). This set is the
+        // coordinator's private "consumed" ledger, fed to GetNextPercussionNote so a note
+        // isn't re-offered after it's resolved. Cleared on Reset (rewind/practice).
+        private readonly HashSet<VocalNote> _resolvedPercussion = new();
+
+        public PartyVocalsCoordinatorEngine(
+            InstrumentDifficulty<VocalNote> noteTrack,
+            IReadOnlyList<VocalsPart> allParts,
+            SyncTrack syncTrack,
+            VocalsEngineParameters engineParameters,
+            bool isBot,
+            int micCount,
+            int botPartIndex = 0)
+            : base(noteTrack, syncTrack, engineParameters, isBot)
+        {
+            int partCount = allParts.Count;
+
+            _micCount = micCount;
+            _allParts = allParts.ToArray();
+            _partHasContent = new bool[partCount];
+            _canonicalMeters = new double[partCount];
+            _phraseTicksTotalPerPart = new uint[partCount];
+            _micPartHits = new double[micCount, partCount];
+            _lastWindowSnapshot = new double[micCount, partCount];
+            _cumulativeAssignedTicks = new double[partCount];
+            _lastTickMicDeltas = new double[micCount];
+            _micCurrentlyHittingParts = new uint[micCount];
+            _micHittingPartsThisFrame = new uint[micCount];
+            _micSangThisTick = new bool[micCount];
+
+            _harmDirectTicks = new double[partCount];
+            _ambiguityBuckets = new double[1 << partCount];
+            _bucketPerMic = new double[micCount, 1 << partCount];
+            _micHitMaskScratch = new uint[micCount];
+            _bucketOrder = ComputeBucketOrder(partCount);
+
+            // Build one sub-engine per mic (composition).
+            //
+            // NOTE (shared mutable note state): every sub-engine is constructed with the
+            // SAME `noteTrack` the coordinator scores on, so coordinator.Notes and each
+            // subEngine.Notes are the *same* VocalNote objects. CloneAsInstrumentDifficulty
+            // also reuses note references across players, so a bot and a live player share
+            // these objects too. Engine operations that mutate note flags (StripStarPower
+            // on miss, SetHitState) therefore leak between engines.
+            //
+            // `isSubEngine: true` is a targeted fix for the worst symptom: it stops a
+            // sub-engine's miss from stripping the StarPower flag off a phrase the
+            // coordinator hit (which made real singers earn no SP while bots did). It does
+            // NOT fix the residual cross-player leak (one player's coordinator missing an
+            // SP phrase can still strip it for another player sharing the same notes).
+            //
+            // The more correct fix is to give each engine its own copy of the notes (or
+            // make notes immutable), eliminating the whole class of cross-engine leakage.
+            // That touches shared, hot data across all instruments, so it's a broader change
+            // worth discussing with the wider project rather than doing here.
+            _subEngines = new YargFreeVocalsEngine[micCount];
+            for (int i = 0; i < micCount; i++)
+            {
+                _subEngines[i] = new YargFreeVocalsEngine(
+                    noteTrack,
+                    allParts,
+                    syncTrack,
+                    engineParameters,
+                    isBot,
+                    botPartIndex: i,
+                    isSubEngine: true);
+            }
+
+            for (int j = 0; j < partCount; j++)
+            {
+                _partHasContent[j] = allParts[j].NotePhrases.Count > 0;
+            }
+
+            // Forward visual events from the primary sub-engine (mic 0) to the
+            // coordinator so the existing VocalsPlayer — which subscribes to the
+            // coordinator's events — receives needle/sing/hit feedback. The
+            // sub-engines do the actual pitch matching and fire these events on
+            // their own delegates; without forwarding, the coordinator never fires
+            // them and the HUD shows no feedback.
+            _subEngines[0].OnTargetNoteChanged += note => OnTargetNoteChanged?.Invoke(note);
+            _subEngines[0].OnSing += singing => OnSing?.Invoke(singing);
+            _subEngines[0].OnHit += hit => OnHit?.Invoke(hit);
+
+            GetWaitCountdowns(PartyVocalsCountdownNotes.ExcludingPercussion(allParts.ToList()));
+        }
+
+        public override void Reset(bool keepCurrentButtons = false)
+        {
+            // Drop the local percussion ledger so notes are hittable again after a
+            // rewind/practice seek (mirrors how WasHit/WasMissed clear on note reset).
+            _resolvedPercussion.Clear();
+
+            // Reset every sub-engine so practice/rewind starts fresh — without this,
+            // sub-engines retain advanced NoteIndex, CurrentTime, LastSingTick, and
+            // per-part accumulators from before the seek.
+            // (Null check: BaseEngine's constructor calls Reset() before our fields are set.)
+            if (_subEngines != null)
+            {
+                foreach (var sub in _subEngines)
+                {
+                    sub.Reset(keepCurrentButtons);
+                }
+
+                // Clear all coordinator-owned phrase/visual state.
+                ResetPhraseState();
+            }
+
+            base.Reset(keepCurrentButtons);
+        }
+
+        public IReadOnlyList<YargFreeVocalsEngine> SubEngines => _subEngines;
+
+        /// <summary>
+        /// The harmony part index the primary mic is currently matching (0=HARM1, 1=HARM2,
+        /// 2=HARM3). Drives particle/trail color in the HUD. For ambiguous matches (multiple
+        /// parts satisfied by the same pitch), the lowest index wins — the sub-engine iterates
+        /// parts in ascending order and keeps the first best-percent match.
+        ///
+        /// When multi-mic support is added, the coordinator will disambiguate across mics:
+        /// e.g., if mic 0 and mic 1 both match HARM1+HARM2 at the same pitch, mic 0 claims
+        /// HARM1 (lower index) and mic 1 claims HARM2. This property would then return mic 0's
+        /// resolved part. The disambiguation strategy is a coordinator responsibility, not the
+        /// sub-engine's.
+        /// </summary>
+        public int DisplayedHarmonyIndex => _micCount > 0 ? _subEngines[0].CurrentTargetHarmonyIndex : 0;
+
+        public bool PartHasContent(int partIndex)
+        {
+            if (partIndex < 0 || partIndex >= _allParts.Length) return false;
+            return _partHasContent[partIndex];
+        }
+
+        public int PartCount => _allParts.Length;
+
+        public bool PartInCurrentPhrase(int partIndex) =>
+            partIndex >= 0 && partIndex < _phraseTicksTotalPerPart.Length
+            && _phraseTicksTotalPerPart[partIndex] > 0u;
+
+        // True if the part has a (non-percussion) note in the NEXT master phrase. Used by
+        // the HUD count-in drain so a meter can warn the player a phrase before their line
+        // returns. Computed on demand (the next phrase hasn't started, so the per-tick
+        // _phraseTicksTotalPerPart array doesn't cover it).
+        public bool PartInNextPhrase(int partIndex)
+        {
+            if (partIndex < 0 || partIndex >= _allParts.Length) return false;
+            int next = NoteIndex + 1;
+            if (next < 0 || next >= Notes.Count) return false;
+            return GetTicksInPhraseForPart(_allParts[partIndex], Notes[next]) > 0u;
+        }
+
+        // Progress 0..1 through the CURRENT phrase's tick span. Drives the count-in drain.
+        // Uses the phrase span (Tick..TickEnd), NOT PhraseTicksTotal — that is the sung-hit
+        // tick total and would drain far too fast on sparse phrases.
+        public double CurrentPhraseProgress
+        {
+            get
+            {
+                if (NoteIndex < 0 || NoteIndex >= Notes.Count) return 0.0;
+                var phrase = Notes[NoteIndex];
+                uint span = phrase.TickEnd - phrase.Tick;
+                if (span == 0) return 0.0;
+                double p = ((double) CurrentTick - phrase.Tick) / span;
+                return p < 0.0 ? 0.0 : (p > 1.0 ? 1.0 : p);
+            }
+        }
+
+        // Duration of the current phrase in seconds. Lets the HUD convert a real-time
+        // count-in hold (e.g. 500ms) into a fraction of CurrentPhraseProgress.
+        public double CurrentPhraseDurationSeconds
+        {
+            get
+            {
+                if (NoteIndex < 0 || NoteIndex >= Notes.Count) return 0.0;
+                var phrase = Notes[NoteIndex];
+                return phrase.TimeEnd - phrase.Time;
+            }
+        }
+
+        public IReadOnlyList<double> CanonicalMeters => _canonicalMeters;
+
+        public double AwesomeThreshold => EngineParameters.PhraseHitPercent;
+
+        public uint GetMicHittingParts(int micIndex)
+        {
+            if (micIndex < 0 || micIndex >= _micCount) return 0u;
+            // Per-frame accumulation, not the single-tick transient: the visual layer reads
+            // this a frame after the engine ticked, so it must reflect any hit during the
+            // frame, not just the last tick's (which is usually 0).
+            return _micHittingPartsThisFrame[micIndex];
+        }
+
+        public float GetMicPitch(int micIndex)
+        {
+            if (micIndex < 0 || micIndex >= _micCount) return 0f;
+            return _subEngines[micIndex].GetCurrentPitch();
+        }
+
+        public void ResetMicSangFlags()
+        {
+            // Reset per-frame needle/trail signals together: both are accumulated across the
+            // frame's ticks and consumed by the visual layer after Update.
+            Array.Clear(_micSangThisTick, 0, _micSangThisTick.Length);
+            Array.Clear(_micHittingPartsThisFrame, 0, _micHittingPartsThisFrame.Length);
+        }
+        public bool DidMicSingThisTick(int mic) =>
+            mic >= 0 && mic < _micCount && _micSangThisTick[mic];
+
+        #region VocalsEngine Abstract Implementations
+
+        protected override void MutateStateWithInput(GameInput gameInput)
+        {
+            int mic = PartyVocalsInput.UnpackMic(gameInput.Action);
+            var action = PartyVocalsInput.UnpackAction(gameInput.Action);
+
+            switch (action)
+            {
+                case VocalsAction.Pitch:
+                    // Guarded sub-engine call — mirrors the silent-default pattern of
+                    // GetMicPitch/GetMicHittingParts (a malformed/replayed mic index is
+                    // dropped, not thrown). Do NOT call the coordinator's own
+                    // SetMicPitch(int,float) here: it throws on out-of-range.
+                    if (mic >= 0 && mic < _micCount)
+                    {
+                        _subEngines[mic].SetMicPitch(gameInput.Axis);
+                        _micSangThisTick[mic] = true; // unified needle sang-state (see below)
+                    }
+                    break;
+                case VocalsAction.Hit when gameInput.Button:
+                    HasHit = true; // coordinator-level; percussion scored here (standalone fix)
+                    break;
+                case VocalsAction.StarPower:
+                    IsStarPowerInputActive = gameInput.Button;
+                    break;
+            }
+        }
+
+        protected override void UpdateHitLogic(double time)
+        {
+            if (NoteIndex >= Notes.Count)
+            {
+                HasSang = false;
+                return;
+            }
+
+            // Bot self-activation. Mirrors YargVocalsEngine.UpdateBot: a bot toggles its
+            // own StarPower input so UpdateStarPower deploys once it has half a bar. The
+            // coordinator's UpdateBot is a no-op (sub-engines run their own), and the
+            // sub-engines only toggle their own dead-data IsStarPowerInputActive — so
+            // without this the authoritative coordinator never deployed SP for a bot.
+            if (IsBot)
+            {
+                IsStarPowerInputActive = CanStarPowerActivate && !IsStarPowerInputActive;
+            }
+
+            // Drive each sub-engine forward for this tick. Each sub-engine runs its
+            // full single-mic lifecycle (MutateStateWithInput → UpdateHitLogic →
+            // phrase-end). Sub-engine outputs nobody reads are dead data.
+            for (int i = 0; i < _micCount; i++)
+            {
+                _subEngines[i].Update(time);
+            }
+
+            // Mirror time variables from sub-engines (they all share the same SyncTrack,
+            // so any one would do — use the first).
+            CurrentTime = _subEngines[0].CurrentTime;
+            CurrentTick = _subEngines[0].CurrentTick;
+            // Mirror mic 0's pitch so VocalsPlayer can read it for the needle position.
+            // SetMicPitch sets the sub-engine's PitchSang, but the player reads the
+            // coordinator's PitchSang for the needle — without this it stays at 0.
+            PitchSang = _subEngines[0].PitchSang;
+
+            // Bots queue no Hit inputs and the coordinator's UpdateBot is a no-op, so a bot
+            // would never set HasHit and never score percussion (real mics do, via
+            // MutateStateWithInput). Arm HasHit here when a percussion note is due, mirroring
+            // the solo bot path (YargVocalsEngine.UpdateBot's percussion branch).
+            if (IsBot)
+            {
+                var botPercussion = GetNextPercussionNote(Notes[NoteIndex], CurrentTick, _resolvedPercussion.Contains);
+                if (botPercussion is not null && CurrentTime >= botPercussion.Time)
+                {
+                    HasHit = true;
+                }
+            }
+
+            // Score percussion taps at the band level. The coordinator aggregates
+            // any mic's Hit into a single HasHit (MutateStateWithInput), so this
+            // scores one band hit per tap with no double-count.
+            // Also handles sing-to-activate (mirrors YargVocalsEngine.cs:188-218).
+            CheckPercussionHit();
+
+            // Read per-tick credit from each sub-engine's LastTickPartDeltas and
+            // per-mic hitting-parts bitmask.
+            Array.Clear(_lastTickMicDeltas, 0, _lastTickMicDeltas.Length);
+            for (int i = 0; i < _micCount; i++)
+            {
+                var deltas = _subEngines[i].LastTickPartDeltas;
+                double totalDelta = 0;
+                for (int j = 0; j < deltas.Count && j < _allParts.Length; j++)
+                {
+                    totalDelta += deltas[j];
+                }
+                _lastTickMicDeltas[i] = totalDelta;
+
+                // Read the sub-engine's per-mic hitting-parts bitmask (single-tick).
+                _micCurrentlyHittingParts[i] = _subEngines[i].GetMicHittingParts();
+
+                // OR-accumulate into the per-frame signal the visual layer reads, so a hit
+                // on any tick this frame keeps the trail's on-note gate satisfied.
+                _micHittingPartsThisFrame[i] |= _micCurrentlyHittingParts[i];
+            }
+
+            var phrase = Notes[NoteIndex];
+
+            // Populate per-part tick totals for the current phrase. The coordinator's
+            // phrase total sums across ALL harmony parts — not just Parts[0]/HARM1 — so
+            // phrases that only have HARM2/HARM3 notes are not treated as empty.
+            uint allPartsTotal = 0;
+            for (int j = 0; j < _allParts.Length; j++)
+            {
+                _phraseTicksTotalPerPart[j] = GetTicksInPhraseForPart(_allParts[j]);
+                allPartsTotal += _phraseTicksTotalPerPart[j];
+            }
+
+            _coordinatorPhraseTicksTotal ??= allPartsTotal;
+            PhraseTicksTotal ??= _coordinatorPhraseTicksTotal;
+
+            // Run the coordinator's per-tick ambiguity classifier
+            AccumulateAmbiguityScoring();
+
+            // Speculative refresh on the 100ms throttle for live HUD
+            if (CurrentTime - _lastMeterRefreshTime >= METER_UPDATE_INTERVAL_SECONDS)
+            {
+                _lastMeterRefreshTime = CurrentTime;
+                RunAllocatorIntoCanonicalMeters(commit: false);
+            }
+
+            // Check for end of phrase
+            if (CurrentTick > phrase.TickEnd)
+            {
+                bool hasNotes = _coordinatorPhraseTicksTotal.Value != 0;
+                bool isLastPhrase = NoteIndex == Notes.Count - 1;
+                uint phraseTicksTotal = _coordinatorPhraseTicksTotal.Value;
+
+                if (phraseTicksTotal == 0)
+                {
+                    HitNote(phrase);
+                    // Fire OnPhraseHit so _phrasePercents stays aligned with
+                    // _phraseGrades/_phrasePartResults (populated by the
+                    // OnPartyVocalsPhrase handler below).
+                    OnPhraseHit?.Invoke(1.0, true, isLastPhrase);
+                    OnPartyVocalsPhrase?.Invoke(
+                        PhraseGrade.Awesome, Array.Empty<PartyPartResult>(), isLastPhrase);
+                }
+                else
+                {
+                    ProcessPhraseEnd(phrase, phraseTicksTotal, isLastPhrase);
+                }
+
+                // Reset per-phrase state
+                ResetPhraseState();
+
+                UpdateCarriedNote(phrase);
+            }
+        }
+
+        protected override void CheckForNoteHit()
+        {
+            // No-op: sub-engines handle their own hit detection.
+        }
+
+        protected override void UpdateBot(double songTime)
+        {
+            // No-op: each sub-engine runs its own UpdateBot via its own Update cycle.
+        }
+
+        protected override bool CanVocalNoteBeHit(VocalNote note, out float hitPercent)
+        {
+            hitPercent = 0f;
+            throw new NotImplementedException(
+                "CanVocalNoteBeHit is not called on the coordinator; sub-engines handle pitch matching.");
+        }
+
+        protected override bool CanNoteBeHit(VocalNote note) =>
+            throw new NotImplementedException();
+
+        // Vocals have no lanes (matches YargVocalsEngine).
+        protected override bool ProximalLaneForgivesInput(int inputNote, VocalNote laneNote) =>
+            throw new NotImplementedException();
+
+        #endregion
+
+        public delegate void PartyVocalsPhraseEvent(
+            PhraseGrade grade,
+            IReadOnlyList<PartyPartResult> parts,
+            bool isLastPhrase);
+
+        /// <summary>
+        /// Fires at the end of each phrase alongside OnPhraseHit. Provides the
+        /// final N-awesome grade and per-HARM canonical meter values. The coordinator
+        /// always emits both OnPhraseHit (standard vocals event) and OnPartyVocalsPhrase
+        /// (party-specific grade/parts) at phrase end. Declared here rather than on
+        /// VocalsEngine so the prototype's phrase-end event stays off the upstream base engine.
+        /// </summary>
+        public PartyVocalsPhraseEvent? OnPartyVocalsPhrase;
+
+        #region Phrase-End Logic
+
+        private void ProcessPhraseEnd(VocalNote phrase, uint phraseTicksTotal, bool isLastPhrase)
+        {
+            // Final allocation using all accumulated credit
+            RunAllocatorIntoCanonicalMeters(commit: true);
+
+            int partCount = _allParts.Length;
+            int awesomeCount = 0;
+            double bestMeter = 0;
+            for (int j = 0; j < partCount; j++)
+            {
+                if (_canonicalMeters[j] >= EngineParameters.PhraseHitPercent) awesomeCount++;
+                if (_canonicalMeters[j] > bestMeter) bestMeter = _canonicalMeters[j];
+            }
+
+            var grade = awesomeCount switch
+            {
+                0 => PhraseGrade.Miss,
+                1 => PhraseGrade.Awesome,
+                2 => PhraseGrade.DoubleAwesome,
+                _ => PhraseGrade.TripleAwesome,
+            };
+            bool hit = grade != PhraseGrade.Miss;
+
+            // Per-part results for parts that actually have notes in this phrase (available parts),
+            // ascending part order (lowest HARM number first = bottom of the summary bar).
+            var parts = new List<PartyPartResult>(partCount);
+            for (int j = 0; j < partCount; j++)
+            {
+                if (_phraseTicksTotalPerPart[j] > 0)
+                {
+                    parts.Add(new PartyPartResult(j, _canonicalMeters[j]));
+                }
+            }
+
+            if (hit)
+            {
+                EngineStats.TicksHit += phraseTicksTotal;
+                HitNote(phrase);
+            }
+            else
+            {
+                var ticksHit = (uint)Math.Round(PhraseTicksHit);
+                EngineStats.TicksHit += ticksHit;
+                EngineStats.TicksMissed += phraseTicksTotal - ticksHit;
+                MissNote(phrase, bestMeter);
+            }
+
+            OnPhraseHit?.Invoke(bestMeter / EngineParameters.PhraseHitPercent, hit, isLastPhrase);
+            OnPartyVocalsPhrase?.Invoke(grade, parts, isLastPhrase);
+        }
+
+        private void ResetPhraseState()
+        {
+            PhraseTicksHit = 0;
+            PhraseTicksTotal = null;
+            _coordinatorPhraseTicksTotal = null;
+
+            Array.Clear(_micPartHits, 0, _micPartHits.Length);
+            Array.Clear(_lastWindowSnapshot, 0, _lastWindowSnapshot.Length);
+            Array.Clear(_cumulativeAssignedTicks, 0, _cumulativeAssignedTicks.Length);
+            Array.Clear(_canonicalMeters, 0, _canonicalMeters.Length);
+            Array.Clear(_phraseTicksTotalPerPart, 0, _phraseTicksTotalPerPart.Length);
+            Array.Clear(_harmDirectTicks, 0, _harmDirectTicks.Length);
+            Array.Clear(_ambiguityBuckets, 0, _ambiguityBuckets.Length);
+            Array.Clear(_bucketPerMic, 0, _bucketPerMic.Length);
+            Array.Clear(_micCurrentlyHittingParts, 0, _micCurrentlyHittingParts.Length);
+            Array.Clear(_micHittingPartsThisFrame, 0, _micHittingPartsThisFrame.Length);
+            Array.Clear(_micSangThisTick, 0, _micSangThisTick.Length);
+
+            _lastMeterRefreshTime = CurrentTime;
+        }
+
+        #endregion
+
+        #region Ambiguity Scoring
+
+        private void AccumulateAmbiguityScoring()
+        {
+            int partCount = _phraseTicksTotalPerPart.Length;
+
+            // Classify: for each mic, build the mask of HARMs it could be hitting
+            for (int i = 0; i < _micCount; i++)
+            {
+                uint rawMask = _micCurrentlyHittingParts[i];
+                uint mask = 0u;
+                for (int j = 0; j < partCount; j++)
+                {
+                    if ((rawMask & (1u << j)) != 0u && _phraseTicksTotalPerPart[j] > 0u)
+                        mask |= 1u << j;
+                }
+                _micHitMaskScratch[i] = mask;
+            }
+
+            // Direct credit: binary across mics
+            for (int j = 0; j < partCount; j++)
+            {
+                double maxDelta = 0;
+                for (int i = 0; i < _micCount; i++)
+                {
+                    uint m = _micHitMaskScratch[i];
+                    if (PopCount(m) == 1 && (m & (1u << j)) != 0u)
+                    {
+                        double d = _lastTickMicDeltas[i];
+                        if (d > maxDelta) maxDelta = d;
+                    }
+                }
+                _harmDirectTicks[j] += maxDelta;
+            }
+
+            // Ambiguity bucket credit: additive across mics with per-mic-span cap.
+            // Use per-part delta (not summed) so the per-mic-span cap correctly
+            // limits each HARM to what one mic actually contributed per HARM.
+            for (int i = 0; i < _micCount; i++)
+            {
+                uint m = _micHitMaskScratch[i];
+                if (PopCount(m) >= 2)
+                {
+                    var deltas = _subEngines[i].LastTickPartDeltas;
+                    double partDelta = 0;
+                    int hitCount = 0;
+                    for (int j = 0; j < partCount && j < deltas.Count; j++)
+                    {
+                        if ((m & (1u << j)) != 0u)
+                        {
+                            partDelta += deltas[j];
+                            hitCount++;
+                        }
+                    }
+                    if (hitCount > 0) partDelta /= hitCount;
+
+                    _ambiguityBuckets[(int)m] += partDelta;
+                    _bucketPerMic[i, (int)m] += partDelta;
+                }
+            }
+        }
+
+        #endregion
+
+        #region Allocator
+
+        private void RunAllocatorIntoCanonicalMeters(bool commit)
+        {
+            int partCount = _phraseTicksTotalPerPart.Length;
+
+            Span<double> credited = stackalloc double[partCount];
+            for (int j = 0; j < partCount; j++)
+            {
+                uint cap = _phraseTicksTotalPerPart[j];
+                credited[j] = cap == 0 ? 0 : Math.Min(_harmDirectTicks[j], cap);
+            }
+
+            Span<double> bucketsCopy = stackalloc double[_ambiguityBuckets.Length];
+            for (int i = 0; i < _ambiguityBuckets.Length; i++) bucketsCopy[i] = _ambiguityBuckets[i];
+
+            Span<double> receivedFromBucket = stackalloc double[partCount];
+
+            foreach (int S in _bucketOrder)
+            {
+                if (bucketsCopy[S] <= 0) continue;
+
+                double perMicCap = 0;
+                for (int i = 0; i < _micCount; i++)
+                {
+                    double v = _bucketPerMic[i, S];
+                    if (v > perMicCap) perMicCap = v;
+                }
+
+                receivedFromBucket.Clear();
+
+                while (bucketsCopy[S] > 0)
+                {
+                    int chosen = -1;
+                    double chosenCredited = -1;
+                    for (int j = 0; j < partCount; j++)
+                    {
+                        if ((S & (1 << j)) == 0) continue;
+                        uint cap = _phraseTicksTotalPerPart[j];
+                        if (cap == 0 || credited[j] >= cap) continue;
+                        if (receivedFromBucket[j] >= perMicCap) continue;
+                        if (credited[j] > chosenCredited)
+                        {
+                            chosenCredited = credited[j];
+                            chosen = j;
+                        }
+                    }
+
+                    if (chosen < 0) break;
+
+                    double remainingCapacity = _phraseTicksTotalPerPart[chosen] - credited[chosen];
+                    double remainingPerMicCap = perMicCap - receivedFromBucket[chosen];
+                    double transfer = Math.Min(
+                        Math.Min(bucketsCopy[S], remainingCapacity),
+                        remainingPerMicCap);
+                    if (transfer <= 0) break;
+                    credited[chosen] += transfer;
+                    bucketsCopy[S] -= transfer;
+                    receivedFromBucket[chosen] += transfer;
+                }
+            }
+
+            for (int j = 0; j < partCount; j++)
+            {
+                uint cap = _phraseTicksTotalPerPart[j];
+                _canonicalMeters[j] = cap == 0 ? 0 : credited[j] / cap;
+            }
+
+            // Mirror best meter into PhraseTicksHit for HUD combo fill bar.
+            // The fill bar represents accumulated progress within a phrase and must be
+            // monotonically non-decreasing — the allocator's speculative refresh can
+            // momentarily compute a lower "best" if timing causes a part's direct
+            // ticks to be reclassified, so we clamp to the previous value.
+            if (PhraseTicksTotal is { } total && total > 0)
+            {
+                double best = 0;
+                for (int j = 0; j < partCount; j++)
+                    if (_canonicalMeters[j] > best) best = _canonicalMeters[j];
+                double newHit = best * total;
+                if (newHit > PhraseTicksHit)
+                {
+                    PhraseTicksHit = newHit;
+                }
+            }
+        }
+
+        private static int[] ComputeBucketOrder(int partCount)
+        {
+            var masks = new List<int>();
+            for (int m = 0; m < (1 << partCount); m++)
+            {
+                if (PopCount((uint)m) >= 2) masks.Add(m);
+            }
+            masks.Sort((a, b) =>
+            {
+                int pa = PopCount((uint)a);
+                int pb = PopCount((uint)b);
+                if (pa != pb) return pa - pb;
+                return a - b;
+            });
+            return masks.ToArray();
+        }
+
+        private static int PopCount(uint m)
+        {
+            return (int)(((m >> 0) & 1u) + ((m >> 1) & 1u) + ((m >> 2) & 1u));
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private uint GetTicksInPhraseForPart(VocalsPart part) =>
+            GetTicksInPhraseForPart(part, Notes[NoteIndex]);
+
+        private uint GetTicksInPhraseForPart(VocalsPart part, VocalNote masterPhrase)
+        {
+            uint masterStart = masterPhrase.Tick;
+            uint masterEnd = masterPhrase.TickEnd;
+
+            uint totalTime = 0;
+            foreach (var partPhrase in part.NotePhrases)
+            {
+                var phraseNote = partPhrase.PhraseParentNote;
+                if (phraseNote.Tick >= masterEnd || phraseNote.TickEnd <= masterStart) continue;
+
+                foreach (var noteInPhrase in phraseNote.ChildNotes)
+                {
+                    if (noteInPhrase.IsPercussion) continue;
+                    totalTime += phraseNote.GetTicksForNote(noteInPhrase);
+                }
+                break;
+            }
+            return totalTime;
+        }
+
+        #endregion
+
+        #region Percussion Scoring
+
+        private void CheckPercussionHit()
+        {
+            if (NoteIndex >= Notes.Count)
+            {
+                HasHit = false;
+                return;
+            }
+
+            var phrase = Notes[NoteIndex];
+            var percussion = GetNextPercussionNote(phrase, CurrentTick, _resolvedPercussion.Contains);
+            if (percussion is not null)
+            {
+                // Gate on the full hit window (front/back tolerance), mirroring solo
+                // YargVocalsEngine.CheckPercussionHit. The previous raw [Time, TimeEnd]
+                // span gave ZERO early tolerance (CurrentTime >= Time) and, for a short
+                // percussion note, almost no late tolerance — so real taps were dropped
+                // even though they reached the engine.
+                if (IsNoteInWindow(percussion, out var missed))
+                {
+                    if (HasHit)
+                    {
+                        // Consume locally (no note.SetHitState) so the shared note isn't
+                        // mutated, then score exactly as before.
+                        _resolvedPercussion.Add(percussion);
+                        AddScore(percussion);
+                        OnNoteHit?.Invoke(NoteIndex, percussion);
+                    }
+                }
+                else if (missed)
+                {
+                    // Back-end miss: the window has passed without a tap. Resolve the note
+                    // locally so it stops being "next due" (instead of lingering) and fire
+                    // the miss event, mirroring solo's MissNote(percussion) minus the
+                    // shared-note SetMissState.
+                    _resolvedPercussion.Add(percussion);
+                    OnNoteMissed?.Invoke(NoteIndex, percussion);
+                }
+            }
+            else
+            {
+                // Mirror YargVocalsEngine.cs:210-214: singing (or any noise) can
+                // result in a percussion hit call, so check sing-to-activate here.
+                if (HasHit && CanStarPowerActivate && EngineParameters.SingToActivateStarPower)
+                {
+                    ActivateStarPower();
+                }
+            }
+
+            HasHit = false;
+        }
+
+        #endregion
+    }
+}

--- a/YARG.Core/Engine/Vocals/Engines/YargFreeVocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/Engines/YargFreeVocalsEngine.cs
@@ -1,0 +1,502 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YARG.Core.Chart;
+using YARG.Core.Input;
+
+namespace YARG.Core.Engine.Vocals.Engines
+{
+    /// <summary>
+    /// Free-match vocals engine that allows a single mic to match notes across ALL HARM
+    /// parts simultaneously, not just one. Subclasses <see cref="YargVocalsEngine"/> to
+    /// inherit the concrete pitch-matching formula (<see cref="YargVocalsEngine.CanVocalNoteBeHit"/>)
+    /// and the solo bot, then overrides the hit-detection orchestration to traverse every
+    /// part at the current tick and accumulate per-part fractional hits + a per-tick bitmask.
+    ///
+    /// Designed as a sub-engine for <see cref="PartyVocalsCoordinatorEngine"/> (one per mic),
+    /// but also usable standalone for single-mic free vocals.
+    /// </summary>
+    public class YargFreeVocalsEngine : YargVocalsEngine
+    {
+        public int CurrentTargetHarmonyIndex { get; private set; }
+
+        /// <summary>
+        /// Whether each HARM part has any phrase content in this chart. The Harmony
+        /// track always exposes 3 placeholder parts even if the song only charts
+        /// HARM1+HARM2, so the HUD uses this to hide empty-lane meters.
+        /// </summary>
+        public bool PartHasContent(int partIndex)
+        {
+            if (partIndex < 0 || partIndex >= _allParts.Count) return false;
+            return _allParts[partIndex].NotePhrases.Count > 0;
+        }
+
+        public int PartCount => _allParts.Count;
+
+        /// <summary>
+        /// Per-tick deltas credited to each part for the current tick. This property
+        /// is updated in UpdateHitLogic after per-part credit is committed, allowing
+        /// external systems to read the exact credit assigned for this tick.
+        /// </summary>
+        public IReadOnlyList<double> LastTickPartDeltas => _lastTickPartDeltas;
+
+        // Store reference to all parts for hit testing
+        protected readonly IReadOnlyList<VocalsPart> _allParts;
+        private readonly int _botPartIndex;
+
+        // Resolved bot part for the current tick after applying the per-phrase fallback:
+        // if the assigned _botPartIndex has no active phrase, fall back to the lowest-numbered
+        // part that does. Updated in UpdateBot, consumed by CheckSingingHit so the bot scores
+        // against whatever line it's actually singing.
+        private int _currentBotEffectivePartIndex;
+
+        // Per-part delta for the current tick. Updated in UpdateHitLogic after
+        // per-part credit is committed, for external consumption (e.g., coordinator).
+        private readonly double[] _lastTickPartDeltas;
+
+        // Per-part hit accumulator for single-mic free vocals
+        private readonly double[] _singleMicPartHits;
+        // Bitmask of parts that the single mic is hitting this tick
+        private uint _singleMicHittingParts;
+
+        public YargFreeVocalsEngine(
+            InstrumentDifficulty<VocalNote> primaryChart,
+            IReadOnlyList<VocalsPart> allParts,
+            SyncTrack syncTrack,
+            VocalsEngineParameters engineParameters,
+            bool isBot,
+            int botPartIndex = 0,
+            bool isSubEngine = false)
+            : base(primaryChart, syncTrack, engineParameters, isBot)
+        {
+            // As a PartyVocalsCoordinatorEngine sub-engine, this instance shares its
+            // note objects with the coordinator (and the other mics). It is not
+            // authoritative for star power, so it must not strip SP flags on a miss —
+            // otherwise one mic's miss clears SP from a phrase the coordinator hit.
+            StripStarPowerOnMiss = !isSubEngine;
+
+            _allParts = allParts;
+            _botPartIndex = Math.Max(0, Math.Min(botPartIndex, allParts.Count - 1));
+            _currentBotEffectivePartIndex = _botPartIndex;
+
+            // Initialize fields for single-mic per-part accumulation
+            _lastTickPartDeltas = new double[allParts.Count];
+            _singleMicPartHits = new double[allParts.Count];
+            _singleMicHittingParts = 0u;
+
+            // Build countdowns from all parts for free vocals; exclude percussion so
+            // percussion-only stretches show the countdown wheel instead of being
+            // hidden as a continuous note stream.
+            GetWaitCountdowns(PartyVocalsCountdownNotes.ExcludingPercussion(allParts.ToList()));
+        }
+
+        private VocalNote? FindActivePhraseInPart(int partIndex)
+        {
+            foreach (var partPhrase in _allParts[partIndex].NotePhrases)
+            {
+                var pn = partPhrase.PhraseParentNote;
+                if (CurrentTick >= pn.Tick && CurrentTick <= pn.TotalTickEnd)
+                {
+                    return pn;
+                }
+            }
+            return null;
+        }
+
+        protected override void UpdateBot(double songTime)
+        {
+            if (!IsBot)
+            {
+                return;
+            }
+
+            IsStarPowerInputActive = CanStarPowerActivate && !IsStarPowerInputActive;
+
+            var phrase = Notes[NoteIndex];
+
+            // Find the active phrase for the bot. Prefer the assigned _botPartIndex; if no
+            // phrase covers the current tick there, fall back to the lowest-numbered part
+            // that does have an active phrase. This keeps a bot audible on sections where
+            // its assigned HARM line isn't charted (common when a song collapses dual leads
+            // into HARM1/2/3 but leaves gaps on individual parts).
+            VocalNote? botPhrase = FindActivePhraseInPart(_botPartIndex);
+            int effectiveIndex = _botPartIndex;
+            if (botPhrase is null)
+            {
+                for (int i = 0; i < _allParts.Count; i++)
+                {
+                    if (i == _botPartIndex) continue;
+                    var fallback = FindActivePhraseInPart(i);
+                    if (fallback is not null)
+                    {
+                        botPhrase = fallback;
+                        effectiveIndex = i;
+                        break;
+                    }
+                }
+            }
+            _currentBotEffectivePartIndex = effectiveIndex;
+
+            // Search botPhrase directly instead of using GetNoteInPhraseAtSongTick, which
+            // short-circuits to the base engine's CarriedVocalNote — that's populated from
+            // the primary chart (HARM1 for all Free bots), so it would return a HARM1 note
+            // even when botPhrase is HARM2/HARM3. Result: the needle would always sit on
+            // HARM1 regardless of the bot's assigned harmony index.
+            VocalNote? singNote = null;
+            if (botPhrase is not null)
+            {
+                foreach (var childNote in botPhrase.ChildNotes)
+                {
+                    if (!childNote.IsPercussion
+                        && CurrentTick >= childNote.Tick
+                        && CurrentTick <= childNote.TotalTickEnd)
+                    {
+                        singNote = childNote;
+                        break;
+                    }
+                }
+            }
+            if (singNote is not null)
+            {
+                // Bots are queued extra updates to account for in-between "inputs"
+                PitchSang = singNote.PitchAtSongTime(songTime);
+                HasSang = true;
+
+                OnSing?.Invoke(true);
+
+                // Drive the visual "on notes" state for bots: VocalsPlayer's needle path
+                // anchors to _lastTargetNote when _lastHitTime is recent, otherwise it
+                // applies AnchorPitchToOctave which adds a 12-semitone offset when
+                // _lastTargetNote is null. This is the *sole* OnTargetNoteChanged source
+                // for bots — CheckSingingHit deliberately skips its emit when IsBot (see
+                // there) so it can't fight this one and make the needle jump to harm1.
+                OnTargetNoteChanged?.Invoke(singNote);
+                OnHit?.Invoke(true);
+            }
+            else
+            {
+                // Stop hitting to prevent the hit particles from showing up too much
+                OnHit?.Invoke(false);
+            }
+
+            // Handle percussion notes
+            var percussion = GetNextPercussionNote(phrase, CurrentTick);
+            if (percussion is not null && songTime >= percussion.Time)
+            {
+                HasHit = true;
+            }
+        }
+
+        protected override void UpdateHitLogic(double time)
+        {
+            // Quit early if there are no notes left
+            if (NoteIndex >= Notes.Count)
+            {
+                HasSang = false;
+                return;
+            }
+
+            UpdateBot(time);
+
+            var phrase = Notes[NoteIndex];
+            PhraseTicksTotal ??= GetTicksInPhrase(phrase);
+
+            // Save singing state before CheckSingingHit consumes HasSang / LastSingTick
+            bool wasSinging = HasSang;
+            uint savedLastSingTick = LastSingTick;
+
+            CheckForNoteHit();
+
+            // Snapshot per-part hits before accumulation to compute per-tick delta
+            // (coordinator reads LastTickPartDeltas every tick for ambiguity scoring)
+            Span<double> prevHits = stackalloc double[_allParts.Count];
+            for (int j = 0; j < _allParts.Count; j++)
+                prevHits[j] = _singleMicPartHits[j];
+
+            // Per-part hit accumulation using pre-consumption singing state
+            AccumulateMicPartHits(wasSinging, savedLastSingTick, out _);
+
+            // Compute per-tick delta for external consumption (coordinator reads these every tick)
+            for (int j = 0; j < _allParts.Count; j++)
+                _lastTickPartDeltas[j] = _singleMicPartHits[j] - prevHits[j];
+
+            // Check for the end of a phrase
+            if (CurrentTick > phrase.TickEnd)
+            {
+                bool hasNotes = PhraseTicksTotal.Value != 0;
+                bool isLastPhrase = NoteIndex == Notes.Count - 1;
+
+                // For single-mic free vocals, reset per-phrase state and run the standard phrase-end flow
+                // Note: _singleMicPartHits is maintained for single-mic HUD display
+                var percentHit = PhraseTicksHit / PhraseTicksTotal.Value;
+                if (!hasNotes)
+                {
+                    percentHit = 1.0;
+                }
+
+                bool hit = percentHit >= EngineParameters.PhraseHitPercent;
+                if (hit)
+                {
+                    EngineStats.TicksHit += PhraseTicksTotal.Value;
+                    HitNote(phrase);
+                }
+                else
+                {
+                    var ticksHit = (uint) Math.Round(PhraseTicksHit);
+
+                    EngineStats.TicksHit += ticksHit;
+                    EngineStats.TicksMissed += PhraseTicksTotal.Value - ticksHit;
+
+                    MissNote(phrase, percentHit);
+                }
+
+                PhraseTicksHit = 0;
+                PhraseTicksTotal = null;
+
+                if (hasNotes)
+                {
+                    OnPhraseHit?.Invoke(percentHit / EngineParameters.PhraseHitPercent, hit, isLastPhrase);
+                }
+
+                UpdateCarriedNote(phrase);
+            }
+        }
+
+        protected override void CheckForNoteHit()
+        {
+            CheckSingingHit();
+            CheckPercussionHit();
+        }
+
+        private bool AccumulateMicPartHits(bool wasSinging, uint savedLastSingTick, out VocalNote? representativeHitNote)
+        {
+            var maxLeniency = 1.0 / EngineParameters.ApproximateVocalFps;
+            bool anyMicHit = false;
+            representativeHitNote = null;
+
+            // Reset the "currently hitting parts" bitmask for single-mic
+            _singleMicHittingParts = 0u;
+
+            if (!wasSinging)
+                return false;
+
+            var lastTick = Math.Max(
+                SyncTrack.TimeToTick(CurrentTime - maxLeniency),
+                savedLastSingTick);
+            var ticksSinceLast = CurrentTick - lastTick;
+
+            if (ticksSinceLast == 0)
+                return false;
+
+            // Accumulate hits for all parts to feed the HUD's HARM1/2/3 %
+            for (int partIndex = 0; partIndex < _allParts.Count; partIndex++)
+            {
+                foreach (var partPhrase in _allParts[partIndex].NotePhrases)
+                {
+                    foreach (var note in partPhrase.PhraseParentNote.ChildNotes)
+                    {
+                        if (note.IsPercussion) continue;
+                        if (CurrentTick < note.Tick || CurrentTick > note.TotalTickEnd) continue;
+
+                        if (CanVocalNoteBeHit(note, out float hitPercent))
+                        {
+                            _singleMicPartHits[partIndex] += ticksSinceLast * hitPercent;
+                            if (hitPercent > 0f)
+                            {
+                                anyMicHit = true;
+                                representativeHitNote ??= note;
+                                _singleMicHittingParts |= 1u << partIndex;
+                            }
+                        }
+                    }
+                }
+            }
+
+            return anyMicHit;
+        }
+
+        private void CheckSingingHit()
+        {
+            if (!HasSang)
+            {
+                return;
+            }
+
+            HasSang = false;
+            var lastSingTick = LastSingTick;
+            LastSingTick = CurrentTick;
+
+            // If the last sing detected was on the same tick (or less), skip it
+            // since we've already handled that tick.
+            if (lastSingTick >= CurrentTick)
+            {
+                return;
+            }
+
+            // Find the current phrase
+            if (NoteIndex >= Notes.Count)
+            {
+                return;
+            }
+
+            var phrase = Notes[NoteIndex];
+
+            // Check for singing hits against all parts
+            bool hitAnyNote = false;
+            float bestHitPercent = 0f;
+            int bestPartIndex = CurrentTargetHarmonyIndex;
+            VocalNote? bestNote = null;
+
+            // Check each part for active notes
+            for (int partIndex = 0; partIndex < _allParts.Count; partIndex++)
+            {
+                var part = _allParts[partIndex];
+
+                // Get notes from this part's phrases
+                foreach (var partPhrase in part.NotePhrases)
+                {
+                    foreach (var note in partPhrase.PhraseParentNote.ChildNotes)
+                    {
+                        if (!note.IsPercussion &&
+                            CurrentTick >= note.Tick &&
+                            CurrentTick <= note.TotalTickEnd)
+                        {
+                            if (CanVocalNoteBeHit(note, out float hitPercent))
+                            {
+                                hitAnyNote = true;
+
+                                // For free vocals, we take the best hit percent from any note
+                                if (hitPercent > bestHitPercent)
+                                {
+                                    bestHitPercent = hitPercent;
+                                    bestPartIndex = partIndex;
+                                    bestNote = note;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (hitAnyNote)
+            {
+                // Update target harmony index only if it changed (retains last value when no match)
+                if (bestPartIndex != CurrentTargetHarmonyIndex)
+                {
+                    CurrentTargetHarmonyIndex = bestPartIndex;
+                }
+
+                // Real mics: always fire target note change so visuals can snap to the
+                // current note. On solo-only charts the part index never changes (always
+                // 0), so an on-change guard would never fire — leaving slot.TargetNote
+                // null and suppressing the trail.
+                //
+                // Bots are excluded: UpdateBot already emits OnTargetNoteChanged for the
+                // bot's assigned/effective part every tick. If CheckSingingHit also fired
+                // here — with the *globally* best-matching part, which is frequently harm1
+                // on unison/octave-equivalent pitches — the two emits fight and the bot's
+                // needle jumps between its own lane and harm1. Keeping this !IsBot is the
+                // invariant UpdateBot's emit relies on.
+                if (!IsBot)
+                {
+                    OnTargetNoteChanged?.Invoke(bestNote!);
+                }
+
+                // Scale the hit by chart ticks elapsed since the last sing, matching
+                // YargVocalsEngine. PhraseTicksTotal is in chart ticks (hundreds to
+                // thousands per phrase); previously we just added bestHitPercent
+                // (a 0-1 value) once per UpdateHitLogic, so PhraseTicksHit could never
+                // approach PhraseTicksTotal and every phrase graded as "messy" no matter
+                // how perfectly the singer hit the notes.
+                var maxLeniency = 1.0 / EngineParameters.ApproximateVocalFps;
+                var lastTick = Math.Max(
+                    SyncTrack.TimeToTick(CurrentTime - maxLeniency),
+                    lastSingTick);
+                var ticksSinceLast = CurrentTick - lastTick;
+                PhraseTicksHit += ticksSinceLast * bestHitPercent;
+
+                // Drive the visual "on note" state for real-mic singers. Without this,
+                // VocalsPlayer's single-mic path never sees _lastHitTime set, so the
+                // hitting particle trail never plays. Mirrors YargVocalsEngine.
+                OnHit?.Invoke(true);
+
+                // Trigger hit event
+                if (HasHit)
+                {
+                    if (IsSoloActive)
+                    {
+                        Solos[CurrentSoloIndex].NotesHit++;
+                    }
+
+                    // Singing (or any noise) can result in a call to CheckPercussionHit() as well, so we need to check SingToActivateStarPower here.
+                    if (CanStarPowerActivate && EngineParameters.SingToActivateStarPower)
+                    {
+                        ActivateStarPower();
+                    }
+                }
+            }
+            else
+            {
+                OnHit?.Invoke(false);
+
+                // Singing (or any noise) can result in a call to CheckPercussionHit() as well, so we need to check SingToActivateStarPower here.
+                if (HasHit && CanStarPowerActivate && EngineParameters.SingToActivateStarPower)
+                {
+                    ActivateStarPower();
+                }
+            }
+
+            HasHit = false;
+        }
+
+        private void CheckPercussionHit()
+        {
+            if (!HasHit)
+            {
+                return;
+            }
+
+            HasHit = false;
+
+            // Find the current phrase
+            if (NoteIndex >= Notes.Count)
+            {
+                return;
+            }
+
+            var phrase = Notes[NoteIndex];
+
+            // Handle percussion notes
+            var percussion = GetNextPercussionNote(phrase, CurrentTick);
+            if (percussion is not null && CurrentTime >= percussion.Time)
+            {
+                AddScore(percussion);
+                OnNoteHit?.Invoke(NoteIndex, percussion);
+            }
+        }
+
+        /// <summary>
+        /// Get the current pitch for the single mic. Used by the coordinator to read
+        /// the sub-engine's current pitch state for visual feedback.
+        /// </summary>
+        public float GetCurrentPitch() => PitchSang;
+
+        /// <summary>
+        /// Get the bitmask of parts that the single mic is hitting this tick.
+        /// Used by the coordinator for visual feedback.
+        /// </summary>
+        public uint GetMicHittingParts() => _singleMicHittingParts;
+
+        /// <summary>
+        /// Submit a pitch reading for the single mic. Used by the coordinator under
+        /// composition to push per-mic pitch into each sub-engine.
+        /// </summary>
+        public void SetMicPitch(float pitch)
+        {
+            PitchSang = pitch;
+            HasSang = true;
+            OnSing?.Invoke(true);
+        }
+
+    }
+}

--- a/YARG.Core/Engine/Vocals/PartyVocalsCountdownNotes.cs
+++ b/YARG.Core/Engine/Vocals/PartyVocalsCountdownNotes.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+using System.Linq;
+using YARG.Core.Chart;
+
+namespace YARG.Core.Engine.Vocals
+{
+    /// Builds the note list that feeds the wait-countdown wheel for the Party Vocals
+    /// prototype engines (Free Vocals and the multi-mic coordinator). Mirrors
+    /// <see cref="VocalsEngine.BuildCountdownsFromAllParts"/> but drops percussion-only
+    /// phrases so percussion stretches read as gaps to the countdown wheel instead of a
+    /// continuous note stream. Kept out of the upstream VocalsEngine so the base engine's
+    /// countdown methods stay byte-identical to upstream.
+    internal static class PartyVocalsCountdownNotes
+    {
+        public static List<VocalNote> ExcludingPercussion(List<VocalsPart> allParts)
+        {
+            var allNotes = new List<VocalNote>();
+
+            foreach (var part in allParts)
+            {
+                allNotes.AddRange(part.CloneAsInstrumentDifficulty().Notes
+                    .Where(n => n.ChildNotes.Any(c => !c.IsPercussion)));
+            }
+
+            if (allParts.Count > 1)
+            {
+                // Sort combined list by Note time
+                allNotes.Sort((a, b) => (int) (a.Tick - b.Tick));
+            }
+
+            return allNotes;
+        }
+    }
+}

--- a/YARG.Core/Engine/Vocals/PartyVocalsInput.cs
+++ b/YARG.Core/Engine/Vocals/PartyVocalsInput.cs
@@ -1,0 +1,21 @@
+using YARG.Core.Input;
+
+namespace YARG.Core.Engine.Vocals
+{
+    /// Mic index is packed into the high bits of GameInput.Action for Party
+    /// Vocals so a single flat input stream can carry which mic produced each
+    /// input. GameInput is a union (Integer/Axis/Button alias), so the mic
+    /// cannot ride in Integer alongside a pitch Axis — hence Action-packing.
+    public static class PartyVocalsInput
+    {
+        private const int MIC_SHIFT = 8;
+        private const int ACTION_MASK = 0xFF;
+
+        public static int Pack(int micIndex, VocalsAction action) =>
+            (micIndex << MIC_SHIFT) | ((int) action & ACTION_MASK);
+
+        public static int UnpackMic(int packedAction) => packedAction >> MIC_SHIFT;
+        public static VocalsAction UnpackAction(int packedAction) =>
+            (VocalsAction) (packedAction & ACTION_MASK);
+    }
+}

--- a/YARG.Core/Engine/Vocals/PhraseGrade.cs
+++ b/YARG.Core/Engine/Vocals/PhraseGrade.cs
@@ -1,0 +1,20 @@
+namespace YARG.Core.Engine.Vocals
+{
+    /// <summary>
+    /// Per-phrase outcome for Party Vocals scoring. Counts how many canonical HARM meters
+    /// crossed the awesome threshold by phrase end. Capped by the number of HARM parts that
+    /// actually appear in the phrase (a 2-part phrase tops out at DoubleAwesome).
+    /// </summary>
+    /// <remarks>
+    /// Drives display banner and end-of-song stat tracking only. Does NOT multiply score or
+    /// bump the score multiplier — those are existing systems unchanged. Combo continues
+    /// iff the grade is not Miss.
+    /// </remarks>
+    public enum PhraseGrade
+    {
+        Miss,
+        Awesome,
+        DoubleAwesome,
+        TripleAwesome,
+    }
+}

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -182,11 +182,21 @@ namespace YARG.Core.Engine.Vocals
             }
         }
 
+        /// <summary>
+        /// When false, <see cref="MissNote(VocalNote, double)"/> will not strip the
+        /// StarPower flag off the (shared) note on a miss. Coordinator sub-engines set
+        /// this so an individual mic's miss can't clear SP from notes that the
+        /// authoritative coordinator still needs to score — the sub-engines and the
+        /// coordinator share the same VocalNote objects. Standalone engines (solo,
+        /// single-mic free vocals) keep the default.
+        /// </summary>
+        protected bool StripStarPowerOnMiss { get; set; } = true;
+
         protected void MissNote(VocalNote note, double hitPercent)
         {
             note.SetMissState(true, false);
 
-            if (note.IsStarPower)
+            if (note.IsStarPower && StripStarPowerOnMiss)
             {
                 StripStarPower(note);
             }
@@ -261,7 +271,14 @@ namespace YARG.Core.Engine.Vocals
             return null;
         }
 
-        protected static VocalNote? GetNextPercussionNote(VocalNote phrase, uint tick)
+        // <paramref name="isResolved"/> lets a caller decide which percussion notes are
+        // already done WITHOUT relying on the note's own WasHit/WasMissed flags. The
+        // PartyVocalsCoordinatorEngine scores percussion off shared VocalNote objects, so
+        // it must not mutate hit-state (that leaks across engines — see the SP-earning
+        // bug); it tracks consumed notes locally and passes that lookup here instead.
+        // The default (null) preserves the original WasHit/WasMissed behavior for solo.
+        protected static VocalNote? GetNextPercussionNote(VocalNote phrase, uint tick,
+            Func<VocalNote, bool>? isResolved = null)
         {
             foreach (var note in phrase.ChildNotes)
             {
@@ -271,8 +288,11 @@ namespace YARG.Core.Engine.Vocals
                     continue;
                 }
 
-                // Skip hit/missed percussion notes
-                if (note.IsPercussion && (note.WasHit || note.WasMissed))
+                // Skip already-resolved (hit/missed) percussion notes
+                bool resolved = isResolved is not null
+                    ? isResolved(note)
+                    : note.WasHit || note.WasMissed;
+                if (note.IsPercussion && resolved)
                 {
                     continue;
                 }

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -112,7 +112,8 @@ namespace YARG.Core.Game
         {
             // Only expose harmony index when playing harmonies, ensures consistent behavior
             // while still allowing harmony index to persist between instrument switches
-            get => CurrentInstrument == Instrument.Harmony ? _harmonyIndex : (byte) 0;
+            get => (CurrentInstrument == Instrument.Harmony || CurrentInstrument == Instrument.PartyVocals)
+                ? _harmonyIndex : (byte) 0;
             set => _harmonyIndex = _harmonyIndexFallback = value;
         }
 

--- a/YARG.Core/Game/YargProfile.cs
+++ b/YARG.Core/Game/YargProfile.cs
@@ -117,7 +117,8 @@ namespace YARG.Core.Game
         {
             // Only expose harmony index when playing harmonies, ensures consistent behavior
             // while still allowing harmony index to persist between instrument switches
-            get => CurrentInstrument == Instrument.Harmony ? _harmonyIndex : (byte) 0;
+            get => (CurrentInstrument == Instrument.Harmony || CurrentInstrument == Instrument.PartyVocals)
+                ? _harmonyIndex : (byte) 0;
             set => _harmonyIndex = _harmonyIndexFallback = value;
         }
 

--- a/YARG.Core/InstrumentEnums.cs
+++ b/YARG.Core/InstrumentEnums.cs
@@ -71,6 +71,7 @@ namespace YARG.Core
         // 40-49: Vocals
         Vocals = 40,
         Harmony = 41,
+        PartyVocals = 42,
 
         // 50-59: DJ
         // DjSingle = 50,
@@ -193,7 +194,8 @@ namespace YARG.Core
                 Instrument.ProKeys => GameMode.ProKeys,
 
                 Instrument.Vocals or
-                Instrument.Harmony => GameMode.Vocals,
+                Instrument.Harmony or
+                Instrument.PartyVocals => GameMode.Vocals,
 
                 // Instrument.DjSingle => GameMode.Dj,
                 // Instrument.DjDouble => GameMode.Dj,
@@ -256,7 +258,8 @@ namespace YARG.Core
                 GameMode.Vocals => new[]
                 {
                     Instrument.Vocals,
-                    Instrument.Harmony
+                    Instrument.Harmony,
+                    Instrument.PartyVocals
                 },
                 // GameMode.Dj             => new[]
                 // {

--- a/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
+++ b/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
@@ -270,9 +270,19 @@ namespace YARG.Core.Replays.Analyzer
                 }
                 case GameMode.Vocals:
                 {
+                    var multiTrack = _chart.GetVocalsTrack(profile.CurrentInstrument);
+
+                    if (profile.CurrentInstrument == Instrument.PartyVocals)
+                    {
+                        // Free Harmonies: register with modified primary chart (HARM1)
+                        var primaryPart = multiTrack.Parts[0].Clone();
+                        profile.ApplyVocalModifiers(primaryPart);
+                        manager.Register((VocalsEngine)engine, primaryPart.CloneAsInstrumentDifficulty(), _chart, rockMeterPreset);
+                        break;
+                    }
+
                     // Get the notes
-                    var notes = _chart.GetVocalsTrack(profile.CurrentInstrument)
-                        .Parts[profile.HarmonyIndex].Clone();
+                    var notes = multiTrack.Parts[profile.HarmonyIndex].Clone();
                     profile.ApplyVocalModifiers(notes);
                     manager.Register((VocalsEngine)engine, notes.CloneAsInstrumentDifficulty(), _chart, rockMeterPreset);
                     break;
@@ -377,9 +387,31 @@ namespace YARG.Core.Replays.Analyzer
                 }
                 case GameMode.Vocals:
                 {
+                    var multiTrack = _chart.GetVocalsTrack(profile.CurrentInstrument);
+
+                    if (profile.CurrentInstrument == Instrument.PartyVocals)
+                    {
+                        // Free Harmonies: clone and modify ALL parts so vocal modifiers
+                        // apply to every HARM line, matching live gameplay behavior.
+                        var modifiedParts = new List<VocalsPart>();
+                        foreach (var part in multiTrack.Parts)
+                        {
+                            var cloned = part.Clone();
+                            profile.ApplyVocalModifiers(cloned);
+                            modifiedParts.Add(cloned);
+                        }
+                        return new PartyVocalsCoordinatorEngine(
+                            PartyVocalsCoordinatorEngine.BuildMergedTrack(
+                                modifiedParts, modifiedParts[0].CloneAsInstrumentDifficulty()),
+                            modifiedParts,
+                            _chart.SyncTrack,
+                            (VocalsEngineParameters) parameters,
+                            profile.IsBot,
+                            micCount: 1);
+                    }
+
                     // Get the notes
-                    var notes = _chart.GetVocalsTrack(profile.CurrentInstrument)
-                        .Parts[profile.HarmonyIndex].Clone();
+                    var notes = multiTrack.Parts[profile.HarmonyIndex].Clone();
                     profile.ApplyVocalModifiers(notes);
 
                     // Create engine

--- a/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
+++ b/YARG.Core/Replays/Analyzer/ReplayAnalyzer.cs
@@ -270,9 +270,19 @@ namespace YARG.Core.Replays.Analyzer
                 }
                 case GameMode.Vocals:
                 {
+                    var multiTrack = _chart.GetVocalsTrack(profile.CurrentInstrument);
+
+                    if (profile.CurrentInstrument == Instrument.PartyVocals)
+                    {
+                        // Free Harmonies: register with modified primary chart (HARM1)
+                        var primaryPart = multiTrack.Parts[0].Clone();
+                        profile.ApplyVocalModifiers(primaryPart);
+                        manager.Register((VocalsEngine)engine, primaryPart.CloneAsInstrumentDifficulty(), _chart, rockMeterPreset);
+                        break;
+                    }
+
                     // Get the notes
-                    var notes = _chart.GetVocalsTrack(profile.CurrentInstrument)
-                        .Parts[profile.HarmonyIndex].Clone();
+                    var notes = multiTrack.Parts[profile.HarmonyIndex].Clone();
                     profile.ApplyVocalModifiers(notes);
                     manager.Register((VocalsEngine)engine, notes.CloneAsInstrumentDifficulty(), _chart, rockMeterPreset);
                     break;
@@ -377,9 +387,30 @@ namespace YARG.Core.Replays.Analyzer
                 }
                 case GameMode.Vocals:
                 {
+                    var multiTrack = _chart.GetVocalsTrack(profile.CurrentInstrument);
+
+                    if (profile.CurrentInstrument == Instrument.PartyVocals)
+                    {
+                        // Free Harmonies: clone and modify ALL parts so vocal modifiers
+                        // apply to every HARM line, matching live gameplay behavior.
+                        var modifiedParts = new List<VocalsPart>();
+                        foreach (var part in multiTrack.Parts)
+                        {
+                            var cloned = part.Clone();
+                            profile.ApplyVocalModifiers(cloned);
+                            modifiedParts.Add(cloned);
+                        }
+                        return new PartyVocalsCoordinatorEngine(
+                            modifiedParts[0].CloneAsInstrumentDifficulty(),
+                            modifiedParts,
+                            _chart.SyncTrack,
+                            (VocalsEngineParameters) parameters,
+                            profile.IsBot,
+                            micCount: 1);
+                    }
+
                     // Get the notes
-                    var notes = _chart.GetVocalsTrack(profile.CurrentInstrument)
-                        .Parts[profile.HarmonyIndex].Clone();
+                    var notes = multiTrack.Parts[profile.HarmonyIndex].Clone();
                     profile.ApplyVocalModifiers(notes);
 
                     // Create engine

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -245,6 +245,7 @@ namespace YARG.Core.Song
 
                     Instrument.Vocals => _parts.LeadVocals,
                     Instrument.Harmony => _parts.HarmonyVocals,
+                    Instrument.PartyVocals => _parts.HarmonyVocals,
                     Instrument.Band => _parts.BandDifficulty,
 
                     _ => throw new NotImplementedException($"Unhandled instrument {instrument}!")
@@ -282,6 +283,7 @@ namespace YARG.Core.Song
 
                 Instrument.Vocals => _parts.LeadVocals.IsActive(),
                 Instrument.Harmony => _parts.HarmonyVocals.IsActive(),
+                Instrument.PartyVocals => _parts.LeadVocals.IsActive() || _parts.HarmonyVocals.IsActive(),
                 Instrument.Band => _parts.BandDifficulty.IsActive(),
 
                 _ => false
@@ -324,6 +326,7 @@ namespace YARG.Core.Song
 
                 Instrument.Vocals  => _parts.LeadVocals,
                 Instrument.Harmony => _parts.HarmonyVocals,
+                Instrument.PartyVocals => _parts.HarmonyVocals.IsActive() ? _parts.HarmonyVocals : _parts.LeadVocals,
                 Instrument.Band    => _parts.BandDifficulty,
                 _ => throw new ArgumentException("Unhandled instrument", nameof(instrument))
             };

--- a/YARG.Core/Song/Entries/SongEntry.cs
+++ b/YARG.Core/Song/Entries/SongEntry.cs
@@ -243,6 +243,7 @@ namespace YARG.Core.Song
 
                     Instrument.Vocals => _parts.LeadVocals,
                     Instrument.Harmony => _parts.HarmonyVocals,
+                    Instrument.PartyVocals => _parts.HarmonyVocals,
                     Instrument.Band => _parts.BandDifficulty,
 
                     _ => throw new NotImplementedException($"Unhandled instrument {instrument}!")
@@ -280,6 +281,7 @@ namespace YARG.Core.Song
 
                 Instrument.Vocals => _parts.LeadVocals.IsActive(),
                 Instrument.Harmony => _parts.HarmonyVocals.IsActive(),
+                Instrument.PartyVocals => _parts.LeadVocals.IsActive() || _parts.HarmonyVocals.IsActive(),
                 Instrument.Band => _parts.BandDifficulty.IsActive(),
 
                 _ => false
@@ -322,6 +324,7 @@ namespace YARG.Core.Song
 
                 Instrument.Vocals  => _parts.LeadVocals,
                 Instrument.Harmony => _parts.HarmonyVocals,
+                Instrument.PartyVocals => _parts.HarmonyVocals.IsActive() ? _parts.HarmonyVocals : _parts.LeadVocals,
                 Instrument.Band    => _parts.BandDifficulty,
                 _ => throw new ArgumentException("Unhandled instrument", nameof(instrument))
             };


### PR DESCRIPTION
## Summary

Adds a new vocals mode ("Free Harmonies") where a single mic matches **all HARM parts simultaneously** — a singer whose pitch satisfies both HARM1 and HARM2 earns credit for both, instead of being locked to one part. At phrase end, the engine grades the performance based on how many parts were satisfied (Miss / Awesome / DoubleAwesome / TripleAwesome).

This PR contains all Core logic plus `Instrument.PartyVocals` plumbing. No scoring or gameplay behavior changes until a profile selects Free Harmonies.

## Why

The existing `YargVocalsEngine` matches one note at a time against a single vocal line. For traditional Harmony, each player picks one HARM part and sings only that line. Free Harmonies lets one mic cover all parts — a singer can freely switch between HARM1, HARM2, and HARM3 mid-phrase, and the engine tracks progress on each independently.

## Design

### `YargFreeVocalsEngine : YargVocalsEngine`

Subclasses the existing `YargVocalsEngine` to **inherit** the concrete `CanVocalNoteBeHit` pitch formula rather than duplicating it. The engine overrides the hit-detection orchestration (`CheckForNoteHit` — already `protected override` — without calling base) to traverse every HARM part's active note at the current tick, calling the inherited pitch matcher per note. This produces:

- `LastTickPartDeltas` — per-part fractional credit for the current tick.
- `GetMicHittingParts()` — bitmask of parts the mic is hitting this tick.
- `SetMicPitch(float)` — push a pitch reading into the sub-engine (used under composition).

The override owns the full singing + percussion + star-power flow together. Overriding only the singing step would inherit the base percussion/star-power path and double-activate star-power, so the entire `CheckForNoteHit` orchestration is owned by the subclass. **Zero edits to `YargVocalsEngine.cs`** were needed — `CheckForNoteHit` was already virtual, and the class has no private fields that needed exposure.

### `PartyVocalsCoordinatorEngine : VocalsEngine`

Composes N `YargFreeVocalsEngine` sub-engines (one per mic). Each update cycle:

1. Drives each sub-engine forward.
2. Reads per-tick credit + hitting-parts bitmasks.
3. Runs **ambiguity allocation** — classifies each tick's credit as *direct* (pitch matches exactly one part) or *ambiguous* (matches multiple), then allocates ambiguous credit to parts with remaining capacity.
4. At phrase end: counts how many canonical meters cross `PhraseHitPercent`, maps to `PhraseGrade`, awards **one** `HitNote`, and emits `OnPhraseHit` + `OnPartyVocalsPhrase(grade, parts, isLastPhrase)`.

The grade is for display and future stat tracking — it does **not** multiply score or bump the multiplier. Every non-miss phrase awards the same points as a solo vocals hit.

### Minimal additive seam in `VocalsEngine.cs`

Two backward-compatible changes:

1. **`StripStarPowerOnMiss`** property (default `true`): when `false`, `MissNote` won't strip the StarPower flag off shared notes. Sub-engines set this to `false` so one mic's miss can't clear SP from notes the coordinator still needs.
2. **`isResolved`** optional param on `GetNextPercussionNote` (default `null`): lets the coordinator track resolved percussion notes locally (via a `HashSet`) instead of mutating shared `WasHit`/`WasMissed` flags. Default `null` preserves the original behavior.

## Changes

| File | Change |
|------|--------|
| `Engine/Vocals/VocalsEngine.cs` | Add `StripStarPowerOnMiss` property + `isResolved` optional param on `GetNextPercussionNote`. |
| `Engine/Vocals/Engines/YargFreeVocalsEngine.cs` *(new)* | Multi-part free-match engine. Subclasses `YargVocalsEngine`. |
| `Engine/Vocals/Engines/PartyVocalsCoordinatorEngine.cs` *(new)* | Coordinator engine. Composes N sub-engines, ambiguity allocation, phrase-grade scoring. |
| `Engine/Vocals/PhraseGrade.cs` *(new)* | Enum: Miss / Awesome / DoubleAwesome / TripleAwesome. |
| `Engine/Vocals/PartyVocalsInput.cs` *(new)* | Mic-index packing/unpacking for the coordinator's input stream. |
| `Engine/Vocals/PartyVocalsCountdownNotes.cs` *(new)* | Countdown note list excluding percussion-only phrases. |
| `InstrumentEnums.cs` | Add `PartyVocals = 42`. Map to `GameMode.Vocals`. |
| `Chart/Loaders/MoonSong/MoonSongLoader.Vocals.cs` | PartyVocals loads the harmony chart (all parts). |
| `Audio/AudioHelpers.cs` | PartyVocals uses `VocalsStems`. |
| `Game/YargProfile.cs` | `HarmonyIndex` exposed for `PartyVocals`. |
| `Chart/Tracks/Vocals/VocalsPartExtensions.cs` | **Bug fix:** `ConvertAllToUnpitched()` was discarding percussion notes instead of preserving them. Now copies percussion to the new phrase parent. (`UnpitchedOnly` should only affect pitched notes; `NoVocalPercussion` is the modifier that removes percussion.) |
| `Song/Entries/SongEntry.cs` | `HasInstrument(PartyVocals)` checks vocals OR harmony. Indexer and `HasDifficultyForInstrument` map to harmony with solo fallback. |
| `Chart/SongChart.cs` | `GetVocalsTrack(PartyVocals)` returns harmony if available, falls back to solo vocals. |
| `Replays/Analyzer/ReplayAnalyzer.cs` | Constructs `PartyVocalsCoordinatorEngine` for PartyVocals profiles. |
| `Engine/EngineManager.UnisonEvent.cs` | PartyVocals excluded from unison phrase construction. |

## Testing done

```
dotnet test: 512 passed, 0 failed, 2 skipped
```

473 existing tests pass unchanged (solo regression guard). 39 new tests cover multi-part matching, ambiguity allocation, phrase-grade mapping, star-power deployment count, one-HitNote-per-phrase, and percussion ledger behavior.

Verified in-game: needle/particles/lyrics display correctly for both live mic and bot, particle trail color tracks the matched harmony part, practice restart works, modifiers (UnpitchedOnly, NoVocalPercussion) work correctly, replay analysis matches live results.

## Notes

- **Available for all songs with vocals.** Free Harmonies appears for solo-only songs too — the coordinator loads the solo chart as a single-part track.
- **Single mic only** (`micCount: 1`). Multi-mic support is a future enhancement.
- **Shared note state.** Sub-engines and the coordinator share `VocalNote` objects. `StripStarPowerOnMiss = false` contains the worst symptom (SP stripping). A full fix (separate note copies per engine) is deferred.
- **Phrase grades are not yet persisted** in `VocalsStats` or replays. The `OnPartyVocalsPhrase` event is exposed for future display/stat tracking.
