### PR TITLE
Fix 1 note solo handling when start doesn't exist

### DIFF
--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -814,6 +814,13 @@ namespace YARG.Core.Engine
                 return;
             }
 
+            if (CurrentSoloIndex >= Solos.Count)
+            {
+                // If this happens, something has probably gone wrong
+                YargLogger.LogFormatWarning("Solo note has been hit at time {0}, but all solos have already been completed! Ignoring solo", CurrentTime);
+                return;
+            }
+
             if (note.IsSoloStart)
             {
                 StartSolo();
@@ -1399,7 +1406,7 @@ namespace YARG.Core.Engine
         {
             var soloSections = new List<SoloSection>();
 
-            if (Notes.Count > 0 && Notes[0] is { IsSolo: true, IsSoloEnd: false })
+            if (Notes.Count > 0 && Notes[0].IsSolo)
             {
                 Notes[0].ActivateFlag(NoteFlags.SoloStart);
             }


### PR DESCRIPTION
If a solo has been cut partially, so the solo start does not exist (for example, in practice mode), it would only create a solo start flag if that note was not also the end of the solo, breaking 1-note solos.

I also added a failsafe to `HandleSoloNote` in case this somehow happens again.

If you want to check my homework, Llama Chorus 2 (after the solo) on Expert Guitar is my test case here.