### PR TITLE
Add tests, fix scoring bugs

### DIFF
--- a/Docs/Scoring.md
+++ b/Docs/Scoring.md
@@ -35,8 +35,8 @@ Defined in `YARG.Core/Engine/BaseEngine.cs`:
 
 | Constant | Value | Meaning |
 |---|---|---|
-| `POINTS_PER_NOTE` | 50 | Points for one regular note (guitar, keys, 4-lane drums) |
-| `POINTS_PER_PRO_NOTE` | 60 | Points for one pro four-lane drum pad |
+| `POINTS_PER_NOTE` | 50 | Points for one regular note (guitar, five-lane keys, four-lane drums, five-lane drums) |
+| `POINTS_PER_PRO_NOTE` | 60 | Points for one pro four-lane drum pad (`ProFourLane` only) |
 | `POINTS_PER_PRO_KEYS_NOTE` | 120 | Points for one pro keys note (`ProKeysEngine.cs`) |
 | `POINTS_PER_BEAT` | 25 | Points per quarter-note beat of sustain (see [Ticks and time](#ticks-and-time)) |
 
@@ -698,16 +698,3 @@ listens for `OnUnisonBonusAwarded` to show the bonus.
 | `LanedNotesHit` | Lane notes autohit (or hit) while a lane was active; excluded from timing-offset stats. |
 | `Overstrums` | Number of overstrums/overhits. |
 | `AverageMultiplier` | `CommittedScore / BaseNoteScore`; float, recomputed on every `AddScore`. |
-
-## History
-
-- `df171b81` (PR #221, Jul 2025) - "Improve Star Score requirements for sparse charts":
-  introduced weighted base score and the sparse-chart leniency rationale.
-- `b3d37169` (Apr 2026) - star rework: replaced weighting with the current pre-note
-  multiplier, split `noteScore` from `baseScore`, added disjoint-chord handling to
-  `CalculateChartScores`. Accidentally double-counted parent sustains (five-lane keys) and
-  double-incremented combo (guitar disjoint chords, keys).
-- PR #439 - fixed the sustain double-count and disjoint-chord combo overcount; restored
-  per-chord combo + per-chord multiplier in five-lane keys.
-- (current) - guitar sustain crediting no longer gated on `IsDisjoint`; non-disjoint
-  chords now credit every sustained member's sustain in base score and runtime.

--- a/Docs/Scoring.md
+++ b/Docs/Scoring.md
@@ -1,0 +1,713 @@
+# Scoring
+
+This document describes how YARG.Core scores notes, builds the multiplier, and derives star
+thresholds.
+
+## Ticks and time
+
+Before the scoring math, the time units:
+
+- **Tick** - the smallest time unit in a chart. A tick is `1 / Resolution` of a
+  quarter note (one beat).
+- **Resolution** - ticks per quarter note (`SyncTrack.Resolution`). YARG does not
+  fix it; the value comes from the file: the .chart `[Song]` header (default 192 if
+  absent, `ChartReader.DEFAULT_RESOLUTION`), or the MIDI header division (ticks per
+  quarter note). Charts authored for YARG use 480, so one beat = 480 ticks. 480 is
+  conventional, not required: at that resolution an eighth-note triplet is 160
+  ticks, a 16th note is 120, and a 32nd note is 60. Older charts may use 192 or 384;
+  precision charts may use 960+. Resolution bounds charting precision, but does not
+  directly scale hit windows, which are measured in seconds.
+- **Beat** - one quarter note. At resolution 480: 480 ticks. The quarter note is a
+  fixed unit defined by `Resolution`, not by the time signature: in 3/4 a measure
+  holds three quarter notes (1440 ticks at 480), and the beat is still 480 ticks.
+
+### Conversions (time)
+
+Tempo affects tick-to-time conversions (`SyncTrack.TickToTime` / `TimeToTick`) - the
+same tick distance can have a different duration before and after a tempo change.
+Chart positions and most scoring quantities use ticks. Hit windows, whammy buffers,
+sustain-drop leniency, and coda recharge use *seconds* (where applicable, scaled by
+song speed).
+
+## Core constants
+
+Defined in `YARG.Core/Engine/BaseEngine.cs`:
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `POINTS_PER_NOTE` | 50 | Points for one regular note (guitar, keys, 4-lane drums) |
+| `POINTS_PER_PRO_NOTE` | 60 | Points for one pro four-lane drum pad |
+| `POINTS_PER_PRO_KEYS_NOTE` | 120 | Points for one pro keys note (`ProKeysEngine.cs`) |
+| `POINTS_PER_BEAT` | 25 | Points per quarter-note beat of sustain (see [Ticks and time](#ticks-and-time)) |
+
+Derived values (`YARG.Core/Engine/BaseEngine.Generic.cs`, engine constructor):
+
+```
+TicksPerSustainPoint = SyncTrack.Resolution / POINTS_PER_BEAT
+```
+
+At the standard resolution of 480 ticks/beat this is 19.2 ticks per sustain point.
+
+## Multiplier
+
+The score multiplier steps with combo:
+
+```
+multiplier = min(combo / 10 + 1, MaxMultiplier)   // integer division
+```
+
+| Combo | Multiplier |
+|---|---|
+| 0–9 | 1x |
+| 10–19 | 2x |
+| 20–29 | 3x |
+| 30+ | 4x (cap) |
+
+Notes:
+
+- `MaxMultiplier` is an engine parameter (default 4).
+- For instruments, a hit increments combo, updates the multiplier, then scores. The
+  note that carries combo from 9 → 10 is therefore scored at 2x.
+- While star power is active the multiplier is doubled (`ScoreMultiplier *= 2`).
+- Vocals are the exception: `multiplier = min(combo + 1, MaxMultiplier)`. A vocal
+  phrase increments combo, scores with the existing multiplier, then updates the
+  multiplier for the next phrase. Vocals have no 10-combo step.
+
+## Runtime scoring (gameplay)
+
+When a note is hit, `AddScore` is called and the engine stats are updated:
+
+Chord data uses one parent note plus zero or more `ChildNotes`; `AllNotes` enumerates
+the parent followed by its children. A **disjoint chord** has members with different
+sustain lengths (`IsDisjoint`). Unless stated otherwise, scoring still treats it as
+one chord event.
+
+- **Note points** - `POINTS_PER_NOTE` (or `POINTS_PER_PRO_NOTE` for pro drums, or
+  `POINTS_PER_PRO_KEYS_NOTE` for pro keys) per note. Guitar/keys/drums score every member
+  of a chord: 3-note chord = 150 points (360 on pro keys).
+- **Sustain points** - per sustained *note*, not per chord: `ceil(note.TickLength /
+  TicksPerSustainPoint)` for each note carrying a sustain. While held, accrued value
+  appears in `PendingScore`. At the burst point, natural end, or a normal drop, the
+  accumulated value is committed through `AddScore` using the multiplier then in
+  effect. Every sustained chord member contributes its own value at its own length,
+  so a 2-note chord sustain is worth 2× a single note's, whether disjoint or not. One
+  beat (480 ticks) = 25 points per note. A long sustain may therefore commit at a
+  higher multiplier than its parent note. The `SustainScore` stats bucket excludes
+  star power doubling; `CommittedScore` keeps it (see
+  [Score accounting while active](#score-accounting-while-active)).
+- **Committed score** - the permanent, definitive score: points that have finished
+  scoring and can no longer be lost or changed. It never decreases and never contains
+  unearned value. Points only *become* committed through one path, `AddScore(int)` →
+  `CommittedScore += points × ScoreMultiplier` (a 50-point note at 2x commits 100).
+  Note hits, partial vocal phrases, and sustain commits all use this same call with
+  the multiplier then in effect. By contrast, a sustain that is still being held
+  accrues value into `PendingScore` - provisional, shown live on the UI, not part of
+  `CommittedScore`; it becomes permanent only when the sustain finishes (burst point
+  or natural end, full value) or drops early (only the value accrued so far). For a
+  note without a sustain, the stats buckets balance as
+  `NoteScore + MultiplierScore + StarPowerScore = CommittedScore` (`StarPowerScore`
+  is 0 unless points were committed while star power was active). Sustain scoring
+  does not balance this way because their
+  multiplier bonus appears in both `SustainScore` and `MultiplierScore`. The committed
+  total remains correct - see
+  [Score accounting while active](#score-accounting-while-active).
+
+### Combo increments per engine
+
+| Engine | Combo per | Source |
+|---|---|---|
+| Guitar (5-fret) | 1 per strum (whole chord, even disjoint chords) | `GuitarEngine.HitNote` |
+| Five-lane keys | 1 per chord (first note hit in a chord) | `FiveLaneKeysEngine.HitNote` - "Only increase combo for the first note in a chord" |
+| Pro keys | 1 per chord | `ProKeysEngine` - "Pro Keys combo increments per chord, not per note." |
+| Drums | 1 per note, *including* every chord member (`1 + ChildNotes.Count`) | `DrumsEngine` |
+| Vocals | 1 per phrase | `VocalsEngine` |
+
+A 3-note chord therefore gives +3 combo on drums but +1 on guitar/keys. This is a
+deliberate engine difference and is mirrored exactly by the chart base score
+(see [Chart base score](#chart-base-score)).
+
+## Vocals
+
+Vocals score per **phrase**, not per note. A charted phrase is a parent `VocalNote`
+whose child notes are the individual syllables; the engine resolves the whole phrase at
+once when it ends (`YargVocalsEngine.Update`).
+
+### Phrase hit resolution
+
+When the current tick passes the phrase end:
+
+```
+hitPercent = PhraseTicksHit / PhraseTicksTotal   // tick-weighted, not note-counted
+hit = hitPercent >= PhraseHitPercent             // parameter, e.g. 0.7
+```
+
+- **Full hit** - `PointsPerPhrase` (engine parameter, typically 100; see
+  `VocalsEngineParameters`) and combo +1. It scores using the multiplier carried into
+  the phrase, then updates the multiplier for the next phrase. A phrase with no
+  singable ticks scores nothing and does not increment combo.
+- **Miss / partial** - combo resets, but `round(PointsPerPhrase × hitPercent)` is
+  passed to `AddScore` (`AddPartialScore`). The multiplier from the preceding phrase
+  still applies because `UpdateMultiplier` runs after this score is applied.
+
+### Percussion
+
+Percussion phrases behave differently (`VocalsEngine.HitNote`):
+
+- Each percussion note is hit individually - `POINTS_PER_PERCUSSION = 100` per note.
+- No combo and no phrase status. A miss deducts no points and does not reset combo,
+  but the missed note earns none of its possible hit score.
+- Percussion phrases are removed from `TotalNotes` at construction and skipped in
+  `CalculateChartScores` - intentionally excluded from base score so they don't
+  affect star calculations.
+
+### Multiplier, star power, harmony
+
+- **Multiplier** - `min(combo + 1, MaxMultiplier)`: every full phrase raises the
+  multiplier used by the following phrase, with no 10-combo step (see
+  [Multiplier](#multiplier)).
+- **Star power** - a star power phrase fully hit calls `AwardStarPower` (quarter bar,
+  same as instruments; see [Earning star power](#earning-star-power)); missing one
+  calls `StripStarPower`, revoking the unearned phrase. The
+  `SingToActivateStarPower` parameter lets the game allow activation by singing
+  rather than a button.
+- **Harmony** - each harmony part is a separate engine instance (`EngineManager`
+  `HarmonyIndex`) with fully independent scoring, combo, and star power. No shared
+  state.
+
+## Forgiveness mechanics
+
+These mechanics forgive errors without a score penalty. They change *whether* a note
+scores, never *how much* it scores.
+
+### Lanes (tremolo / trills)
+
+Lane notes are chord members flagged `IsLane` (with `IsLaneStart` / `IsLaneEnd`
+markers; `IsTrill` vs `IsTremolo`). While a lane is active (`BaseEngine.Generic.cs`
+`AutohitNoteFromLane` / `SubmitLaneNote`):
+
+- The **first** lane note must be hit manually - `AutohitNoteFromLane` explicitly
+  refuses `IsLaneStart` notes. The autohit window is a single timer, extended by
+  every correct input, so at the end of a lane it can still be running into the
+  next one; without the guard it would carry over and autohit the next lane's
+  first note too.
+- Subsequent lane notes that would be missed are **autohit** instead: `HitNote` is
+  called, so the note scores fully (points, combo, sustain) as if played. The window is
+  `HitWindow.LaneAutohitWindow`, extended by every correct input.
+- Trills alternate the required fret (`NextTrillNote`); `WildcardMask` (open strum)
+  satisfies any lane.
+- **Proximity protection** (`IsInLaneLeniencyWindow`): inputs near a lane start/end
+  within `HitWindow.LaneProximityProtectionWindow` are forgiven instead of punished as
+  overstrums - guitar's parameterless variant forgives any input, drums/keys only
+  inputs that would satisfy the nearby lane.
+
+Stats: autohit lane notes still count toward `NotesHit`, but `IncrementNotesHit` routes
+`IsLane` notes to `LanedNotesHit` and skips offset tracking - `GetAverageOffset()` and
+`GetOffsetSamples()` (the score-screen timing distribution) exclude them, since their
+hit time is synthetic.
+
+### Sustain burst
+
+Sustains get a fixed early-commit grace period of one quarter-beat
+(`SUSTAIN_BURST_FRACTION = 4`, `SustainBurstThreshold = Resolution / 4`). Whether it
+applies depends on the **charted** sustain length:
+
+- **Charted longer than a quarter-beat:** finishes scoring at `TickEnd −
+  SustainBurstThreshold` - you may release up to a quarter-beat early and still get
+  full credit.
+- **Charted a quarter-beat or less:** no grace period - it scores in full
+  immediately when the note is hit (burst condition `CurrentTick >= note.Tick`),
+  so no holding is required.
+
+Drop leniency: after release, the sustain is kept in `IsLeniencyHeld` state for
+`SustainDropLeniency` seconds (scaled by song speed) before it is dropped and
+forfeits the remaining points.
+
+### Overstrum / overhit (guitar)
+
+Overstrumming has **no direct score penalty** - no points are taken. The punishment is
+indirect (`GuitarEngine.Overstrum`):
+
+- All active sustains are broken immediately (only points scored so far are banked).
+- The current star power phrase is stripped if it was not the start of a phrase
+  (`StripStarPower`), so a broken SP phrase no longer banks.
+- Combo resets, `Overstrums++`, multiplier recomputed.
+
+Overstrum is *prevented* entirely in several situations: before the first note, during
+wait countdown, when the input satisfies an active lane, inside the lane proximity
+window, and during active Big Rock Ending (BRE) free-play. After that free-play span
+ends, `CodaHasStarted` remains true until the ending chord resolves. An overstrum in
+this tail calls `Codas[CurrentCodaIndex].Overhit()`, which forfeits the coda bonus
+(see [Coda](#coda-big-rock-endings)).
+
+### Derived stats
+
+- `AverageMultiplier` - `CommittedScore / BaseNoteScore` (float, recomputed on every
+  `AddScore`). Includes star power doubling, so a song played with SP averages higher
+  than its combo curve would suggest.
+- `GetAverageOffset()` - mean hit timing in seconds (negative = early), excluding lane
+  notes.
+
+## Star power
+
+### Two tick coordinates: chart ticks and normalized measure ticks
+
+Star power drain is defined in chart measures: a phrase fills a quarter of the bar,
+four phrases fill it, and a full bar drains over 8 measures. Raw chart ticks cannot
+represent that duration uniformly because ticks per measure depend on both parts of
+the time signature:
+
+```
+chart ticks per measure = Resolution * 4 * Numerator / Denominator
+```
+
+At resolution 480, a 3/4 or 6/8 measure is 1440 chart ticks while a 4/4 measure is
+1920.
+
+The meter therefore stores **normalized measure ticks**, not raw chart ticks. Every
+charted measure maps to `MeasureResolution = Resolution * 4` normalized ticks
+(`TimeSignatureEvent.MEASURE_RESOLUTION_SCALE`), regardless of that measure's time
+signature. At resolution 480, every chart measure advances the normalized coordinate
+by 1920:
+
+| Tick count | Resolution | Used for |
+|---|---|---|
+| Chart ticks | `Resolution` per beat (480 at res. 480) | Note positions, sustains, sustain points |
+| Normalized measure ticks | `Resolution * 4` per chart measure (1920 at res. 480) | Star power storage, drain, thresholds, activation timing |
+
+A phrase awards a fixed quarter bar (`TicksPerQuarterSpBar = MeasureResolution * 2`)
+regardless of its charted length.
+
+### The 4/4 coincidence (and the trap)
+
+In 4/4, one charted measure is `Resolution * 4` raw ticks, so chart ticks and
+normalized measure ticks produce the same *numbers*: a note at 1440 chart ticks is
+also at 1440 normalized measure ticks. In 3/4 they diverge: a charted measure is
+only 1440 chart ticks but converts to 1920 normalized measure ticks (ratio
+`MeasureResolution` / ticks-per-measure: 4:3).
+
+The engine never relies on the coincidence: every update it converts `CurrentTick`
+with `QuarterTickToMeasureTick` (`StarPowerTickPosition`), and drain is the
+difference of two *converted* positions (`CalculateStarPowerDrain`). The trap is a
+future edit that skips the conversion - say, draining `CurrentTick − lastTick`
+directly. On 4/4 charts that is indistinguishable from correct code, because the
+numbers are the same. On 3/4 it drains 1440 ticks per measure instead of 1920: a
+full bar lasts 10⅔ measures instead of 8, and half-bar thresholds land at the
+wrong positions. 4/4 charts can never catch the bug.
+
+### Converting between chart and normalized measure ticks
+
+Switching between chart ticks and normalized measure ticks requires conversion
+(`QuarterTickToMeasureTick` /
+`MeasureTickToQuarterTick`), which is *time-signature*-aware: it counts how many
+measures were traveled on the chart side, then scales by `Resolution * 4`.
+
+### The bar
+
+The star power bar is measured in normalized measure ticks (`BaseEngine.cs`
+constructor):
+
+```
+TicksPerQuarterSpBar = MeasureResolution * 2
+TicksPerHalfSpBar     = TicksPerQuarterSpBar * 2   // 4 chart measures
+TicksPerFullSpBar     = TicksPerQuarterSpBar * 4   // 8 chart measures
+```
+
+A full bar is always 8 chart measures (15360 normalized ticks at resolution 480).
+That duration is 32 quarter-note beats in 4/4, 24 in 3/4 or 6/8.
+
+### Earning star power
+
+A star power **phrase** is a charted span: in .chart files, between the `[sp]` and
+`[end]` markers. The notes inside - however many - carry the star power flag, and
+every note in the span must be hit to earn it. Phrase length is author-chosen and
+irrelevant to the award; the meter fills a fixed quarter bar either way.
+
+| Source | Gain | Notes |
+|---|---|---|
+| Completing a star power phrase | Quarter bar (2 measures) | `AwardStarPower` → `GainStarPower(TicksPerQuarterSpBar)`; 4 phrases fill a bar |
+| Whammying a star power sustain | Time-based | Only while the sustain is held *and* the whammy timer is active (`StarPowerWhammyBuffer` parameter adds a grace buffer) |
+| Unison bonus (non-vocal instruments, band mode) | Quarter bar | `AwardUnisonBonus` |
+
+Whammy gain is the exception to measure-based drain. It is computed from raw chart
+ticks (`CalculateStarPowerGain`) and added directly to the meter because the bar
+constants are also multiples of `Resolution`. With gain factor `32/30`
+(`GAIN_FACTOR = MAX_BEATS / (MAX_BEATS - 2)`, `MAX_BEATS = 32`), 30 quarter-note
+beats of whammy add the same numeric amount as a full bar (`32 * Resolution`). Thus
+whammy earning is quarter-note-based while drain is chart-measure-based. Do not use
+raw chart-tick durations for drain or threshold math. Fractional gain carries over
+via `WhammyTicksRemainder`; the bar caps at `TicksPerFullSpBar`.
+
+Gain while star power is already active extends the current activation
+(`UpdateStarPowerEnds` recomputes the end position).
+
+### Activation
+
+- Requires at least a half bar (`CanStarPowerActivate`: `StarPowerTickAmount >=
+  TicksPerHalfSpBar`) plus star power input.
+- If a bandmate has failed (`PlayerNeedsRevive`), activating burns half a bar and
+  revives them (`StarPowerRevives++`) instead of activating star power - even if the
+  player is already in star power.
+- Otherwise star power activates: `ScoreMultiplier` doubles (`UpdateMultiplier`
+  multiplies by 2 while active), activation time/position/count are recorded, and the
+  end time is derived from the current bar amount.
+
+### Drain and duration
+
+While active, the bar drains one normalized measure tick per normalized measure tick
+of chart progress (`CalculateStarPowerDrain`). A full bar therefore lasts 8 chart
+measures. Activation ends when the bar hits zero (`ReleaseStarPower`); whammy gain
+during an activation pushes the end later.
+
+### Score accounting while active
+
+`AddScore` (called per commit - scored note, partial phrase, or finished sustain) while star power is active:
+
+```
+scoreMultiplier = score * ScoreMultiplier        // includes the ×2
+spScore        = scoreMultiplier / 2             // half - the SP portion
+CommittedScore += scoreMultiplier
+StarPowerScore += spScore
+MultiplierScore += spScore - score               // combo bonus only; SP portion stays in StarPowerScore
+BandBonusScore  += BandBonusMultiplier * spScore // band layer (see band section)
+```
+
+`StarPowerScore` is the total points attributable to star power (the extra half of
+every doubled note, `spScore`). `MultiplierScore` receives `spScore - score` - the
+combo bonus only, the same increment a non-SP note at the same combo multiplier
+would add. Star power therefore does *not* inflate `MultiplierScore`; the SP
+portion lives in `StarPowerScore` alone.
+
+The **total** has exactly one formula: every commit runs the same line
+`CommittedScore += points × ScoreMultiplier`. The buckets split each commit
+differently, though (combo multiplier `m`; star power on, so the total multiplier
+is `2m`):
+
+| Commit | `NoteScore` | `SustainScore` | `MultiplierScore` | `StarPowerScore` |
+|---|---|---|---|---|
+| Plain note | `+points` | `+0` | `+points × (m − 1)` | `+points × m` |
+| Sustain finish | `+0` | `+points × m` | `+points × (m − 1)` | `+points × m` |
+
+With star power off, drop the `StarPowerScore` column (`m` becomes the total
+multiplier). For plain notes the buckets sum exactly to `CommittedScore` - a
+50-point note at 2x combo with SP doubling commits 200 = 50 note + 0 + 50 combo
+bonus + 100 SP.
+
+Sustain commits are the exception: the combo bonus is counted twice. It appears in
+`SustainScore` (inside `points × m`) *and* in `MultiplierScore` (as
+`points × (m − 1)`), so the bucket sum overshoots `CommittedScore` - a 25-point
+sustain finished at 2x combo while SP is active commits 100, yet the buckets read
+50 (sustain) + 25 (combo) + 50 (SP) = 125. The total is
+always correct; only the bucket sum lies, and only for sustains.
+
+Star power does not change the star *cutoffs* (thresholds are derived from the chart
+base score), but live star progress uses `TotalScore`, which includes star power
+doubling - see [Star thresholds](#star-thresholds).
+
+## Coda (Big Rock Endings)
+
+Big Rock Endings are chart phrases (`PhraseType.BigRockEnding`) with a start/end time.
+BRE-flagged notes in the span do not score as normal notes: the engine suppresses or
+auto-resolves them, skips them in the chart base score, and excludes them from
+`TotalNotes`. Instead the player free-plays and builds a bonus.
+
+Two related states matter. `IsCodaActive` covers the timed free-play span. After that
+span ends, `CodaHasStarted` can remain true until the charted ending chord is fully
+resolved; this interval is the post-BRE tail mentioned above.
+
+**Scoring zones** (`CodaSection.cs`):
+
+| Instrument | Zones | Max score per zone hit |
+|---|---|---|
+| Guitar, keys (fret mode) | 5 (one per fret) | 150 |
+| Drums | 1 (all pads) | 750 |
+
+Zones are notional lanes for bonus bookkeeping, not visual lanes. During the coda,
+every input hit calls `HitLane(time, zone)` and the zone awards a bonus based on
+time since its last hit:
+
+```
+bonus = floor(min(time - lastCollectedTime[zone], 1.5) / 1.5 * MaxLaneScore)
+```
+
+`BONUS_RECHARGE_TIME = 1.5`s. Hitting the same zone again within 1.5s awards a partial
+bonus scaled by the elapsed time; waiting a full 1.5s awards the maximum. Zones recharge
+independently, so on guitar/keys cycling frets collects up to 5 × 150 per 1.5s window.
+`TotalCodaBonus` accumulates over the whole section.
+
+**Success condition** - the bonus is only banked if the coda succeeds:
+
+- Starts `true`. BRE-flagged notes inside free-play cannot be missed normally, but a
+  miss or overhit while `CodaHasStarted`-notably around the ending chord/tail-sets it
+  to `false`.
+- The coda ends when its final chord is fully resolved (hit or missed) - coda-end
+  markers sit on a single sub-note, so ending early on one chord member is guarded
+  against in both `HitNote` and `MissNote`.
+- `AwardCodaBonus(success)` banks `CurrentCodaBonus` into `CodaBonuses` (and thus
+  `TotalScore` → live stars) only on success.
+- Band mode (`EngineManager.Band.cs`): `CodaSuccess` is the AND of every engine's
+  success - if any player fails, nobody banks the bonus.
+
+After ending, `InhibitCoda` prevents re-activation until the next coda
+(`AwardCodaBonus` clears it).
+
+## Chart base score
+
+`CalculateChartScores()` (abstract in `BaseEngine.Generic.cs`, implemented per engine) is
+run once at engine construction and produces two numbers:
+
+- **BaseScore** - the star-cutoff reference score.
+- **BaseNoteScore** - the raw point value of the chart (all notes + sustains at 1x, no
+  multiplier, no combo).
+
+### The pre-note multiplier convention
+
+**BaseScore values every note at the multiplier the player *brings into* it** - the
+multiplier computed from the combo *before* that note's combo increment. It is deliberately
+*not* the maximum possible score.
+
+Rationale (commit `df171b81`, "Improve Star Score requirements for sparse charts (#221)"):
+players start every song at 1x and must build the multiplier. If the star reference assumed
+a permanent 4x, sparse charts (long gaps, low note density) would have mathematically
+unreachable star thresholds. Basing stars on the pre-note multiplier gives every chart a
+reachable reference and makes star difficulty roughly comparable across songs.
+
+Consequences:
+
+- On instrument charts that cross a multiplier step, BaseScore is lower than an FC's
+  committed score. Example: 10 singles → BaseScore 500 (all at 1x), FC committed 550
+  (10th note at 2x). Charts that never cross a step can be equal; vocals also use the
+  pre-phrase multiplier at runtime. The example's 50-point gap is `MultiplierScore`,
+  the bonus earned by building combo.
+- The convention must be applied *uniformly*: every note - chord member or not - is valued
+  at the pre-increment multiplier of its chord. A chord never scores at two different
+  multipliers inside the base calculation.
+- Sustains are valued at the same per-chord multiplier as their parent note.
+
+### Per-engine implementation
+
+All engines share the same skeleton (`BaseEngine.cs` / engine-specific overrides);
+Big Rock Endings are skipped because they can't be scored as notes - their value is a
+runtime bonus, not chartable points (see [Coda](#coda-big-rock-endings)):
+
+```
+for each parent note (one chord event):
+    if note is BRE: skip                              // BREs can't be scored as notes
+    multiplier = min(combo / 10 + 1, MaxMultiplier)   // pre-increment
+    note points  = POINTS_PER_NOTE * (1 + ChildNotes.Count)
+    baseScore   += multiplier * notePoints
+    noteScore   += notePoints
+    sustain points = sum over chord of ceil(TickLength / TicksPerSustainPoint)
+    baseScore   += multiplier * sustainPoints
+    noteScore   += sustainPoints
+    combo++     // once per chord, except drums
+```
+
+Engine-specific differences:
+
+Sustain handling is **identical** across guitar, five-lane keys, and pro keys (see below);
+the real per-engine differences are combo semantics and note point values:
+
+| Engine | Combo | Note points | Sustain handling |
+|---|---|---|---|
+| Guitar | `combo++` once per chord | `POINTS_PER_NOTE` (50) per chord member | shared (below) |
+| Five-lane keys | `combo++` once per chord | `POINTS_PER_NOTE` (50) per chord member | shared |
+| Pro keys | `combo++` once per chord | `POINTS_PER_PRO_KEYS_NOTE` (120) per chord member | shared |
+| Drums | `combo += 1 + ChildNotes.Count` - every chord member increments | `POINTS_PER_NOTE`, or `POINTS_PER_PRO_NOTE` (60) in pro 4-lane mode, per chord member | none - drums have no sustained notes in base calc |
+| Vocals | `combo++` per phrase; multiplier = `min(combo + 1, MaxMultiplier)`, no 10-combo step | `PointsPerPhrase` (typically 100) per phrase | n/a - phrases score as a unit, no sustains; percussion phrases intentionally excluded from base score |
+
+Sources: `GuitarEngine.cs:398`, `FiveLaneKeysEngine.cs:169`, `ProKeysEngine.cs:235`, `DrumsEngine.cs:363`, `VocalsEngine.cs:324`.
+
+**Shared sustain handling (guitar, five-lane keys, pro keys):** sum over `note.AllNotes` -
+`ceil(chordNote.TickLength / TicksPerSustainPoint)` per member, each valued at the chord's
+pre-increment multiplier. The `AllNotes` enumerator's index 0 is the parent note itself, so
+the parent sustain is counted exactly once through the loop - never add it separately.
+
+### Pitfalls (bugs found here)
+
+- The `AllNotes` enumerator starts at index 0 = the note itself. Summing sustains over
+  `AllNotes` *and* adding the parent's sustain separately double-counts the parent sustain.
+  The parent's sustain must only be counted via the `AllNotes` loop.
+- Recomputing the multiplier or incrementing combo *inside* the per-note chord loop
+  (instead of once per chord) breaks the pre-note convention: chord members after the first
+  get scored at a stepped-up multiplier, inflating BaseScore and shifting star thresholds.
+  This happened to five-lane keys (PR #439) because the per-note loop recomputed both per
+  chord member.
+
+## Total score and live stars
+
+`TotalScore` (`BaseStats.cs`) composes every scoring surface:
+
+```
+TotalScore = CommittedScore + PendingScore + SoloBonuses + CodaBonuses
+```
+
+- `CommittedScore` - banked points (notes, sustains, multiplier, star power).
+- `PendingScore` - points earned but not yet banked (sustain still being held).
+- `SoloBonuses` - bonus from completed solo sections (see [Solo bonuses](#solo-bonuses)).
+- `CodaBonuses` - bonus from Big Rock Endings (see [Coda](#coda-big-rock-endings)).
+
+`UpdateStars` runs after scored notes and sustain updates. It advances
+`CurrentStarIndex` only when `TotalScore` is strictly greater than a threshold. At
+exact equality the index has not advanced, although interpolated `Stars` can equal
+the next integer because progress is 1.
+
+```
+Stars = CurrentStarIndex + progress   // progress = inverse lerp between thresholds
+```
+
+Live star progress therefore moves with *everything*: star power doubling, solo
+bonuses, coda bonuses, and pending sustain points. The thresholds themselves are
+static (computed once at engine construction from the [chart base score](#chart-base-score)); only
+the comparison value is live.
+
+### Solo bonuses
+
+Solo sections are chart markers (`IsSolo` notes between `solo` / `soloend` events).
+`SoloSection` tracks the section's note count and how many were hit; when the section
+ends (`EndSolo`, `BaseEngine.Generic.cs`):
+
+```
+soloPercentage = NotesHit / NoteCount
+
+if soloPercentage < 0.6:
+    SoloBonus = 0
+else:
+    multiplier = clamp((soloPercentage - 0.6) / 0.4, 0, 1)
+    SoloBonus = floor_to_50(100 * NotesHit * multiplier)
+```
+
+- **60% threshold** - below 60% yields no bonus. Exactly 60% also computes to zero;
+  the bonus becomes positive only above 60%.
+- **Scales 60% → 100%** - bonus ramps from 0 to `100 × NotesHit` (2×
+  `POINTS_PER_NOTE` per hit; the code comment flags this value as unverified against
+  the old engine).
+- **Rounded down to nearest 50.**
+
+For star thresholds, the engine precomputes `MaxSoloBonusPoints`
+(`CalculateTotalSoloBonus`): `Σ solo.NoteCount × 100` over all solo sections - the
+bonus if every solo is 100% hit. It feeds the `soloScore` term of the [star thresholds](#star-thresholds) formula,
+so solos raise the bar *and* provide the points to reach it.
+
+## Star thresholds
+
+`PopulateStarScoreThresholds` (`BaseEngine.Generic.cs`):
+
+```
+threshold[i] = floor(baseScore * starThresholds[i] + soloScore * soloThresholds[i])
+```
+
+- `starThresholds` / `soloThresholds` are engine parameters (fractions of BaseScore /
+  MaxSoloBonusPoints).
+- Instrument test fixtures use 0.06, 0.12, 0.2, 0.45, 0.75, and 1.09 for stars 1–6;
+  these are test inputs, not constants owned by the engine. Vocal fixtures differ.
+- `soloScore` = `MaxSoloBonusPoints`, the maximum solo bonus available in the chart.
+- Star power is not part of base score or thresholds; it doubles committed score mid-song
+  but does not change the star cutoffs.
+
+Thresholds are computed once at engine construction and never move. Whether the player
+actually reaches them depends on live `TotalScore` (see
+[Total score and live stars](#total-score-and-live-stars)),
+which includes star power doubling, solo bonuses, coda bonuses, and pending sustains.
+
+## Band layer
+
+In band mode (`EngineManager.Band.cs`) the per-player engines keep their own scores, and
+the manager adds the band layer on top.
+
+### Band multiplier and band bonus
+
+```
+BandMultiplier = max(_starpowerCount * 2, 1)     // 1x with none; then 2x, 4x, 6x, ...
+BandBonusMultiplier = BandMultiplier - (own SP active ? 2 : 1)
+```
+
+`_starpowerCount` tracks how many players have star power active (updated from each
+engine's `OnStarPowerStatus`). The player's own star power contribution is subtracted
+from their band bonus multiplier because their individual `ScoreMultiplier` already
+includes their own doubling.
+
+Examples (2 players, A in star power):
+
+| Player | BandMultiplier | BandBonusMultiplier | Effect |
+|---|---|---|---|
+| A (SP active) | 2 | 0 | own doubling already in individual score; no band bonus |
+| B (no SP) | 2 | 1 | every scored note earns a +100% band bonus |
+
+`AddScore` accumulates band bonus on every scored note (`BaseEngine.Generic.cs`):
+
+```
+// star power inactive:
+BandBonusScore += BandBonusMultiplier * scoreMultiplier
+// star power active (uses spScore = scoreMultiplier / 2):
+BandBonusScore += BandBonusMultiplier * spScore
+```
+
+`BandBonusScore` is engine-side; the band's displayed `Score`/`Combo`/`Stars` are
+assembled by the game layer from all players' committed scores plus their
+`BandBonusScore`s (the manager's `Score` property is set externally).
+
+### Band star cutoffs
+
+`GetStarScoreCutoffs` combines each player's per-threshold cutoffs:
+
+```
+bandCutoff[i] = floor((sum over players of playerCutoff[i]) * (1 + 0.265 * (nPlayers - 1)))
+```
+
+Six thresholds (`NUMBER_OF_STAR_SCORE_THRESHOLDS = 6`). The `1 + 0.265 × (nPlayers − 1)`
+factor compensates for band play: more players make the multiplier easier to keep high
+and star power easier to chain, so the combined cutoff is scaled up rather than summed
+plain.
+
+### Unison bonus
+
+Matching star power phrases across at least two non-vocal instrument tracks
+(`UnisonEvent`). Vocals and harmonies are explicitly excluded. When every participant
+completes their phrase, `AwardUnisonBonus` gives each participating engine a quarter
+bar of star power (see [Earning star power](#earning-star-power)). The game layer
+listens for `OnUnisonBonusAwarded` to show the bonus.
+
+## Score stats glossary
+
+| Stat | Meaning |
+|---|---|
+| `BaseScore` | Chart reference score: every note/sustain at pre-note multiplier. Star cutoffs derive from it. |
+| `BaseNoteScore` | Raw chart value: every note/sustain at 1x. |
+| `CommittedScore` | Actual banked score from note, phrase, partial-vocal, and committed sustain scoring; multiplier included. |
+| `NoteScore` | Committed points from note hits (base value, no multiplier). |
+| `SustainScore` | Sustain points credited at commit: `points × combo multiplier` at the multiplier in effect when the sustain finishes, star power doubling stripped. Includes the multiplier - not a base value. |
+| `MultiplierScore` | Accumulated multiplier bonus, summed per `AddScore` call: `scored - base` (or `scored / 2 - base` while star power is active, the SP half landing in `StarPowerScore`). Includes sustain bonuses; not equal to `CommittedScore - NoteScore - SustainScore` (that residual only balances for notes without sustains - see [Score accounting while active](#score-accounting-while-active)). |
+| `PendingScore` | Points earned but not yet banked (e.g. sustain still being held). |
+| `MaxCombo` | Highest combo reached. |
+| `Percent` | `NotesHit / TotalNotes`; forced to 1.0 when `TotalNotes` is 0. Vocals override this with tick-based percent. |
+| `IsFullCombo` | Whether `MaxCombo` reached the chart target: `TotalNotes`, or `TotalChords` for keys. A combo-breaking overhit can make this false even when no charted note was missed. |
+| `TotalScore` | `CommittedScore + PendingScore + SoloBonuses + CodaBonuses`. The value compared against star thresholds. |
+| `SoloBonuses` | Sum of bonuses from completed solo sections. |
+| `CodaBonuses` | Sum of bonuses from completed Big Rock Endings. |
+| `MaxSoloBonusPoints` | Theoretical maximum solo bonus (`Σ solo.NoteCount × 100`); the `soloScore` term of the star thresholds. |
+| `BandMultiplier` | `max(2 × players-in-SP, 1)`. |
+| `BandBonusMultiplier` | Per-player band bonus factor = `BandMultiplier − (own SP active ? 2 : 1)`. |
+| `BandBonusScore` | Accumulated band bonus. Uses `BandBonusMultiplier × scoreMultiplier` outside own SP, or `BandBonusMultiplier × spScore` during own SP. |
+| `StarPowerScore` | Points attributable to star power: half of every score committed while active. |
+| `StarPowerWhammyTicks` | Total whammy ticks earned from sustains. |
+| `TotalStarPowerTicks` | Total star power ticks earned from all sources (phrases, whammy, unison). |
+| `TotalStarPowerBarsFilled` | `TotalStarPowerTicks / TicksPerFullSpBar`. |
+| `StarPowerActivationCount` | Number of star power activations. |
+| `StarPowerRevives` | Number of half-bar revives performed. |
+| `TimeInStarPower` | Total time spent with star power active. |
+| `LanedNotesHit` | Lane notes autohit (or hit) while a lane was active; excluded from timing-offset stats. |
+| `Overstrums` | Number of overstrums/overhits. |
+| `AverageMultiplier` | `CommittedScore / BaseNoteScore`; float, recomputed on every `AddScore`. |
+
+## History
+
+- `df171b81` (PR #221, Jul 2025) - "Improve Star Score requirements for sparse charts":
+  introduced weighted base score and the sparse-chart leniency rationale.
+- `b3d37169` (Apr 2026) - star rework: replaced weighting with the current pre-note
+  multiplier, split `noteScore` from `baseScore`, added disjoint-chord handling to
+  `CalculateChartScores`. Accidentally double-counted parent sustains (five-lane keys) and
+  double-incremented combo (guitar disjoint chords, keys).
+- PR #439 - fixed the sustain double-count and disjoint-chord combo overcount; restored
+  per-chord combo + per-chord multiplier in five-lane keys.
+- (current) - guitar sustain crediting no longer gated on `IsDisjoint`; non-disjoint
+  chords now credit every sustained member's sustain in base score and runtime.

--- a/YARG.Core.UnitTests/Chart/ProKeysNoteTests.cs
+++ b/YARG.Core.UnitTests/Chart/ProKeysNoteTests.cs
@@ -1,0 +1,29 @@
+using NUnit.Framework;
+using YARG.Core.Chart;
+
+namespace YARG.Core.UnitTests.Chart;
+
+public class ProKeysNoteTests
+{
+    [Test]
+    public void PrimaryCtor_SetsDisjointMask()
+    {
+        var note = new ProKeysNote(7, ProKeysNoteFlags.None, NoteFlags.None, 0, 0, 0, 0);
+        Assert.That(note.DisjointMask, Is.EqualTo(1 << 7));
+    }
+
+    [Test]
+    public void CopyCtor_SetsDisjointMask()
+    {
+        var note = new ProKeysNote(12, ProKeysNoteFlags.None, NoteFlags.None, 0, 0, 0, 0);
+        var copy = note.Clone();
+        Assert.That(copy.DisjointMask, Is.EqualTo(1 << 12));
+    }
+
+    [Test]
+    public void PrimaryAndCopyCtor_DisjointMaskAgree()
+    {
+        var primary = new ProKeysNote(3, ProKeysNoteFlags.None, NoteFlags.None, 0, 0, 0, 0);
+        Assert.That(primary.Clone().DisjointMask, Is.EqualTo(primary.DisjointMask));
+    }
+}

--- a/YARG.Core.UnitTests/Chart/SyncTrackTests.cs
+++ b/YARG.Core.UnitTests/Chart/SyncTrackTests.cs
@@ -712,4 +712,21 @@ public class SyncTrackTests
             }
         });
     }
+
+    [Test]
+    public void FindMinTimeForMeasureTick_UnreachableTarget_DoesNotHang()
+    {
+        // Regression: the high-side doubling search must terminate when the target
+        // measure tick is unreachable (beyond the track end, or no time signatures).
+        // Star power end times can exceed the track's final measure when a full bar
+        // is banked near the end of a chart.
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        Assert.DoesNotThrow(() =>
+        {
+            double time = syncTrack.FindMinTimeForMeasureTick(100_000);
+            Assert.That(time, Is.GreaterThanOrEqualTo(0));
+        });
+    }
 }

--- a/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
@@ -54,6 +54,174 @@ public class DrumEngineTester : EngineTester
     }
 
     [Test]
+    public void TenSingleNotes_FcUsesCorrectMultiplierBoundary()
+    {
+        var notes = Enumerable.Range(1, 10)
+            .Select(index => new DrumNote(
+                FourLaneDrumPad.RedDrum,
+                DrumNoteType.Neutral,
+                DrumNoteFlags.None,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+        LinkNotes(notes);
+
+        var difficulty = new InstrumentDifficulty<DrumNote>(Instrument.ProDrums, Difficulty.Expert,
+            notes, new(), new());
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+        var engineParams = new DrumsEngineParameters(
+            new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            DrumsEngineParameters.DrumMode.ProFourLane,
+            false,
+            true);
+        var engine = new YargDrumsEngine(difficulty, syncTrack, engineParams, true, false);
+
+        engine.Update(notes[^1].Time + 0.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 10 notes at 60 points each (pro four lane = 50 + 10); chart base score assumes
+            // the pre-note combo (all 1x), while an FC commits the 10th note at 2x
+            Assert.That(engine.BaseNoteScore, Is.EqualTo(600));
+            Assert.That(engine.BaseScore, Is.EqualTo(600));
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(660));
+            Assert.That(engine.EngineStats.NoteScore, Is.EqualTo(600));
+            Assert.That(engine.EngineStats.MultiplierScore, Is.EqualTo(60));
+            Assert.That(engine.EngineStats.PendingScore, Is.Zero);
+            Assert.That(engine.EngineStats.TotalNotes, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesMissed, Is.Zero);
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(1f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.True);
+        }
+    }
+
+    [Test]
+    public void MissOneNote_PercentReflectsMissAndComboResets()
+    {
+        var notes = Enumerable.Range(1, 10)
+            .Select(index => new DrumNote(
+                FourLaneDrumPad.RedDrum,
+                DrumNoteType.Neutral,
+                DrumNoteFlags.None,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+        LinkNotes(notes);
+
+        var difficulty = new InstrumentDifficulty<DrumNote>(Instrument.ProDrums, Difficulty.Expert,
+            notes, new(), new());
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+        var engine = new YargDrumsEngine(difficulty, syncTrack, _engineParams, false, false);
+
+        // Hit every note except the 5th (at 2.5s)
+        for (int i = 0; i < notes.Count; i++)
+        {
+            if (i == 4)
+            {
+                continue;
+            }
+
+            HitPad(engine, notes[i].Time, DrumsAction.RedDrum);
+        }
+
+        engine.Update(notes[^1].Time + 0.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(9));
+            Assert.That(engine.EngineStats.NotesMissed, Is.EqualTo(1));
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(5));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(0.9f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.False);
+        }
+    }
+
+    [Test]
+    public void SoloUnderSixtyPercent_AwardsNoBonus()
+    {
+        // 5/10 = 50% < 60% -> bonus deleted
+        var (engine, notes) = CreateSoloEngine(10);
+
+        for (int i = 0; i < 5; i++)
+        {
+            HitPad(engine, notes.Notes[i].Time, DrumsAction.RedDrum);
+        }
+
+        engine.Update(notes.Notes[^1].Time + 0.5);
+
+        Assert.That(engine.EngineStats.SoloBonuses, Is.Zero);
+    }
+
+    [Test]
+    public void SoloAtExactlySixtyPercent_AwardsNoBonus()
+    {
+        // 6/10 = 60% -> multiplier clamps to 0 -> 0 points
+        var (engine, notes) = CreateSoloEngine(10);
+
+        for (int i = 0; i < 6; i++)
+        {
+            HitPad(engine, notes.Notes[i].Time, DrumsAction.RedDrum);
+        }
+
+        engine.Update(notes.Notes[^1].Time + 0.5);
+
+        Assert.That(engine.EngineStats.SoloBonuses, Is.Zero);
+    }
+
+    [Test]
+    public void SoloOverSixtyPercent_RoundsBonusDownToNearestFifty()
+    {
+        // 7/10 = 70% -> multiplier (0.7 - 0.6) / 0.4 = 0.25 -> 100 * 7 * 0.25 = 175 -> 150
+        var (engine, notes) = CreateSoloEngine(10);
+
+        for (int i = 0; i < 7; i++)
+        {
+            HitPad(engine, notes.Notes[i].Time, DrumsAction.RedDrum);
+        }
+
+        engine.Update(notes.Notes[^1].Time + 0.5);
+
+        Assert.That(engine.EngineStats.SoloBonuses, Is.EqualTo(150));
+    }
+
+    private static (YargDrumsEngine Engine, InstrumentDifficulty<DrumNote> Notes) CreateSoloEngine(int noteCount)
+    {
+        var notes = Enumerable.Range(1, noteCount)
+            .Select(index => new DrumNote(
+                FourLaneDrumPad.RedDrum,
+                DrumNoteType.Neutral,
+                DrumNoteFlags.None,
+                NoteFlags.Solo,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+        LinkNotes(notes);
+
+        var difficulty = new InstrumentDifficulty<DrumNote>(Instrument.ProDrums, Difficulty.Expert,
+            notes, new(), new());
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        return (new YargDrumsEngine(difficulty, syncTrack, new DrumsEngineParameters(
+            new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            DrumsEngineParameters.DrumMode.ProFourLane,
+            false,
+            true), false, false), difficulty);
+    }
+
+    [Test]
     public void Reset_ClearsRuntimeDrumStatsButPreservesChartTotals()
     {
         var (engine, notes) = CreateEngine(isBot: true);
@@ -331,6 +499,22 @@ public class DrumEngineTester : EngineTester
         return (new YargDrumsEngine(notes, syncTrack, engineParams, false, false), notes);
     }
 
+
+    private static void LinkNotes(List<DrumNote> notes)
+    {
+        for (int i = 0; i < notes.Count; i++)
+        {
+            if (i > 0)
+            {
+                notes[i].PreviousNote = notes[i - 1];
+            }
+
+            if (i < notes.Count - 1)
+            {
+                notes[i].NextNote = notes[i + 1];
+            }
+        }
+    }
 
     private static void HitPad(YargDrumsEngine engine, double time, DrumsAction action)
     {

--- a/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/DrumEngineTester.cs
@@ -499,23 +499,6 @@ public class DrumEngineTester : EngineTester
         return (new YargDrumsEngine(notes, syncTrack, engineParams, false, false), notes);
     }
 
-
-    private static void LinkNotes(List<DrumNote> notes)
-    {
-        for (int i = 0; i < notes.Count; i++)
-        {
-            if (i > 0)
-            {
-                notes[i].PreviousNote = notes[i - 1];
-            }
-
-            if (i < notes.Count - 1)
-            {
-                notes[i].NextNote = notes[i + 1];
-            }
-        }
-    }
-
     private static void HitPad(YargDrumsEngine engine, double time, DrumsAction action)
     {
         var input = GameInput.Create(time, action, 1.0f);

--- a/YARG.Core.UnitTests/Engine/EngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/EngineTester.cs
@@ -64,4 +64,23 @@ public class EngineTester
         var engine = new YargFiveLaneKeysEngine(notes, chart.SyncTrack, engineParams, isBot);
         return (engine, notes);
     }
+
+    protected static void LinkNotes<TNote>(IList<TNote> notes) where TNote : Note<TNote>
+    {
+        for (int i = 0; i < notes.Count; i++)
+        {
+            if (i > 0)
+            {
+                notes[i].PreviousNote = notes[i - 1];
+            }
+
+            if (i < notes.Count - 1)
+            {
+                notes[i].NextNote = notes[i + 1];
+            }
+        }
+    }
+
+    protected static void LinkNotes<TNote>(params TNote[] notes) where TNote : Note<TNote>
+        => LinkNotes((IList<TNote>) notes);
 }

--- a/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
@@ -182,6 +182,68 @@ public class GuitarEngineTester : EngineTester
     }
 
     [Test]
+    public void NonDisjointChord_WithChildSustain_ScoresEachSustain()
+    {
+        var notes = Enumerable.Range(1, 8)
+            .Select(index => CreateNote(
+                FiveFretGuitarFret.Green,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+
+        // Non-disjoint chord: green (no sustain) + red (one-beat sustain), same tick,
+        // no Disjoint flag. The child sustain must still be scored, like the disjoint case.
+        var chord = new GuitarNote(FiveFretGuitarFret.Green, GuitarNoteType.Strum,
+            GuitarNoteFlags.None, NoteFlags.None, 4.5, 0, 8 * 480, 0);
+        chord.AddChildNote(new GuitarNote(FiveFretGuitarFret.Red, GuitarNoteType.Strum,
+            GuitarNoteFlags.None, NoteFlags.None, 4.5, 0.5, 8 * 480, 480));
+
+        var lastNote = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 5.0, 9 * 480);
+        var allNotes = notes.Concat(new[] { chord, lastNote }).ToList();
+        LinkNotes(allNotes.ToArray());
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.FiveFretGuitar, Difficulty.Expert,
+            allNotes, new(), new());
+        var engineParams = new GuitarEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.1,
+            0.1,
+            0.1,
+            false,
+            true,
+            false,
+            false,
+            true);
+        var engine = new YargFiveFretGuitarEngine(difficulty, CreateSyncTrack(), engineParams, true);
+
+        engine.Update(5.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 8 singles at 1x + chord (2 notes) at 1x + last single at 1x = 550,
+            // plus the child sustain (480 ticks / 19.2 ticks per point) = 25.
+            // Same numbers as the disjoint case: sustain crediting must not depend
+            // on the Disjoint flag.
+            Assert.That(engine.BaseNoteScore, Is.EqualTo(575));
+            Assert.That(engine.BaseScore, Is.EqualTo(575));
+            Assert.That(engine.EngineStats.TotalNotes, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(10));
+            // The child sustain was actually paid at runtime: 480 ticks = 25 points.
+            Assert.That(engine.EngineStats.SustainScore, Is.EqualTo(25));
+            // CommittedScore = 575 + 50: the note that carries combo 9 -> 10 is
+            // scored at the post-increment multiplier (2x), same as the disjoint case.
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(625));
+        }
+    }
+
+    [Test]
     public void TopFretBeforeTrillStart_IsForgivenByGuitarGhostLeniency()
     {
         var (engine, notes) = CreateTrillProximityEngine();
@@ -261,22 +323,6 @@ public class GuitarEngineTester : EngineTester
     private static GuitarNote CreateNote(FiveFretGuitarFret fret, NoteFlags flags, double time, uint tick)
     {
         return new GuitarNote(fret, GuitarNoteType.Strum, GuitarNoteFlags.None, flags, time, 0, tick, 0);
-    }
-
-    private static void LinkNotes(params GuitarNote[] notes)
-    {
-        for (int i = 0; i < notes.Length; i++)
-        {
-            if (i > 0)
-            {
-                notes[i].PreviousNote = notes[i - 1];
-            }
-
-            if (i < notes.Length - 1)
-            {
-                notes[i].NextNote = notes[i + 1];
-            }
-        }
     }
 
     private static SyncTrack CreateSyncTrack()

--- a/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
@@ -10,6 +10,117 @@ namespace YARG.Core.UnitTests.Engine;
 public class GuitarEngineTester : EngineTester
 {
     [Test]
+    public void TenSingleNotes_FcUsesCorrectMultiplierBoundary()
+    {
+        var notes = Enumerable.Range(1, 10)
+            .Select(index => CreateNote(
+                FiveFretGuitarFret.Green,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+        LinkNotes(notes.ToArray());
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.FiveFretGuitar, Difficulty.Expert,
+            notes, new(), new());
+        var engineParams = new GuitarEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.1,
+            0.1,
+            0.1,
+            false,
+            true,
+            false,
+            false,
+            true);
+        var engine = new YargFiveFretGuitarEngine(difficulty, CreateSyncTrack(), engineParams, true);
+
+        engine.Update(notes[^1].Time + 0.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 10 notes at 50 points each; chart base score assumes the pre-note combo (all 1x),
+            // while an FC commits the 10th note at 2x
+            Assert.That(engine.BaseNoteScore, Is.EqualTo(500));
+            Assert.That(engine.BaseScore, Is.EqualTo(500));
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(550));
+            Assert.That(engine.EngineStats.NoteScore, Is.EqualTo(500));
+            Assert.That(engine.EngineStats.MultiplierScore, Is.EqualTo(50));
+            Assert.That(engine.EngineStats.PendingScore, Is.Zero);
+            Assert.That(engine.EngineStats.TotalNotes, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesMissed, Is.Zero);
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(1f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.True);
+        }
+    }
+
+    [Test]
+    public void MissedNote_PercentReflectsMissAndComboResets()
+    {
+        var notes = Enumerable.Range(1, 10)
+            .Select(index => CreateNote(
+                FiveFretGuitarFret.Green,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+        LinkNotes(notes.ToArray());
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.FiveFretGuitar, Difficulty.Expert,
+            notes, new(), new());
+        var engineParams = new GuitarEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.1,
+            0.1,
+            0.1,
+            false,
+            true,
+            false,
+            false,
+            true);
+        var engine = new YargFiveFretGuitarEngine(difficulty, CreateSyncTrack(), engineParams, false);
+
+        // Hold green, strum every note except the 5th (at 2.5s)
+        var fret = GameInput.Create(0, GuitarAction.GreenFret, true);
+        engine.QueueInput(ref fret);
+        for (int i = 0; i < notes.Count; i++)
+        {
+            if (i == 4)
+            {
+                continue;
+            }
+
+            Strum(engine, notes[i].Time);
+        }
+
+        engine.Update(notes[^1].Time + 0.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(9));
+            Assert.That(engine.EngineStats.NotesMissed, Is.EqualTo(1));
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(5));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(0.9f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.False);
+            // Combo resets after the miss, so no note ever reaches 2x
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(450));
+            Assert.That(engine.EngineStats.MultiplierScore, Is.Zero);
+        }
+    }
+
+    [Test]
     public void TopFretBeforeTrillStart_IsForgivenByGuitarGhostLeniency()
     {
         var (engine, notes) = CreateTrillProximityEngine();
@@ -77,6 +188,13 @@ public class GuitarEngineTester : EngineTester
             NoteIndex = noteIndex;
             return IsGhostInTrillLeniencyWindow(inputNote);
         }
+    }
+
+    private static void Strum(YargFiveFretGuitarEngine engine, double time)
+    {
+        var strum = GameInput.Create(time, GuitarAction.StrumDown, true);
+        engine.QueueInput(ref strum);
+        engine.Update(time);
     }
 
     private static GuitarNote CreateNote(FiveFretGuitarFret fret, NoteFlags flags, double time, uint tick)

--- a/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/GuitarEngineTester.cs
@@ -121,6 +121,67 @@ public class GuitarEngineTester : EngineTester
     }
 
     [Test]
+    public void DisjointChord_CountsSingleComboAndScoresEachSustainOnce()
+    {
+        var notes = Enumerable.Range(1, 8)
+            .Select(index => CreateNote(
+                FiveFretGuitarFret.Green,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+
+        // Disjoint chord: green (no sustain) + red (one-beat sustain), same tick
+        var disjointChord = new GuitarNote(FiveFretGuitarFret.Green, GuitarNoteType.Strum,
+            GuitarNoteFlags.Disjoint, NoteFlags.None, 4.5, 0, 8 * 480, 0);
+        disjointChord.AddChildNote(new GuitarNote(FiveFretGuitarFret.Red, GuitarNoteType.Strum,
+            GuitarNoteFlags.None, NoteFlags.None, 4.5, 0.5, 8 * 480, 480));
+
+        var lastNote = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 5.0, 9 * 480);
+        var allNotes = notes.Concat(new[] { disjointChord, lastNote }).ToList();
+        LinkNotes(allNotes.ToArray());
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.FiveFretGuitar, Difficulty.Expert,
+            allNotes, new(), new());
+        var engineParams = new GuitarEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.1,
+            0.1,
+            0.1,
+            false,
+            true,
+            false,
+            false,
+            true);
+        var engine = new YargFiveFretGuitarEngine(difficulty, CreateSyncTrack(), engineParams, true);
+
+        engine.Update(5.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 8 singles at 1x + chord (2 notes) at 1x + last single at 1x = 550,
+            // plus the child sustain (480 ticks / 19.2 ticks per point) = 25
+            //
+            // The disjoint chord is hit with a single strum, so it must only
+            // increment combo once (8 singles + chord + last note = 10 max combo).
+            // If the chord's child notes incremented combo, the last note would
+            // be scored at 2x and BaseScore would be 625 instead of 575.
+            Assert.That(engine.BaseNoteScore, Is.EqualTo(575));
+            Assert.That(engine.BaseScore, Is.EqualTo(575));
+            Assert.That(engine.EngineStats.TotalNotes, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(1f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.True);
+        }
+    }
+
+    [Test]
     public void TopFretBeforeTrillStart_IsForgivenByGuitarGhostLeniency()
     {
         var (engine, notes) = CreateTrillProximityEngine();

--- a/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
@@ -188,6 +188,58 @@ public class KeysEngineTester : EngineTester
     }
 
     [Test]
+    public void ChordAcrossMultiplierBoundary_ScoresWholeChordAtSingleMultiplier()
+    {
+        // 9 singles so the pre-chord combo is 9, then a 3-note chord that crosses the 10-note boundary
+        var notes = Enumerable.Range(1, 9)
+            .Select(index => CreateNote(
+                FiveFretGuitarFret.Green,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+
+        var chord = CreateNote(FiveFretGuitarFret.Green, NoteFlags.None, 4.5, 8 * 480);
+        chord.AddChildNote(CreateNote(FiveFretGuitarFret.Red, NoteFlags.None, 4.5, 8 * 480));
+        chord.AddChildNote(CreateNote(FiveFretGuitarFret.Yellow, NoteFlags.None, 4.5, 8 * 480));
+        var allNotes = notes.Concat(new[] { chord }).ToList();
+        LinkNotes(allNotes.ToArray());
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert,
+            allNotes, new(), new());
+        var engineParams = new KeysEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.05,
+            0,
+            false,
+            true);
+        var engine = new YargFiveLaneKeysEngine(difficulty, CreateSyncTrack(), engineParams, true);
+
+        engine.Update(5.0);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // Base score assumes the pre-chord combo (9 -> 1x) for the whole chord:
+            // 9 * 50 at 1x + 3 * 50 at 1x = 600. Never 700 (chord notes 2-3 at 2x).
+            Assert.That(engine.BaseNoteScore, Is.EqualTo(600));
+            Assert.That(engine.BaseScore, Is.EqualTo(600));
+            // Gameplay: chord gives +1 combo, all 3 notes commit at 2x after the boundary
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(750));
+            Assert.That(engine.EngineStats.TotalNotes, Is.EqualTo(12));
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(12));
+            Assert.That(engine.EngineStats.NotesMissed, Is.Zero);
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(1f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.True);
+        }
+    }
+
+    [Test]
     public void MatchingKeyBeforeChordTremoloLaneStart_DoesNotOverhit()
     {
         var (engine, notes) = CreateChordTremoloLaneProximityEngine();
@@ -313,22 +365,6 @@ public class KeysEngineTester : EngineTester
     private static GuitarNote CreateNote(FiveFretGuitarFret fret, NoteFlags flags, double time, uint tick)
     {
         return new GuitarNote(fret, GuitarNoteType.Strum, GuitarNoteFlags.None, flags, time, 0, tick, 0);
-    }
-
-    private static void LinkNotes(params GuitarNote[] notes)
-    {
-        for (int i = 0; i < notes.Length; i++)
-        {
-            if (i > 0)
-            {
-                notes[i].PreviousNote = notes[i - 1];
-            }
-
-            if (i < notes.Length - 1)
-            {
-                notes[i].NextNote = notes[i + 1];
-            }
-        }
     }
 
     private static SyncTrack CreateSyncTrack()

--- a/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
+++ b/YARG.Core.UnitTests/Engine/KeysEngineTester.cs
@@ -10,6 +10,184 @@ namespace YARG.Core.UnitTests.Engine;
 public class KeysEngineTester : EngineTester
 {
     [Test]
+    public void TenSingleNotes_FcUsesCorrectMultiplierBoundary()
+    {
+        var notes = Enumerable.Range(1, 10)
+            .Select(index => CreateNote(
+                FiveFretGuitarFret.Green,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+        LinkNotes(notes.ToArray());
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert,
+            notes, new(), new());
+        var engineParams = new KeysEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.05,
+            0,
+            false,
+            true);
+        var engine = new YargFiveLaneKeysEngine(difficulty, CreateSyncTrack(), engineParams, true);
+
+        engine.Update(notes[^1].Time + 0.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 10 notes at 50 points each; chart base score assumes the pre-note combo (all 1x),
+            // while an FC commits the 10th note at 2x
+            Assert.That(engine.BaseNoteScore, Is.EqualTo(500));
+            Assert.That(engine.BaseScore, Is.EqualTo(500));
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(550));
+            Assert.That(engine.EngineStats.NoteScore, Is.EqualTo(500));
+            Assert.That(engine.EngineStats.MultiplierScore, Is.EqualTo(50));
+            Assert.That(engine.EngineStats.PendingScore, Is.Zero);
+            Assert.That(engine.EngineStats.TotalNotes, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.NotesMissed, Is.Zero);
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(10));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(1f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.True);
+        }
+    }
+
+    [Test]
+    public void MissedNote_PercentReflectsMissAndComboResets()
+    {
+        var notes = Enumerable.Range(1, 10)
+            .Select(index => CreateNote(
+                FiveFretGuitarFret.Green,
+                NoteFlags.None,
+                index * 0.5,
+                (uint) index * 480))
+            .ToList();
+        LinkNotes(notes.ToArray());
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert,
+            notes, new(), new());
+        var engineParams = new KeysEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.05,
+            0,
+            false,
+            true);
+        var engine = new YargFiveLaneKeysEngine(difficulty, CreateSyncTrack(), engineParams, false);
+
+        // Hit every note except the 5th (at 2.5s)
+        for (int i = 0; i < notes.Count; i++)
+        {
+            if (i == 4)
+            {
+                continue;
+            }
+
+            PressKey(engine, notes[i].Time, ProKeysAction.GreenKey);
+            ReleaseKey(engine, notes[i].Time + 0.05, ProKeysAction.GreenKey);
+        }
+
+        engine.Update(notes[^1].Time + 0.5);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(9));
+            Assert.That(engine.EngineStats.NotesMissed, Is.EqualTo(1));
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(5));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(0.9f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.False);
+            // Combo resets after the miss, so no note ever reaches 2x
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(450));
+            Assert.That(engine.EngineStats.MultiplierScore, Is.Zero);
+        }
+    }
+
+    [Test]
+    public void EmptyChart_ReportsFullPercentAndFullComboByDefinition()
+    {
+        // TotalNotes == 0 forces Percent to 1f (div-by-zero guard) and IsFullCombo to true
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert,
+            new List<GuitarNote>(), new(), new());
+        var engineParams = new KeysEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.05,
+            0,
+            false,
+            true);
+        var engine = new YargFiveLaneKeysEngine(difficulty, CreateSyncTrack(), engineParams, false);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engine.BaseScore, Is.Zero);
+            Assert.That(engine.EngineStats.TotalNotes, Is.Zero);
+            Assert.That(engine.EngineStats.NotesHit, Is.Zero);
+            Assert.That(engine.EngineStats.NotesMissed, Is.Zero);
+            Assert.That(engine.EngineStats.MaxCombo, Is.Zero);
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(1f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.True);
+        }
+    }
+
+    [Test]
+    public void SingleSustainNote_ChartScoreMatchesRuntimeScore()
+    {
+        // One green note with a one-beat sustain (480 ticks at 120bpm)
+        var note = new GuitarNote(FiveFretGuitarFret.Green, GuitarNoteType.Strum, GuitarNoteFlags.None,
+            NoteFlags.None, 0.0, 0.5, 0, 480);
+        LinkNotes(note);
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.Keys, Difficulty.Expert,
+            new List<GuitarNote> { note }, new(), new());
+        var engineParams = new KeysEngineParameters(
+            CreateHitWindowSettings(),
+            4,
+            0,
+            0,
+            StarMultiplierThresholds,
+            SoloBonusStarMultiplierThresholds,
+            0.05,
+            0,
+            false,
+            true);
+        var engine = new YargFiveLaneKeysEngine(difficulty, CreateSyncTrack(), engineParams, true);
+
+        // Step through time so the bot keeps the key held through the sustain
+        for (double t = 0; t <= 0.8; t += 0.01)
+        {
+            engine.Update(t);
+        }
+
+        using (Assert.EnterMultipleScope())
+        {
+            // 50 for the note + 25 for the one-beat sustain (480 ticks / 19.2 ticks per point)
+            Assert.That(engine.BaseNoteScore, Is.EqualTo(75));
+            Assert.That(engine.BaseScore, Is.EqualTo(75));
+            Assert.That(engine.EngineStats.CommittedScore, Is.EqualTo(75));
+            Assert.That(engine.EngineStats.NoteScore, Is.EqualTo(50));
+            Assert.That(engine.EngineStats.SustainScore, Is.EqualTo(25));
+            Assert.That(engine.EngineStats.MultiplierScore, Is.Zero);
+            Assert.That(engine.EngineStats.PendingScore, Is.Zero);
+            Assert.That(engine.EngineStats.MaxCombo, Is.EqualTo(1));
+            Assert.That(engine.EngineStats.Percent, Is.EqualTo(1f));
+            Assert.That(engine.EngineStats.IsFullCombo, Is.True);
+        }
+    }
+
+    [Test]
     public void MatchingKeyBeforeChordTremoloLaneStart_DoesNotOverhit()
     {
         var (engine, notes) = CreateChordTremoloLaneProximityEngine();

--- a/YARG.Core.UnitTests/Engine/ProKeysSustainTests.cs
+++ b/YARG.Core.UnitTests/Engine/ProKeysSustainTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Keys;
+using YARG.Core.Engine.Keys.Engines;
+using YARG.Core.Game;
+
+namespace YARG.Core.UnitTests.Engine;
+
+// Regression tests for the ProKeysNote constructor asymmetry: the primary (parsed-note)
+// constructor previously never set DisjointMask (only the copy constructor did), so any
+// engine built from un-cloned parsed notes could never hold a sustain (CanSustainHold
+// checked `(KeyMask & DisjointMask) != 0` against 0) and the chord-stagger key-hold
+// enforcement was dead code. The game always clones charts before play, which masked this;
+// these tests pin the un-cloned path so it cannot silently break again.
+public class ProKeysSustainTests : EngineTester
+{
+    private const int RES = 480;
+
+    // 120 bpm → 0.5s per beat
+    private static double TimeOf(uint tick) => tick / (double) RES * 0.5;
+
+    private static KeysEngineParameters KeysParams() =>
+        new(new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4, 0, 0, StarMultiplierThresholds, SoloBonusStarMultiplierThresholds, 0.05, 0, false, true);
+
+    private static YargProKeysEngine BuildEngine()
+    {
+        var notes = new List<ProKeysNote>
+        {
+            // Sustained note: key 0, one beat (480 ticks / 0.5s)
+            new(0, ProKeysNoteFlags.None, NoteFlags.None, TimeOf(0), TimeOf(480), 0, 480),
+            // Trailing note keeps the engine moving past the sustain end
+            new(4, ProKeysNoteFlags.None, NoteFlags.None, TimeOf(960), 0, 960, 0),
+        };
+
+        for (int i = 1; i < notes.Count; i++)
+        {
+            notes[i].PreviousNote = notes[i - 1];
+            notes[i - 1].NextNote = notes[i];
+        }
+
+        var diff = new InstrumentDifficulty<ProKeysNote>(Instrument.ProKeys, Difficulty.Expert, notes, new List<Phrase>(), new());
+
+        var syncTrack = new SyncTrack(RES);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        return new YargProKeysEngine(diff, syncTrack, KeysParams(), isBot: true);
+    }
+
+    [Test]
+    public void ParsedNotes_BotRun_SustainScores()
+    {
+        var engine = BuildEngine();
+
+        double endTime = TimeOf(960) + 1.0;
+        for (double t = 0; t <= endTime; t += 0.01)
+        {
+            engine.Update(t);
+        }
+
+        Assert.That(engine.EngineStats.NotesHit, Is.EqualTo(2), "both notes should be hit");
+        Assert.That(engine.EngineStats.NotesMissed, Is.EqualTo(0));
+        // One beat of sustain = 480 / 19.2 = 25 points, paid at combo 1 (1x)
+        Assert.That(engine.EngineStats.SustainScore, Is.EqualTo(25));
+    }
+}

--- a/YARG.Core.UnitTests/Parsing/MidiPreparserScanTests.cs
+++ b/YARG.Core.UnitTests/Parsing/MidiPreparserScanTests.cs
@@ -1,0 +1,702 @@
+using Melanchall.DryWetMidi.Common;
+using Melanchall.DryWetMidi.Core;
+using NUnit.Framework;
+using YARG.Core.Chart;
+using YARG.Core.IO;
+using YARG.Core.Song;
+using YARG.Core.UnitTests.Song;
+
+namespace YARG.Core.UnitTests.Parsing
+{
+    using MidiTextEvent = Melanchall.DryWetMidi.Core.TextEvent;
+
+    /// <summary>
+    /// End-to-end tests for the MIDI preparsers: builds real MIDI bytes via DryWetMidi,
+    /// feeds them through <see cref="SongEntry.ParseMidi"/> (via <see cref="TestSongEntry"/>),
+    /// and asserts the resulting <see cref="AvailableParts"/> and <see cref="DrumsType"/>.
+    /// This covers the preparsers, the YARGMidiFile binary parser, and track-name lookup in one shot.
+    /// </summary>
+    public class MidiPreparserScanTests
+    {
+        private const short Resolution = 192;
+        private const int DefaultVelocity = 100;
+
+        private readonly record struct TimedMidiEvent(long Tick, MidiEvent Event);
+
+        private static SevenBitNumber S(int number) => (SevenBitNumber) (byte) number;
+        private static FourBitNumber F(int number) => (FourBitNumber) (byte) number;
+
+        // Five fret: valid lanes are 60-65 per difficulty (59 is open, disabled by default)
+        private const int FIVEFRET_EASY = 60;
+        private const int FIVEFRET_MEDIUM = 72;
+        private const int FIVEFRET_HARD = 84;
+        private const int FIVEFRET_EXPERT = 96;
+        private const int FIVEFRET_OPEN = 59;
+
+        // Six fret: valid lanes are 58-64 per difficulty
+        private const int SIXFRET_EASY = 62;
+        private const int SIXFRET_MEDIUM = 74;
+        private const int SIXFRET_HARD = 86;
+        private const int SIXFRET_EXPERT = 98;
+
+        // Drums: kick lane is the first lane of each difficulty
+        private const int DRUMS_EASY = 60;
+        private const int DRUMS_MEDIUM = 72;
+        private const int DRUMS_HARD = 84;
+        private const int DRUMS_EXPERT = 96;
+        private const int DRUMS_DOUBLE_KICK = 95;
+        private const int DRUMS_YELLOW_TOM = 65;
+        private const int DRUMS_PRO_FLAG = 110;
+
+        // Elite drums: 24 notes per difficulty, 11 lanes
+        private const int ELITE_EASY = 1;
+        private const int ELITE_MEDIUM = 25;
+        private const int ELITE_HARD = 49;
+        private const int ELITE_EXPERT = 74;
+        private const int ELITE_DOUBLE_KICK = 73;
+        private const int ELITE_HAT_PEDAL_EASY = 0;
+
+        // Pro guitar: 24 notes per difficulty, 6 strings
+        private const int PROGUITAR_EASY = 24;
+        private const int PROGUITAR_MEDIUM = 48;
+        private const int PROGUITAR_HARD = 72;
+        private const int PROGUITAR_EXPERT = 96;
+
+        // Pro keys: any note in 48-72
+        private const int PROKEYS_NOTE = 48;
+
+        // Vocals: 36-84 are vocals, 105/106 are phrases, 96 is percussion
+        private const int VOCAL_NOTE = 60;
+        private const int VOCAL_PHRASE = 105;
+        private const int VOCAL_PERCUSSION = 96;
+
+        #region Five fret
+
+        [Test]
+        public void FiveFretGuitar_ParsesAllFourDifficulties()
+        {
+            var (result, parts, _) = ScanMidi(
+                MakeTrack("PART GUITAR",
+                    Note(0, 100, FIVEFRET_EASY),
+                    Note(200, 300, FIVEFRET_MEDIUM),
+                    Note(400, 500, FIVEFRET_HARD),
+                    Note(600, 700, FIVEFRET_EXPERT)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.HasValue, Is.True);
+                Assert.That(parts.FiveFretGuitar.Difficulties,
+                    Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy | DifficultyMask.Medium |
+                        DifficultyMask.Hard | DifficultyMask.Expert));
+                Assert.That(parts.FiveFretBass.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        [Test]
+        public void FiveFretGuitar_SingleDifficulty_DoesNotAddOthers()
+        {
+            var (_, parts, _) = ScanMidi(MakeTrack("PART GUITAR", Note(0, 100, FIVEFRET_MEDIUM)));
+
+            Assert.That(parts.FiveFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.Medium));
+        }
+
+        [Test]
+        public void FiveFretGuitar_OpenNote_RequiresEnhancedOpensText()
+        {
+            var (_, withoutText, _) = ScanMidi(MakeTrack("PART GUITAR", Note(0, 100, FIVEFRET_OPEN)));
+            var (_, withText, _) = ScanMidi(MakeTrack("PART GUITAR",
+                Text(0, "[ENHANCED_OPENS]"),
+                Note(0, 100, FIVEFRET_OPEN)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(withoutText.FiveFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.None));
+                Assert.That(withText.FiveFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+            }
+        }
+
+        [Test]
+        public void FiveFret_AllTrackTypes_AreParsed()
+        {
+            var (_, parts, _) = ScanMidi(
+                MakeTrack("PART GUITAR", Note(0, 100, FIVEFRET_EASY)),
+                MakeTrack("PART BASS", Note(0, 100, FIVEFRET_EASY)),
+                MakeTrack("PART RHYTHM", Note(0, 100, FIVEFRET_EASY)),
+                MakeTrack("PART GUITAR COOP", Note(0, 100, FIVEFRET_EASY)),
+                MakeTrack("PART KEYS", Note(0, 100, FIVEFRET_EASY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts.FiveFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(parts.FiveFretBass.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(parts.FiveFretRhythm.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(parts.FiveFretCoopGuitar.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(parts.Keys.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(parts.SixFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        #endregion
+
+        #region Six fret
+
+        [Test]
+        public void SixFretGuitar_ParsesAllFourDifficulties_WithoutBeginner()
+        {
+            var (_, parts, _) = ScanMidi(
+                MakeTrack("PART GUITAR GHL",
+                    Note(0, 100, SIXFRET_EASY),
+                    Note(200, 300, SIXFRET_MEDIUM),
+                    Note(400, 500, SIXFRET_HARD),
+                    Note(600, 700, SIXFRET_EXPERT)));
+
+            Assert.That(parts.SixFretGuitar.Difficulties,
+                Is.EqualTo(DifficultyMask.Easy | DifficultyMask.Medium | DifficultyMask.Hard | DifficultyMask.Expert));
+        }
+
+        [Test]
+        public void SixFret_AllTrackTypes_AreParsed()
+        {
+            var (_, parts, _) = ScanMidi(
+                MakeTrack("PART GUITAR GHL", Note(0, 100, SIXFRET_EASY)),
+                MakeTrack("PART BASS GHL", Note(0, 100, SIXFRET_EASY)),
+                MakeTrack("PART RHYTHM GHL", Note(0, 100, SIXFRET_EASY)),
+                MakeTrack("PART GUITAR COOP GHL", Note(0, 100, SIXFRET_EASY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts.SixFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.Easy));
+                Assert.That(parts.SixFretBass.Difficulties, Is.EqualTo(DifficultyMask.Easy));
+                Assert.That(parts.SixFretRhythm.Difficulties, Is.EqualTo(DifficultyMask.Easy));
+                Assert.That(parts.SixFretCoopGuitar.Difficulties, Is.EqualTo(DifficultyMask.Easy));
+            }
+        }
+
+        #endregion
+
+        #region Drums
+
+        [Test]
+        public void Drums_FourLane_KeepsFourLaneType()
+        {
+            var (_, parts, drumsType) = ScanMidi(DrumsType.FourLane,
+                MakeTrack("PART DRUMS",
+                    Note(0, 100, DRUMS_EASY),
+                    Note(200, 300, DRUMS_MEDIUM),
+                    Note(400, 500, DRUMS_HARD),
+                    Note(600, 700, DRUMS_EXPERT)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(drumsType, Is.EqualTo(DrumsType.FourLane));
+                Assert.That(parts.FourLaneDrums.Difficulties,
+                    Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy | DifficultyMask.Medium |
+                        DifficultyMask.Hard | DifficultyMask.Expert));
+            }
+        }
+
+        [Test]
+        public void Drums_ProDrums_DetectedFromProNote()
+        {
+            var (_, parts, drumsType) = ScanMidi(DrumsType.FourLane,
+                MakeTrack("PART DRUMS",
+                    Note(0, 100, DRUMS_EASY),
+                    Note(200, 300, DRUMS_PRO_FLAG)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(drumsType, Is.EqualTo(DrumsType.ProDrums));
+                Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+            }
+        }
+
+        [Test]
+        public void Drums_FiveLane_DetectedFromYellowTom_AndFinalized()
+        {
+            var (_, parts, drumsType) = ScanMidi(DrumsType.FiveLane,
+                MakeTrack("PART DRUMS", Note(0, 100, DRUMS_YELLOW_TOM)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(drumsType, Is.EqualTo(DrumsType.FiveLane));
+                Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+
+                var finalized = TestSongEntry.FinalizeDrumsForTest(parts, drumsType);
+                Assert.That(finalized.FiveLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(finalized.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        [Test]
+        public void Drums_YellowTom_IgnoredWhenFourLane()
+        {
+            var (_, parts, drumsType) = ScanMidi(DrumsType.FourLane,
+                MakeTrack("PART DRUMS", Note(0, 100, DRUMS_YELLOW_TOM)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(drumsType, Is.EqualTo(DrumsType.FourLane));
+                Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        [Test]
+        public void Drums_DoubleKick_ActivatesExpertPlus()
+        {
+            var (_, parts, _) = ScanMidi(DrumsType.FourLane,
+                MakeTrack("PART DRUMS", Note(0, 100, DRUMS_DOUBLE_KICK)));
+
+            Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.Expert | DifficultyMask.ExpertPlus));
+        }
+
+        [Test]
+        public void Drums_ProNote_IgnoredWhenFiveLane()
+        {
+            var (_, _, drumsType) = ScanMidi(DrumsType.FiveLane,
+                MakeTrack("PART DRUMS", Note(0, 100, DRUMS_PRO_FLAG)));
+
+            Assert.That(drumsType, Is.EqualTo(DrumsType.FiveLane));
+        }
+
+        #endregion
+
+        #region Elite drums
+
+        [Test]
+        public void EliteDrums_ParsesDifficulties_AndSetsDownchart()
+        {
+            var (_, parts, _) = ScanMidi(
+                MakeTrack("PART ELITE_DRUMS",
+                    Note(0, 100, ELITE_EASY),
+                    Note(200, 300, ELITE_MEDIUM),
+                    Note(400, 500, ELITE_HARD),
+                    Note(600, 700, ELITE_EXPERT)));
+
+            var expected = DifficultyMask.Beginner | DifficultyMask.Easy | DifficultyMask.Medium |
+                DifficultyMask.Hard | DifficultyMask.Expert;
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts.EliteDrums.Difficulties, Is.EqualTo(expected));
+                Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(expected));
+            }
+        }
+
+        [Test]
+        public void EliteDrums_HatPedal_ExcludedFromDownchart()
+        {
+            var (_, parts, _) = ScanMidi(MakeTrack("PART ELITE_DRUMS", Note(0, 100, ELITE_HAT_PEDAL_EASY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts.EliteDrums.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        [Test]
+        public void EliteDrums_HatPedal_WithCymbalChannel_IncludedInDownchart()
+        {
+            var (_, parts, _) = ScanMidi(MakeTrack("PART ELITE_DRUMS", Note(0, 100, ELITE_HAT_PEDAL_EASY, channel: 11)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts.EliteDrums.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+                Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+            }
+        }
+
+        [Test]
+        public void EliteDrums_DoubleKick_ActivatesExpertPlus()
+        {
+            var (_, parts, _) = ScanMidi(MakeTrack("PART ELITE_DRUMS", Note(0, 100, ELITE_DOUBLE_KICK)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts.EliteDrums.Difficulties, Is.EqualTo(DifficultyMask.Expert | DifficultyMask.ExpertPlus));
+                Assert.That(parts.FourLaneDrums.Difficulties, Is.EqualTo(DifficultyMask.Expert | DifficultyMask.ExpertPlus));
+            }
+        }
+
+        #endregion
+
+        #region Pro keys
+
+        [Test]
+        public void ProKeys_ParsesEachDifficultyTrack()
+        {
+            var (_, parts, _) = ScanMidi(
+                MakeTrack("PART REAL_KEYS_E", Note(0, 100, PROKEYS_NOTE)),
+                MakeTrack("PART REAL_KEYS_M", Note(0, 100, PROKEYS_NOTE)),
+                MakeTrack("PART REAL_KEYS_H", Note(0, 100, PROKEYS_NOTE)),
+                MakeTrack("PART REAL_KEYS_X", Note(0, 100, PROKEYS_NOTE)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts.ProKeys[Difficulty.Easy], Is.True);
+                Assert.That(parts.ProKeys[Difficulty.Medium], Is.True);
+                Assert.That(parts.ProKeys[Difficulty.Hard], Is.True);
+                Assert.That(parts.ProKeys[Difficulty.Expert], Is.True);
+                Assert.That(parts.ProKeys[Difficulty.ExpertPlus], Is.False);
+            }
+        }
+
+        #endregion
+
+        #region Pro guitar
+
+        [Test]
+        public void ProGuitar_17Fret_ParsesAllFourDifficulties()
+        {
+            var (_, parts, _) = ScanMidi(
+                MakeTrack("PART REAL_GUITAR",
+                    Note(0, 100, PROGUITAR_EASY),
+                    Note(200, 300, PROGUITAR_MEDIUM),
+                    Note(400, 500, PROGUITAR_HARD),
+                    Note(600, 700, PROGUITAR_EXPERT)));
+
+            Assert.That(parts.ProGuitar_17Fret.Difficulties,
+                Is.EqualTo(DifficultyMask.Easy | DifficultyMask.Medium | DifficultyMask.Hard | DifficultyMask.Expert));
+        }
+
+        [Test]
+        public void ProGuitar_22Fret_AcceptsHigherVelocity()
+        {
+            const int HIGH_VELOCITY = 120;
+
+            var (_, parts17, _) = ScanMidi(MakeTrack("PART REAL_GUITAR", Note(0, 100, PROGUITAR_EASY, velocity: HIGH_VELOCITY)));
+            var (_, parts22, _) = ScanMidi(MakeTrack("PART REAL_GUITAR_22", Note(0, 100, PROGUITAR_EASY, velocity: HIGH_VELOCITY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts17.ProGuitar_17Fret.Difficulties, Is.EqualTo(DifficultyMask.None));
+                Assert.That(parts22.ProGuitar_22Fret.Difficulties, Is.EqualTo(DifficultyMask.Easy));
+            }
+        }
+
+        [Test]
+        public void ProGuitar_VelocityBelowMinimum_Ignored()
+        {
+            const int LOW_VELOCITY = 99;
+
+            var (_, parts17, _) = ScanMidi(MakeTrack("PART REAL_GUITAR", Note(0, 100, PROGUITAR_EASY, velocity: LOW_VELOCITY)));
+            var (_, parts22, _) = ScanMidi(MakeTrack("PART REAL_GUITAR_22", Note(0, 100, PROGUITAR_EASY, velocity: LOW_VELOCITY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts17.ProGuitar_17Fret.Difficulties, Is.EqualTo(DifficultyMask.None));
+                Assert.That(parts22.ProGuitar_22Fret.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        [Test]
+        public void ProGuitar_ArpeggioChannel_Ignored()
+        {
+            var (_, parts17, _) = ScanMidi(MakeTrack("PART REAL_GUITAR", Note(0, 100, PROGUITAR_EASY, channel: 1)));
+            var (_, parts22, _) = ScanMidi(MakeTrack("PART REAL_GUITAR_22", Note(0, 100, PROGUITAR_EASY, channel: 1)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(parts17.ProGuitar_17Fret.Difficulties, Is.EqualTo(DifficultyMask.None));
+                Assert.That(parts22.ProGuitar_22Fret.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        #endregion
+
+        #region Vocals
+
+        [Test]
+        public void Vocals_Lead_RequiresPhrase()
+        {
+            var (_, withoutPhrase, _) = ScanMidi(MakeTrack("PART VOCALS", Note(0, 100, VOCAL_NOTE)));
+            var (_, withPhrase, _) = ScanMidi(MakeTrack("PART VOCALS",
+                Note(0, 100, VOCAL_NOTE),
+                Note(10, 110, VOCAL_PHRASE)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(withoutPhrase.LeadVocals[0], Is.False);
+                Assert.That(withPhrase.LeadVocals[0], Is.True);
+            }
+        }
+
+        [Test]
+        public void Vocals_Lead_Percussion_DoesNotActivateWithoutPhrase()
+        {
+            var (_, parts, _) = ScanMidi(MakeTrack("PART VOCALS",
+                Note(0, 100, VOCAL_NOTE),
+                Note(200, 300, VOCAL_PERCUSSION)));
+
+            Assert.That(parts.LeadVocals[0], Is.False);
+        }
+
+        [Test]
+        public void Vocals_HarmonyTracks_RequireHarmony1()
+        {
+            var (_, harm2Only, _) = ScanMidi(MakeTrack("PART HARM2", Note(0, 100, VOCAL_NOTE)));
+
+            var (_, allHarmonies, _) = ScanMidi(
+                MakeTrack("PART HARM1",
+                    Note(0, 100, VOCAL_NOTE),
+                    Note(10, 110, VOCAL_PHRASE)),
+                MakeTrack("PART HARM2", Note(0, 100, VOCAL_NOTE)),
+                MakeTrack("PART HARM3", Note(0, 100, VOCAL_NOTE)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(harm2Only.HarmonyVocals[0], Is.False);
+                Assert.That(allHarmonies.HarmonyVocals[0], Is.True);
+                Assert.That(allHarmonies.HarmonyVocals[1], Is.True);
+                Assert.That(allHarmonies.HarmonyVocals[2], Is.True);
+                Assert.That(allHarmonies.LeadVocals[0], Is.False);
+            }
+        }
+
+        #endregion
+
+        #region General scan behavior
+
+        [Test]
+        public void UnknownAndNamelessTracks_AreSkipped()
+        {
+            var (result, parts, _) = ScanMidi(
+                MakeTrack("PART BANJO", Note(0, 100, FIVEFRET_EASY)),
+                MakeNamelessTrack(Note(0, 100, FIVEFRET_EASY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.HasValue, Is.True);
+                Assert.That(result.Value, Is.EqualTo(Resolution));
+                Assert.That(parts.FiveFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.None));
+            }
+        }
+
+        [Test]
+        public void MultipleTrackNamesInSameTrack_ReturnsError()
+        {
+            var (result, _, _) = ScanMidi(MakeTrack("PART GUITAR",
+                TrackName(0, "PART BASS"),
+                Note(0, 100, FIVEFRET_EASY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.HasValue, Is.False);
+                Assert.That(result.Error, Is.EqualTo(ScanResult.MultipleMidiTrackNames));
+            }
+        }
+
+        [Test]
+        public void DuplicateTrackNameEvents_AreAllowed()
+        {
+            var (result, parts, _) = ScanMidi(MakeTrack("PART GUITAR",
+                TrackName(0, "PART GUITAR"),
+                Note(0, 100, FIVEFRET_EASY)));
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.HasValue, Is.True);
+                Assert.That(parts.FiveFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+            }
+        }
+
+        [Test]
+        public void DuplicateInstrumentTrack_IsIgnored()
+        {
+            var (_, parts, _) = ScanMidi(
+                MakeTrack("PART GUITAR", Note(0, 100, FIVEFRET_EASY)),
+                MakeTrack("PART GUITAR", Note(0, 100, FIVEFRET_MEDIUM)));
+
+            Assert.That(parts.FiveFretGuitar.Difficulties, Is.EqualTo(DifficultyMask.Beginner | DifficultyMask.Easy));
+        }
+
+        [Test]
+        public void InvalidResolution_ReturnsError()
+        {
+            var midi = MakeMidi(MakeTrack("PART GUITAR", Note(0, 100, FIVEFRET_EASY)));
+            using var file = ToFixedArrayWithZeroResolution(midi);
+
+            var (result, _, _) = TestSongEntry.ParseMidiForTest(file);
+
+            using (Assert.EnterMultipleScope())
+            {
+                Assert.That(result.HasValue, Is.False);
+                Assert.That(result.Error, Is.EqualTo(ScanResult.InvalidResolution));
+            }
+        }
+
+        [Test]
+        public void CorruptHeader_Throws()
+        {
+            var garbage = new byte[] { 0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02, 0x03 };
+            using var stream = new MemoryStream(garbage);
+            using var file = FixedArray.Read(stream, garbage.Length);
+
+            Assert.That(() => TestSongEntry.ParseMidiForTest(file),
+                Throws.Exception.With.Message.Contains("MThd"));
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static (ScanExpected<long> Result, AvailableParts Parts, DrumsType DrumsType) ScanMidi(
+            params TrackChunk[] tracks)
+        {
+            using var file = ToFixedArray(MakeMidi(tracks));
+            return TestSongEntry.ParseMidiForTest(file);
+        }
+
+        private static (ScanExpected<long> Result, AvailableParts Parts, DrumsType DrumsType) ScanMidi(
+            DrumsType initialDrumsType, params TrackChunk[] tracks)
+        {
+            using var file = ToFixedArray(MakeMidi(tracks));
+            return TestSongEntry.ParseMidiForTest(file, initialDrumsType);
+        }
+
+        private static MidiFile MakeMidi(params TrackChunk[] tracks)
+        {
+            var midi = new MidiFile
+            {
+                TimeDivision = new TicksPerQuarterNoteTimeDivision(Resolution),
+            };
+
+            // Required: DryWetMidi 7.0's writer splits a *single*-chunk file into separate
+            // meta/channel chunks when writing MultiTrack format, which would sever the
+            // track-name event from its notes. Adding a sync track (ignored by ParseMidi:
+            // "EVENTS" maps to MidiTrackType.Events, which has no switch case) keeps every
+            // chunk intact, and mirrors real charts which always carry a tempo track.
+            midi.Chunks.Add(new TrackChunk(new SequenceTrackNameEvent("EVENTS"), new SetTempoEvent(400000)));
+
+            foreach (var track in tracks)
+            {
+                midi.Chunks.Add(track);
+            }
+
+            return midi;
+        }
+
+        private static FixedArray<byte> ToFixedArray(MidiFile midi)
+        {
+            using var stream = new MemoryStream();
+            midi.Write(stream, MidiFileFormat.MultiTrack, null);
+            stream.Position = 0;
+            return FixedArray.Read(stream, stream.Length);
+        }
+
+        private static FixedArray<byte> ToFixedArrayWithZeroResolution(MidiFile midi)
+        {
+            using var stream = new MemoryStream();
+            midi.Write(stream, MidiFileFormat.MultiTrack, null);
+            var bytes = stream.ToArray();
+            // Division field is the last two bytes of the 14-byte header, big-endian
+            bytes[12] = 0;
+            bytes[13] = 0;
+
+            using var patched = new MemoryStream(bytes);
+            return FixedArray.Read(patched, patched.Length);
+        }
+
+        private static TrackChunk MakeTrack(string trackName, params object[] eventItems)
+        {
+            return MakeTrack(trackName, FlattenEvents(eventItems));
+        }
+
+        private static TrackChunk MakeTrack(string trackName, IEnumerable<TimedMidiEvent> events)
+        {
+            var ordered = SortEvents(events);
+            var chunk = new TrackChunk(new SequenceTrackNameEvent(trackName));
+            chunk.Events.AddRange(ordered.Select(item => item.Event));
+            return chunk;
+        }
+
+        private static TrackChunk MakeNamelessTrack(params object[] eventItems)
+        {
+            var ordered = SortEvents(FlattenEvents(eventItems));
+            var chunk = new TrackChunk();
+            chunk.Events.AddRange(ordered.Select(item => item.Event));
+            return chunk;
+        }
+
+        private static TimedMidiEvent[] SortEvents(IEnumerable<TimedMidiEvent> events)
+        {
+            var ordered = events
+                .OrderBy(item => item.Tick)
+                .ThenBy(item => EventPriority(item.Event))
+                .ThenBy(item => item.Event is NoteEvent note ? (int) note.NoteNumber : 0)
+                .ToArray();
+
+            long previousTick = 0;
+            foreach (var (tick, midiEvent) in ordered)
+            {
+                midiEvent.DeltaTime = tick - previousTick;
+                previousTick = tick;
+            }
+
+            return ordered;
+        }
+
+        private static int EventPriority(MidiEvent midiEvent)
+        {
+            return midiEvent switch
+            {
+                NoteOffEvent => 0,
+                BaseTextEvent => 1,
+                NoteOnEvent => 2,
+                _ => 1,
+            };
+        }
+
+        private static IEnumerable<TimedMidiEvent> FlattenEvents(IEnumerable<object> eventItems)
+        {
+            foreach (var item in eventItems)
+            {
+                switch (item)
+                {
+                    case TimedMidiEvent timedEvent:
+                        yield return timedEvent;
+                        break;
+                    case IEnumerable<TimedMidiEvent> eventGroup:
+                        foreach (var timedEvent in eventGroup)
+                        {
+                            yield return timedEvent;
+                        }
+                        break;
+                    default:
+                        throw new ArgumentException($"Unsupported MIDI test event item: {item.GetType()}");
+                }
+            }
+        }
+
+        private static TimedMidiEvent Text(long tick, string text)
+        {
+            return new TimedMidiEvent(tick, new MidiTextEvent(text));
+        }
+
+        private static TimedMidiEvent TrackName(long tick, string name)
+        {
+            return new TimedMidiEvent(tick, new SequenceTrackNameEvent(name));
+        }
+
+        private static TimedMidiEvent[] Note(long startTick, long endTick, int noteNumber,
+            int velocity = DefaultVelocity, int channel = 0)
+        {
+            return new[]
+            {
+                new TimedMidiEvent(startTick, new NoteOnEvent
+                {
+                    NoteNumber = S(noteNumber),
+                    Velocity = S(velocity),
+                    Channel = F(channel),
+                }),
+                new TimedMidiEvent(endTick, new NoteOffEvent
+                {
+                    NoteNumber = S(noteNumber),
+                    Channel = F(channel),
+                }),
+            };
+        }
+
+        #endregion
+    }
+}

--- a/YARG.Core.UnitTests/Replays/ReplayInfoTests.cs
+++ b/YARG.Core.UnitTests/Replays/ReplayInfoTests.cs
@@ -130,11 +130,18 @@ public class ReplayInfoTests
         return info;
     }
 
+    /// <summary>
+    /// Fallback value for fields not listed in <see cref="BuildCanonicalReplayInfo"/>'s switch,
+    /// so newly added fields are covered automatically. Values are deliberately non-default
+    /// and recognizable: a field that is not serialized comes back as its default value
+    /// (0 / null / false) and fails the round-trip equality assert.
+    /// </summary>
     private static object DistinctValueFor(Type type, string fieldName)
     {
         if (type == typeof(string))
         {
-            return "pǝɹʇ-юникод-名前";
+            // Distinctive string, deliberately non-default.
+            return "The quick brown fox jumps over the lazy dog";
         }
 
         if (type == typeof(bool))

--- a/YARG.Core.UnitTests/Replays/ReplayInfoTests.cs
+++ b/YARG.Core.UnitTests/Replays/ReplayInfoTests.cs
@@ -140,8 +140,8 @@ public class ReplayInfoTests
     {
         if (type == typeof(string))
         {
-            // Distinctive string, deliberately non-default.
-            return "The quick brown fox jumps over the lazy dog";
+            // Accented character, deliberately: exercises UTF-8 encode/decode round-trip.
+            return "café";
         }
 
         if (type == typeof(bool))

--- a/YARG.Core.UnitTests/Replays/ReplayInfoTests.cs
+++ b/YARG.Core.UnitTests/Replays/ReplayInfoTests.cs
@@ -1,0 +1,255 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using NUnit.Framework;
+using YARG.Core.Engine.Drums;
+using YARG.Core.Engine.Guitar;
+using YARG.Core.Engine.Keys;
+using YARG.Core.Engine.Vocals;
+using YARG.Core.Game;
+using YARG.Core.IO;
+using YARG.Core.Replays;
+using YARG.Core.Song;
+
+namespace YARG.Core.UnitTests.Replays;
+
+public class ReplayInfoTests
+{
+    [Test]
+    public void Serialize_ThenReadBack_RoundTripsAllFields()
+    {
+        var original = BuildCanonicalReplayInfo();
+        byte[] bytes = SerializeToBytes(original);
+
+        using var array = FixedArray.Read(new MemoryStream(bytes), bytes.Length);
+        var stream = array.ToValueStream();
+        var roundTripped = new ReplayInfo("C:\\fake\\test.replay", ref stream);
+
+        AssertAllFieldsEqual(original, roundTripped);
+
+        // The reader must consume exactly the bytes the writer produced.
+        // Any layout mismatch between Serialize and the read constructor
+        // (wrong field order, missing field, off-by-one version guard)
+        // shifts the stream and breaks this invariant.
+        Assert.That(stream.Position, Is.EqualTo(array.Length),
+            "Reader did not consume exactly the bytes written by Serialize");
+    }
+
+    public static IEnumerable<ReplayStats> AllStatsModes
+    {
+        get
+        {
+            yield return new DrumsReplayStats("DrumsPlayer", true, new DrumsStats
+            {
+                TotalNotes = 50,
+                NotesHit = 42,
+                Overhits = 2,
+                SoloBonuses = 1000,
+            });
+            yield return new ProKeysReplayStats("KeysPlayer", true, new KeysStats
+            {
+                TotalNotes = 40,
+                NotesHit = 35,
+                Overhits = 1,
+                SoloBonuses = 800,
+            });
+            yield return new VocalsReplayStats("Vocalist", true, new VocalsStats
+            {
+                TotalNotes = 30,
+                NotesHit = 28,
+            });
+        }
+    }
+
+    [Test]
+    public void Serialize_ThenReadBack_RoundTripsEachStatsMode(
+        [ValueSource(nameof(AllStatsModes))] ReplayStats stat)
+    {
+        var info = BuildCanonicalReplayInfo();
+        typeof(ReplayInfo).GetField("Stats")!.SetValue(info, new[] { stat });
+
+        byte[] bytes = SerializeToBytes(info);
+        using var array = FixedArray.Read(new MemoryStream(bytes), bytes.Length);
+        var stream = array.ToValueStream();
+        var roundTripped = new ReplayInfo("C:\\fake\\test.replay", ref stream);
+
+        // Is.InstanceOf in AssertStatsEqual verifies the mode byte written by
+        // Serialize dispatches back to the same stats class on read.
+        AssertAllFieldsEqual(info, roundTripped);
+        Assert.That(stream.Position, Is.EqualTo(array.Length),
+            "Reader did not consume exactly the bytes written by Serialize");
+    }
+
+    /// <summary>
+    /// Builds a ReplayInfo whose every field holds a distinct, recognizable value,
+    /// without knowing the constructor signature. The type is allocated uninitialized
+    /// and all public fields are assigned via reflection, so newly added fields are
+    /// picked up automatically.
+    /// </summary>
+    private static ReplayInfo BuildCanonicalReplayInfo()
+    {
+        var info = (ReplayInfo) RuntimeHelpers.GetUninitializedObject(typeof(ReplayInfo));
+
+        foreach (var field in typeof(ReplayInfo).GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            object? value = field.Name switch
+            {
+                // Serialized as a constant by Serialize(), not round-tripped from the field.
+                "ReplayVersion" => ReplayIO.REPLAY_VERSIONS.CURRENT,
+                // Recomputed by the read constructor from the song/artist/charter/date fields.
+                "ReplayName" => null,
+                "FilePath" => "C:\\fake\\test.replay",
+                "ReplayChecksum" => HashWrapper.FromString("00112233445566778899AABBCCDDEEFF00112233"),
+                "SongChecksum" => HashWrapper.FromString("FFEEDDCCBBAA99887766554433221100FEDCBA98"),
+                "Pauses" => new PauseInfo[]
+                {
+                    new() { PauseTime = 30.0, PauseLength = 5.0 },
+                    new() { PauseTime = 60.0, PauseLength = 2.5 },
+                },
+                "Stats" => new ReplayStats[]
+                {
+                    new GuitarReplayStats("PlayerOne", true, BuildGuitarStats()),
+                },
+                "Date" => new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc),
+                "BandStars" => StarAmount.Star5,
+                "SongSpeed" => 1.25f,
+                "ReplayLength" => 210.5,
+                "BandScore" => 123456,
+                "EngineVersion" => 5,
+                _ => DistinctValueFor(field.FieldType, field.Name),
+            };
+
+            if (value != null)
+            {
+                field.SetValue(info, value);
+            }
+        }
+
+        typeof(ReplayInfo).GetField(nameof(ReplayInfo.ReplayName))!.SetValue(info,
+            ReplayInfo.ConstructReplayName(info.SongName, info.ArtistName, info.CharterName, info.Date));
+        return info;
+    }
+
+    private static object DistinctValueFor(Type type, string fieldName)
+    {
+        if (type == typeof(string))
+        {
+            return "pǝɹʇ-юникод-名前";
+        }
+
+        if (type == typeof(bool))
+        {
+            return true;
+        }
+
+        if (type == typeof(int))
+        {
+            return 0x12345678;
+        }
+
+        if (type == typeof(long))
+        {
+            return 0x123456789ABCDEF0L;
+        }
+
+        if (type == typeof(float))
+        {
+            return 3.14159f;
+        }
+
+        if (type == typeof(double))
+        {
+            return 2.718281828;
+        }
+
+        if (type.IsEnum)
+        {
+            return Enum.GetValues(type).Cast<object>().Last();
+        }
+
+        throw new InvalidOperationException($"No distinct test value defined for field {fieldName} of type {type}");
+    }
+
+    private static GuitarStats BuildGuitarStats()
+    {
+        return new GuitarStats
+        {
+            CommittedScore = 100000,
+            TotalNotes = 100,
+            NotesHit = 87,
+            Overstrums = 3,
+            GhostInputs = 2,
+            SoloBonuses = 5000,
+            TotalStarPowerPhrases = 10,
+            StarPowerActivationCount = 2,
+            Stars = 4.5f,
+        };
+    }
+
+    private static byte[] SerializeToBytes(ReplayInfo info)
+    {
+        using var ms = new MemoryStream();
+        using (var writer = new BinaryWriter(ms, Encoding.UTF8, leaveOpen: true))
+        {
+            info.Serialize(writer);
+        }
+        return ms.ToArray();
+    }
+
+    private static void AssertAllFieldsEqual(ReplayInfo expected, ReplayInfo actual)
+    {
+        var fields = typeof(ReplayInfo).GetFields(BindingFlags.Public | BindingFlags.Instance);
+        using (Assert.EnterMultipleScope())
+        {
+            foreach (var field in fields)
+            {
+                var expectedValue = field.GetValue(expected);
+                var actualValue = field.GetValue(actual);
+                if (field.FieldType == typeof(PauseInfo[]))
+                {
+                    AssertPausesEqual((PauseInfo[]) expectedValue!, (PauseInfo[]) actualValue!, field.Name);
+                }
+                else if (field.FieldType == typeof(ReplayStats[]))
+                {
+                    AssertStatsEqual((ReplayStats[]) expectedValue!, (ReplayStats[]) actualValue!, field.Name);
+                }
+                else
+                {
+                    Assert.That(actualValue, Is.EqualTo(expectedValue), $"Field {field.Name} did not round-trip");
+                }
+            }
+        }
+    }
+
+    private static void AssertPausesEqual(PauseInfo[] expected, PauseInfo[] actual, string context)
+    {
+        Assert.That(actual, Has.Length.EqualTo(expected.Length), $"{context}: pause count");
+        for (int i = 0; i < expected.Length; i++)
+        {
+            Assert.That(actual[i].PauseTime, Is.EqualTo(expected[i].PauseTime), $"{context}[{i}].PauseTime");
+            Assert.That(actual[i].PauseLength, Is.EqualTo(expected[i].PauseLength), $"{context}[{i}].PauseLength");
+        }
+    }
+
+    private static void AssertStatsEqual(ReplayStats[] expected, ReplayStats[] actual, string context)
+    {
+        Assert.That(actual, Has.Length.EqualTo(expected.Length), $"{context}: stats count");
+        for (int i = 0; i < expected.Length; i++)
+        {
+            AssertStatsEqual(expected[i], actual[i], $"{context}[{i}]");
+        }
+    }
+
+    private static void AssertStatsEqual(ReplayStats expected, ReplayStats actual, string context)
+    {
+        Assert.That(actual, Is.InstanceOf(expected.GetType()), context);
+
+        var type = expected.GetType();
+        foreach (var field in type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.FlattenHierarchy))
+        {
+            var expectedValue = field.GetValue(expected);
+            var actualValue = field.GetValue(actual);
+            Assert.That(actualValue, Is.EqualTo(expectedValue), $"{context}.{field.Name} did not round-trip");
+        }
+    }
+}

--- a/YARG.Core.UnitTests/Song/TestSongEntry.cs
+++ b/YARG.Core.UnitTests/Song/TestSongEntry.cs
@@ -118,6 +118,15 @@ internal sealed class TestSongEntry : SongEntry
         return parts;
     }
 
+    public static (ScanExpected<long> Result, AvailableParts Parts, DrumsType DrumsType) ParseMidiForTest(
+        FixedArray<byte> file, DrumsType initialDrumsType = DrumsType.Unknown)
+    {
+        var parts = AvailableParts.Default;
+        var drumsType = initialDrumsType;
+        var result = ParseMidi(file, ref parts, ref drumsType);
+        return (result, parts, drumsType);
+    }
+
     public static bool IsValidForTest(in AvailableParts parts)
     {
         return IsValid(in parts);

--- a/YARG.Core/Chart/Notes/ProKeysNote.cs
+++ b/YARG.Core/Chart/Notes/ProKeysNote.cs
@@ -29,6 +29,7 @@ namespace YARG.Core.Chart
             ProKeysFlags = _proKeysFlags = proKeysFlags;
 
             NoteMask = GetKeyMask(Key);
+            DisjointMask = GetKeyMask(Key);
         }
 
         public ProKeysNote(ProKeysNote other) : base(other)

--- a/YARG.Core/Chart/Sync/SyncTrack.cs
+++ b/YARG.Core/Chart/Sync/SyncTrack.cs
@@ -425,8 +425,21 @@ namespace YARG.Core.Chart
             {
                 low = approxTime;
                 high = approxTime * 2;
+
+                uint lastHighTick = TimeToMeasureTick(high);
                 while (TimeToMeasureTick(high) < targetTick)
                 {
+                    uint nextHighTick = TimeToMeasureTick(high * 2);
+
+                    // The measure tick is monotonic in time, so if it stops growing the
+                    // target is unreachable (e.g. beyond the end of the track, or a track
+                    // with no time signatures). Bail out instead of doubling forever.
+                    if (nextHighTick <= lastHighTick)
+                    {
+                        return approxTime;
+                    }
+
+                    lastHighTick = nextHighTick;
                     low = high;
                     high *= 2;
                 }

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -471,6 +471,7 @@ namespace YARG.Core.Engine
 
         protected void ActivateStarPower()
         {
+
             // I don't think RB quite did it this way, but we'll let players burn half a bar to revive bandmates
             // even if they are already in SP, so long as they have enough
             if (PlayerNeedsRevive && BaseStats.StarPowerTickAmount >= TicksPerHalfSpBar)

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using YARG.Core.Chart;
 using YARG.Core.Input;
 using YARG.Core.Logging;
@@ -421,20 +420,15 @@ namespace YARG.Core.Engine.Guitar
                 noteScore += pointsForSustain;
                 combo++;
                 // If a note is disjoint, each sustain is counted separately.
+                // Disjoint chords are hit with a single strum, so they do not
+                // increment combo beyond the single increment above.
                 if (note.IsDisjoint)
                 {
-                    HashSet<uint> seenNoteTicks = new();
                     foreach (var child in note.ChildNotes)
                     {
                         double pointsForDisjoint = Math.Ceiling(child.TickLength / TicksPerSustainPoint);
                         baseScore += multiplier * pointsForDisjoint;
                         noteScore += pointsForDisjoint;
-                        // Only increment combo if we haven't already seen a note in that tick
-                        if (!seenNoteTicks.Contains(child.Tick))
-                        {
-                            combo++;
-                            seenNoteTicks.Add(child.Tick);
-                        }
                     }
                 }
             }

--- a/YARG.Core/Engine/Guitar/GuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/GuitarEngine.cs
@@ -274,21 +274,13 @@ namespace YARG.Core.Engine.Guitar
 
             AddScore(note);
 
-            if (note.IsDisjoint)
+            // Every sustained chord member gets its own sustain, disjoint or not.
+            foreach (var chordNote in note.AllNotes)
             {
-                foreach (var chordNote in note.AllNotes)
+                if (chordNote.IsSustain)
                 {
-                    if (!chordNote.IsSustain)
-                    {
-                        continue;
-                    }
-
                     StartSustain(chordNote);
                 }
-            }
-            else if (note.IsSustain)
-            {
-                StartSustain(note);
             }
 
             WasNoteGhosted = false;
@@ -415,21 +407,16 @@ namespace YARG.Core.Engine.Guitar
                 baseScore += multiplier * pointsForNote;
                 noteScore += pointsForNote;
 
-                double pointsForSustain = Math.Ceiling(note.TickLength / TicksPerSustainPoint);
-                baseScore += multiplier * pointsForSustain;
-                noteScore += pointsForSustain;
                 combo++;
-                // If a note is disjoint, each sustain is counted separately.
                 // Disjoint chords are hit with a single strum, so they do not
                 // increment combo beyond the single increment above.
-                if (note.IsDisjoint)
+                // Every sustained chord member scores its own sustain (AllNotes[0]
+                // is the parent itself), disjoint or not.
+                foreach (var chordNote in note.AllNotes)
                 {
-                    foreach (var child in note.ChildNotes)
-                    {
-                        double pointsForDisjoint = Math.Ceiling(child.TickLength / TicksPerSustainPoint);
-                        baseScore += multiplier * pointsForDisjoint;
-                        noteScore += pointsForDisjoint;
-                    }
+                    double pointsForSustain = Math.Ceiling(chordNote.TickLength / TicksPerSustainPoint);
+                    baseScore += multiplier * pointsForSustain;
+                    noteScore += pointsForSustain;
                 }
             }
 

--- a/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
@@ -181,38 +181,16 @@ namespace YARG.Core.Engine.Keys
                 }
 
                 // Get the current multiplier given the current combo
-                multiplier = Math.Min((combo / 10) + 1, BaseParameters.MaxMultiplier);
-                double scoreForNote = POINTS_PER_NOTE * (1 + note.ChildNotes.Count);
-
-                foreach (var child in note.AllNotes)
+                // Every note in a chord is hit and scored separately on keys, and
+                // each sustain is worth its own points, so iterate over AllNotes
+                foreach (var chordNote in note.AllNotes)
                 {
-                    scoreForNote += (int) Math.Ceiling(child.TickLength / TicksPerSustainPoint);
+                    multiplier = Math.Min((combo / 10) + 1, BaseParameters.MaxMultiplier);
+                    double scoreForNote = POINTS_PER_NOTE + (int) Math.Ceiling(chordNote.TickLength / TicksPerSustainPoint);
+                    baseScore += multiplier * scoreForNote;
+                    noteScore += scoreForNote;
+                    combo++;
                 }
-                baseScore += multiplier * scoreForNote;
-                noteScore += scoreForNote;
-
-                double pointsForSustain = Math.Ceiling(note.TickLength / TicksPerSustainPoint);
-                baseScore += multiplier * pointsForSustain;
-                noteScore += pointsForSustain;
-                combo++;
-                // If a note is disjoint, each sustain is counted separately.
-                if (note.IsDisjoint)
-                {
-                    foreach (var child in note.ChildNotes)
-                    {
-                        HashSet<uint> seenNoteTicks = new();
-                        double pointsForDisjoint = Math.Ceiling(child.TickLength / TicksPerSustainPoint);
-                        baseScore += multiplier * pointsForDisjoint;
-                        noteScore += pointsForDisjoint;
-                        // Only increment combo if we haven't already seen a note in that tick
-                        if (!seenNoteTicks.Contains(child.Tick))
-                        {
-                            combo++;
-                            seenNoteTicks.Add(child.Tick);
-                        }
-                    }
-                }
-                combo++;
             }
 
             YargLogger.LogDebug($"[Keys] Base score: {baseScore}, Max Combo: {combo}");

--- a/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
+++ b/YARG.Core/Engine/Keys/FiveLaneKeys/FiveLaneKeysEngine.cs
@@ -181,16 +181,19 @@ namespace YARG.Core.Engine.Keys
                 }
 
                 // Get the current multiplier given the current combo
-                // Every note in a chord is hit and scored separately on keys, and
-                // each sustain is worth its own points, so iterate over AllNotes
+                multiplier = Math.Min((combo / 10) + 1, BaseParameters.MaxMultiplier);
+                double pointsForNote = POINTS_PER_NOTE * (1 + note.ChildNotes.Count);
+                baseScore += multiplier * pointsForNote;
+                noteScore += pointsForNote;
                 foreach (var chordNote in note.AllNotes)
                 {
-                    multiplier = Math.Min((combo / 10) + 1, BaseParameters.MaxMultiplier);
-                    double scoreForNote = POINTS_PER_NOTE + (int) Math.Ceiling(chordNote.TickLength / TicksPerSustainPoint);
-                    baseScore += multiplier * scoreForNote;
-                    noteScore += scoreForNote;
-                    combo++;
+                    int pointsForSustain = (int) Math.Ceiling(chordNote.TickLength / TicksPerSustainPoint);
+                    baseScore += multiplier * pointsForSustain;
+                    noteScore += pointsForSustain;
                 }
+
+                // Keys combo increments per chord, not per note.
+                combo++;
             }
 
             YargLogger.LogDebug($"[Keys] Base score: {baseScore}, Max Combo: {combo}");

--- a/YARG.Core/Engine/Vocals/VocalsEngine.cs
+++ b/YARG.Core/Engine/Vocals/VocalsEngine.cs
@@ -313,7 +313,7 @@ namespace YARG.Core.Engine.Vocals
 
         protected override void UpdateMultiplier()
         {
-            EngineStats.ScoreMultiplier = Math.Min(EngineStats.Combo + 1, 4);
+            EngineStats.ScoreMultiplier = Math.Min(EngineStats.Combo + 1, BaseParameters.MaxMultiplier);
 
             if (EngineStats.IsStarPowerActive)
             {

--- a/YARG.Core/Song/Entries/SongEntry.Scanning.cs
+++ b/YARG.Core/Song/Entries/SongEntry.Scanning.cs
@@ -6,7 +6,7 @@ namespace YARG.Core.Song
 {
     public abstract partial class SongEntry
     {
-        private protected static ScanExpected<long> ParseMidi(FixedArray<byte> file, ref AvailableParts parts, ref DrumsType drumsType)
+        internal static ScanExpected<long> ParseMidi(FixedArray<byte> file, ref AvailableParts parts, ref DrumsType drumsType)
         {
             var midiFile = YARGMidiFile.Load(file);
             if (midiFile.Resolution == 0)


### PR DESCRIPTION
Note: This pr was almost entirely vibecoded as I just wanted to get some tests in for the scoring, given we have more than one PR to do with scoring changes.  In the process, two bugs may have been found.  I appreciate any look at the scoring changes as I'm not entirely sure what is correct there.

 Added tests for:
 - DrumsEngine
 - GuitarEngine
 - FiveLaneKeysEngine
 - ReplayInfo
 - MidiPreparser


 Bug 1 (5-lane keys): the song's max score counted every sustain note's points twice.
 Introduced in https://github.com/YARC-Official/YARG.Core/commit/b3d37169

 Bug 2 (guitar): split chords got extra combo in the max-score math, but the game only gives one combo per strum.
 Introduced in  https://github.com/YARC-Official/YARG.Core/commit/df171b81