### PR TITLE
Parse strings and keys authors from DTA

### DIFF
--- a/YARG.Core/IO/DTA/DTAEntry.cs
+++ b/YARG.Core/IO/DTA/DTAEntry.cs
@@ -19,6 +19,8 @@ namespace YARG.Core.IO
         public string? Genre;
         public string? Subgenre;
         public TextSpan? Charter;
+        public TextSpan? CharterKeys;
+        public TextSpan? CharterProStrings;
         public string? Source;
         public TextSpan? Playlist;
         public TextSpan? LoadingPhrase;
@@ -221,6 +223,8 @@ namespace YARG.Core.IO
                     case "song_length": SongLength = YARGDTAReader.ExtractInteger<long>(ref container); break;
                     case "sub_genre": Subgenre = YARGDTAReader.ExtractText(ref container); break;
                     case "author": Charter = YARGDTAReader.ExtractTextBytes(ref container); break;
+                    case "keys_author": CharterKeys = YARGDTAReader.ExtractTextBytes(ref container); break;
+                    case "strings_author": CharterProStrings = YARGDTAReader.ExtractTextBytes(ref container); break;
                     case "guide_pitch_volume": /*GuidePitchVolume = YARGDTAReader.Extract<float>(ref container);*/ break;
                     case "encoding":
                         MetadataEncoding = YARGDTAReader.ExtractText(ref container).ToLower() switch

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -767,6 +767,16 @@ namespace YARG.Core.Song
             if (dta.CoveredBy != null)            { entry._metadata.CoveredBy     = YARGDTAReader.DecodeString(dta.CoveredBy.Value, dta.MetadataEncoding); }
             if (dta.Album != null)                { entry._metadata.Album         = YARGDTAReader.DecodeString(dta.Album.Value, dta.MetadataEncoding); }
             if (dta.Charter != null)              { entry._metadata.Charter       = YARGDTAReader.DecodeString(dta.Charter.Value, dta.MetadataEncoding); }
+            if (dta.CharterKeys != null)
+            {
+                entry._metadata.CharterKeys    = YARGDTAReader.DecodeString(dta.CharterKeys.Value, dta.MetadataEncoding);
+                entry._metadata.CharterProKeys = YARGDTAReader.DecodeString(dta.CharterKeys.Value, dta.MetadataEncoding);
+            }
+            if (dta.CharterProStrings != null)
+            {
+                entry._metadata.CharterProGuitar = YARGDTAReader.DecodeString(dta.CharterProStrings.Value, dta.MetadataEncoding);
+                entry._metadata.CharterProBass   = YARGDTAReader.DecodeString(dta.CharterProStrings.Value, dta.MetadataEncoding);
+            }
             if (dta.LoadingPhrase != null)        { entry._metadata.LoadingPhrase = YARGDTAReader.DecodeString(dta.LoadingPhrase.Value, dta.MetadataEncoding); }
             if (dta.Playlist != null)             { entry._metadata.Playlist      = YARGDTAReader.DecodeString(dta.Playlist.Value, dta.MetadataEncoding); }
             if (dta.Genre != null)


### PR DESCRIPTION
In RB3DX, `strings_author` is used to credit pro strings upgrades and `keys_author` is used to credit keys upgrades. These values are included in `songs_updates` as well as some customs.