### PR TITLE
Read CON listings in parallel during cache deserialization

### DIFF
--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -905,7 +905,13 @@ namespace YARG.Core.Song.Cache
         private HashSet<string> invalidSongsInCache = new();
         private Dictionary<string, FileCollection> collectionCache = new();
         private Dictionary<string, QuickCONMods> cacheCONModifications = new();
-        private Dictionary<string, List<CONFileListing>?> cacheCONListings = new();
+        private Dictionary<string, Lazy<List<CONFileListing>?>> cacheCONListings = new();
+
+        /// <summary>
+        /// Spans every header field <see cref="CONFile.TryParseListings"/> reads (0x0 - 0x381), so that they all
+        /// resolve out of a single buffer fill.
+        /// </summary>
+        private const int CON_HEADER_BUFFERSIZE = 0x1000;
 
         /// <summary>
         /// The sum of all "count" variables in a file
@@ -1548,20 +1554,38 @@ namespace YARG.Core.Song.Cache
 
         private List<CONFileListing>? GetCacheCONListings(string filename)
         {
-            List<CONFileListing>? listings = null;
+            Lazy<List<CONFileListing>?> listings;
+            // Callers arrive from a Parallel.ForEach over every CON in the cache, so the read is deliberately
+            // left outside the lock - holding it across the read serializes the whole library behind one file
             lock (cacheCONListings)
             {
                 if (!cacheCONListings.TryGetValue(filename, out listings))
                 {
-                    if (File.Exists(filename))
-                    {
-                        using var filestream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read, 1);
-                        listings = CONFile.TryParseListings(filename, filestream);
-                    }
-                    cacheCONListings.Add(filename, listings);
+                    cacheCONListings.Add(filename, listings = new Lazy<List<CONFileListing>?>(
+                        () => ParseCONListings(filename), LazyThreadSafetyMode.ExecutionAndPublication));
                 }
             }
-            return listings;
+            return listings.Value;
+        }
+
+        // Every failure has to resolve to null - neither call site is guarded, so a throw would unwind through
+        // the loops in Deserialize_Quick and abandon the remainder of the cache read
+        private static List<CONFileListing>? ParseCONListings(string filename)
+        {
+            try
+            {
+                using var filestream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read, CON_HEADER_BUFFERSIZE);
+                return CONFile.TryParseListings(filename, filestream);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            {
+                return null;
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogException(ex, $"Error while reading the listings of {filename}");
+                return null;
+            }
         }
 
         private struct PackedGroupResult

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -1577,7 +1577,11 @@ namespace YARG.Core.Song.Cache
                 using var filestream = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read, CON_HEADER_BUFFERSIZE);
                 return CONFile.TryParseListings(filename, filestream);
             }
-            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
+            catch (DirectoryNotFoundException)
             {
                 return null;
             }


### PR DESCRIPTION
GetCacheCONListings held the cacheCONListings lock across the file open and the listing parse itself. Since every caller reaches it from a Parallel.ForEach over the CON groups in the cache, that serialized the entire library behind one file read at a time where every thread waited on the lock.

Only the dictionary lookup needs to be guarded. Storing a `Lazy<>` lets the read happen outside the lock while still parsing any individual CON exactly once.

Also gives the `FileStream` a buffer large enough to cover the CON header. The header is read in four small chunks spread over the first 0x380 bytes, and with the previous buffer size of 1 each of those was its own trip to the filesystem.

Measured on a 4187 song library (3394 ini, 175 sng, 618 packed CONs) where the CONs live on a network share:

  cold cache:  6362ms -> 812ms
  warm cache:   186ms ->  61ms

The win scales with how many separate CON files a library has, and is largest when they are slow to reach.