### PR TITLE
Make subfile lookup in UnpackedIniEntry case-insensitive

### DIFF
--- a/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
+++ b/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs
@@ -267,7 +267,7 @@ namespace YARG.Core.Song
 
         private Dictionary<string, string> GetSubFiles()
         {
-            Dictionary<string, string> files = new();
+            Dictionary<string, string> files = new(StringComparer.OrdinalIgnoreCase);
             if (Directory.Exists(_location))
             {
                 foreach (var file in Directory.EnumerateFiles(_location))


### PR DESCRIPTION
GetSubFiles() lowercases directory entries when building its lookup dict, but _video/_background/_cover are stored as written in song.ini and looked up with exact-case TryGetValue. Any song whose referenced filename has uppercase characters silently fails to resolve. This is my simplest solution to resolve the issue, but I'm happy to take recommendations that limit collateral damage concerns.

[SongEntry.UnpackedIni.cs:275](/YARC-Official/YARG.Core/tree/master/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs#L275) — GetSubFiles() builds its lookup dictionary with lowercased filenames: files.Add(file[...].ToLower(), file).
[SongEntry.IniBase.cs:278](/YARC-Official/YARG.Core/tree/master/YARG.Core/Song/Entries/Ini/SongEntry.IniBase.cs#L278) — entry._video = video stores the video= value from song.ini as-written, original case.
[SongEntry.UnpackedIni.cs:174](/YARC-Official/YARG.Core/tree/master/YARG.Core/Song/Entries/Ini/SongEntry.UnpackedIni.cs#L174) — subFiles.TryGetValue(_video, out var video) then does an exact-case lookup.