### PR TITLE
Fix folder sorting for CON multisong packs

### DIFF
--- a/YARG.Core/IO/DTA/DTAEntry.cs
+++ b/YARG.Core/IO/DTA/DTAEntry.cs
@@ -22,7 +22,6 @@ namespace YARG.Core.IO
         public TextSpan? CharterKeys;
         public TextSpan? CharterProStrings;
         public string? Source;
-        public TextSpan? Playlist;
         public TextSpan? LoadingPhrase;
         public int? YearAsNumber;
         public int? YearSecondaryAsNumber;
@@ -216,7 +215,7 @@ namespace YARG.Core.IO
                     case "date_released": YearAsNumber = int.Parse(YARGDTAReader.ExtractText(ref container).AsSpan(0, 4)); break;
                     case "album_name": Album = YARGDTAReader.ExtractTextBytes(ref container); break;
                     case "album_track_number": AlbumTrack = YARGDTAReader.ExtractInteger<int>(ref container); break;
-                    case "pack_name": Playlist = YARGDTAReader.ExtractTextBytes(ref container); break;
+                    case "pack_name": /*Playlist = YARGDTAReader.ExtractTextBytes(ref container);*/ break;
                     case "base_points": /*BasePoints = YARGDTAReader.Extract<uint>(ref container);*/ break;
                     case "band_fail_cue": /*BandFailCue = YARGDTAReader.ExtractText(ref container);*/ break;
                     case "drum_bank": DrumBank = YARGDTAReader.ExtractText(ref container); break;

--- a/YARG.Core/IO/DTA/DTAEntry.cs
+++ b/YARG.Core/IO/DTA/DTAEntry.cs
@@ -22,6 +22,7 @@ namespace YARG.Core.IO
         public TextSpan? CharterKeys;
         public TextSpan? CharterProStrings;
         public string? Source;
+        public TextSpan? PackName;
         public TextSpan? LoadingPhrase;
         public int? YearAsNumber;
         public int? YearSecondaryAsNumber;
@@ -215,7 +216,7 @@ namespace YARG.Core.IO
                     case "date_released": YearAsNumber = int.Parse(YARGDTAReader.ExtractText(ref container).AsSpan(0, 4)); break;
                     case "album_name": Album = YARGDTAReader.ExtractTextBytes(ref container); break;
                     case "album_track_number": AlbumTrack = YARGDTAReader.ExtractInteger<int>(ref container); break;
-                    case "pack_name": /*Playlist = YARGDTAReader.ExtractTextBytes(ref container);*/ break;
+                    case "pack_name": PackName = YARGDTAReader.ExtractTextBytes(ref container); break;
                     case "base_points": /*BasePoints = YARGDTAReader.Extract<uint>(ref container);*/ break;
                     case "band_fail_cue": /*BandFailCue = YARGDTAReader.ExtractText(ref container);*/ break;
                     case "drum_bank": DrumBank = YARGDTAReader.ExtractText(ref container); break;

--- a/YARG.Core/Song/Cache/CacheHandler.cs
+++ b/YARG.Core/Song/Cache/CacheHandler.cs
@@ -623,6 +623,22 @@ namespace YARG.Core.Song.Cache
                 }
                 return new PlaylistTracker(_fullDirectoryFlag, playlist);
             }
+
+            /// <summary>
+            /// Returns the accumulated directory-based playlist, if any was found.
+            /// Used by packed CON scanning to fall back to the CON's own file name
+            /// instead of "Unknown Playlist" when no meaningful directory exists.
+            /// </summary>
+            public bool TryGetPlaylist(out string playlist)
+            {
+                if (!string.IsNullOrEmpty(_playlist))
+                {
+                    playlist = _playlist!;
+                    return true;
+                }
+                playlist = string.Empty;
+                return false;
+            }
         }
 
         /// <summary>
@@ -775,7 +791,13 @@ namespace YARG.Core.Song.Cache
                     }
                     else
                     {
-                        var result = CreateCONGroup(info, tracker.Playlist);
+                        // Loose multisong CON packs rarely sit in a meaningfully-named
+                        // directory, so fall back to the pack's own file name rather
+                        // than dumping every unnamed pack into "Unknown Playlist"
+                        string playlist = tracker.TryGetPlaylist(out var directoryPlaylist)
+                            ? directoryPlaylist
+                            : GetConDisplayName(info.Name);
+                        var result = CreateCONGroup(info, playlist);
                         if (result.Upgrades != null)
                         {
                             // Ensures any con entries pulled from cache are removed for re-evaluation
@@ -1293,7 +1315,10 @@ namespace YARG.Core.Song.Cache
 
             FindOrMarkFile(filename);
 
-            string defaultPlaylist = ConstructPlaylist(filename, baseGroup.Directory, fullDirectoryPlaylists);
+            // Upgrade CONs are always packed files, so fall back to the file's own
+            // name rather than "Unknown Playlist" when it has no real directory
+            string defaultPlaylist = ConstructPlaylist(filename, baseGroup.Directory, fullDirectoryPlaylists,
+                GetConDisplayName(filename));
             var result = CreateCONGroup(info, defaultPlaylist);
             if (result.Upgrades != null && result.Upgrades.Root.LastWriteTime == conLastWrite)
             {
@@ -1406,7 +1431,6 @@ namespace YARG.Core.Song.Cache
             }
 
             var lastWriteTime = DateTime.FromBinary(stream.Read<long>(Endianness.Little));
-            string defaultPlaylist = ConstructPlaylist(location, baseGroup.Directory, fullDirectoryPlaylists);
 
             CONEntryGroup? group = null;
             if (stream.ReadBoolean())
@@ -1422,6 +1446,9 @@ namespace YARG.Core.Song.Cache
                     if (info.Exists)
                     {
                         FindOrMarkFile(location);
+                        // Packed CON: fall back to the file's own name, not "Unknown Playlist"
+                        string defaultPlaylist = ConstructPlaylist(location, baseGroup.Directory, fullDirectoryPlaylists,
+                            GetConDisplayName(location));
                         group = CreateCONGroup(info, defaultPlaylist).Entries;
                     }
                 }
@@ -1432,6 +1459,9 @@ namespace YARG.Core.Song.Cache
                 if (dtaInfo.Exists)
                 {
                     FindOrMarkDirectory(location);
+                    // Unpacked/ex-CON: behavior unchanged for now (see PR notes)
+                    string defaultPlaylist = ConstructPlaylist(location, baseGroup.Directory, fullDirectoryPlaylists,
+                        "Unknown Playlist");
                     if (UnpackedConsolePackageEntryGroup.Create(location, dtaInfo, defaultPlaylist, out var unpacked))
                     {
                         lock (conEntryGroups)
@@ -1657,13 +1687,18 @@ namespace YARG.Core.Song.Cache
         /// </summary>
         /// <param name="filename">The path for the current file</param>
         /// <param name="baseDirectory">One of the base directories provided by the user</param>
+        /// <param name="unknownFallback">
+        /// What to return when no meaningful directory exists (e.g. the file sits
+        /// directly in a base directory). Callers pick this so packed CONs can fall
+        /// back to their own file name instead of a generic "Unknown Playlist".
+        /// </param>
         /// <returns>The default playlist to potentially use</returns>
-        private string ConstructPlaylist(string filename, string baseDirectory, bool fullDirectoryPlaylists)
+        private string ConstructPlaylist(string filename, string baseDirectory, bool fullDirectoryPlaylists, string unknownFallback)
         {
             string directory = Path.GetDirectoryName(filename);
             if (directory.Length == baseDirectory.Length)
             {
-                return "Unknown Playlist";
+                return unknownFallback;
             }
 
             if (!fullDirectoryPlaylists)
@@ -1671,6 +1706,24 @@ namespace YARG.Core.Song.Cache
                 return Path.GetFileName(directory);
             }
             return directory[(baseDirectory.Length + 1)..];
+        }
+
+        /// <summary>
+        /// Returns a CON pack's display name for use as a folder/playlist fallback.
+        /// Many packed CONs have no real extension (e.g. "13.A RB1 DLC 01"), so
+        /// Path.GetFileNameWithoutExtension would wrongly treat a mid-name dot as
+        /// the extension separator and truncate the name. Only a genuine trailing
+        /// ".con" is stripped; everything else is left exactly as named.
+        /// </summary>
+        private static string GetConDisplayName(string conPath)
+        {
+            string name = Path.GetFileName(conPath);
+            const string conExtension = ".con";
+            if (name.EndsWith(conExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                name = name[..^conExtension.Length];
+            }
+            return name;
         }
         #endregion
     }

--- a/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
+++ b/YARG.Core/Song/Entries/RBCON/SongEntry.RBCON.cs
@@ -792,7 +792,9 @@ namespace YARG.Core.Song
                 entry._metadata.CharterProBass   = YARGDTAReader.DecodeString(dta.CharterProStrings.Value, dta.MetadataEncoding);
             }
             if (dta.LoadingPhrase != null)        { entry._metadata.LoadingPhrase = YARGDTAReader.DecodeString(dta.LoadingPhrase.Value, dta.MetadataEncoding); }
-            if (dta.Playlist != null)             { entry._metadata.Playlist      = YARGDTAReader.DecodeString(dta.Playlist.Value, dta.MetadataEncoding); }
+            // pack_name is intentionally not applied to Playlist - CacheHandler now derives
+            // the folder/playlist name from directory structure or the CON's own file name,
+            // which is more reliable than a pack_name field that many CONs omit or vary in.
             if (dta.Genre != null)
             {
                 entry._metadata.Genre    = dta.Genre;


### PR DESCRIPTION
## Goal

CON multisong packs are currently not categorized correctly when the library is sorted by folders. By default, they appear under "Unknown Playlist" unless they are placed in a subfolder or have a `pack_name` entry in their DTA. The `pack_name` entry is currently read as `Playlist`, which doesn't seem fitting. More importantly, `Playlist` shouldn't be used to determine the folder name when sorting the library by folders.

Using `pack_name` this way also seems to contradict the goal of folder sorting, which should let users decide how their songs are organized and what their folders are named.

## The fix

The changes are as follows:

1. The `pack_name` entry from DTA files is renamed from `Playlist` to `PackName`. This is currently unused, but if it is used in the future, naming it `PackName` should make its purpose more transparent.
2. When a CON multisong pack is not inside a subfolder, its default folder name is now the name of the CON file itself. This allows users to have a library containing only multisong CON packs without needing to manually create subfolders just to get meaningful names when using folder sorting.

## Additional info

This solves the main issues I was originally trying to address with #411 and #422.

It turns out that video backgrounds **are** supported for CON multisong packs. The videos simply need to be placed alongside the CON file and follow the naming convention `$"{dtanode}.{extension}"`. Since this was one of the reasons I originally wanted to extract my CON packs, this is now much less of an issue.

CON multisong packs also being sorted incorrectly when using folder sorting was another reason I found extracting them useful. This is exactly the issue that this PR wishes to solve, so extracting CON packs would be less necessary than I originally thought.

I still think having the option to support MOGG and `png_xbox` files directly is a worthwhile addition, so I will leave #422 open. The other reasons I mentioned in #422 still apply, particularly avoiding unnecessary conversion and allowing the original files to be used directly. I also believe that supporting the maximum amount of different file types will help the game feel more accessible to all users.

As long as this PR gets merged, though, #422 doesn't serve quite as much of a purpose as it originally did. :)

## Minimal changes

Changing the naming convention is not that big of a deal since making subfolders is not the end of the world, but `pack_name`'s having precedence over a user's named folders shouldn't happen. I would say that renaming pack_name in DTAEntry is the least that could be done to help with this.