### PR TITLE
Commit points when rebasing sustains

### DIFF
--- a/YARG.Core.UnitTests/Engine/SustainListTests.cs
+++ b/YARG.Core.UnitTests/Engine/SustainListTests.cs
@@ -114,7 +114,6 @@ public class SustainListTests
         {
             Assert.That(sustain.Note, Is.SameAs(note));
             Assert.That(sustain.BaseTick, Is.EqualTo(note.Tick));
-            Assert.That(sustain.BaseScore, Is.Zero);
             Assert.That(sustain.HasFinishedScoring, Is.False);
             Assert.That(sustain.IsLeniencyHeld, Is.False);
             Assert.That(sustain.LeniencyDropTime, Is.EqualTo(-9999));

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -841,13 +841,10 @@ namespace YARG.Core.Engine
         {
             EngineStats.PendingScore = 0;
 
-            bool isStarPowerSustainActiveRightNow = false;
             for (int i = 0; i < ActiveSustains.Count; i++)
             {
                 ref var sustain = ref ActiveSustains[i];
                 var note = sustain.Note;
-
-                isStarPowerSustainActiveRightNow |= note.IsStarPower;
 
                 // If we're close enough to the end of the sustain, finish it
                 // Provides leniency for sustains with no gap (and just in general)
@@ -871,7 +868,7 @@ namespace YARG.Core.Engine
 
                 if(!CanSustainHold(note))
                 {
-                    // Currently beind held by sustain drop leniency
+                    // Currently being held by sustain drop leniency
                     if (sustain.IsLeniencyHeld)
                     {
                         if (CurrentTime >= sustain.LeniencyDropTime + EngineParameters.SustainDropLeniency * EngineParameters.SongSpeed)
@@ -911,8 +908,7 @@ namespace YARG.Core.Engine
 
                         AddScore(points);
                         ulong timeAsUlong = UnsafeExtensions.DoubleToUInt64Bits(CurrentTime);
-                        ulong baseScoreAsUlong = UnsafeExtensions.DoubleToUInt64Bits(sustain.BaseScore);
-                        YargLogger.LogFormatTrace("Added {0} points for end of sustain at {1} (0x{2}). Base Score/Tick: {3} (0x{4}), {5}", points, CurrentTime, timeAsUlong.ToString("X"), sustain.BaseScore, baseScoreAsUlong.ToString("X"), sustain.BaseTick);
+                        YargLogger.LogFormatTrace("Added {0} points for end of sustain at {1} (0x{2}). Base Tick: {3}", points, CurrentTime, timeAsUlong.ToString("X"), sustain.BaseTick);
 
                         // SustainPoints must include the multiplier, but NOT the star power multiplier
                         int sustainPoints = points * EngineStats.ScoreMultiplier;
@@ -920,7 +916,6 @@ namespace YARG.Core.Engine
                         {
                             sustainPoints /= 2;
                         }
-
                         EngineStats.SustainScore += sustainPoints;
                     }
                     else
@@ -1248,7 +1243,7 @@ namespace YARG.Core.Engine
 
         protected override void RebaseSustains(uint baseTick)
         {
-            EngineStats.PendingScore = 0;
+            int totalSustainScore = 0;
             for (int i = 0; i < ActiveSustains.Count; i++)
             {
                 ref var sustain = ref ActiveSustains[i];
@@ -1262,11 +1257,19 @@ namespace YARG.Core.Engine
                     continue;
                 }
 
+                if (baseTick == sustain.BaseTick)
+                {
+                    continue;
+                }
+
                 double sustainScore = CalculateSustainPoints(ref sustain, baseTick);
+                totalSustainScore += (int) Math.Ceiling(sustainScore);
 
                 sustain.BaseTick = Math.Clamp(baseTick, sustain.Note.Tick, sustain.Note.TickEnd);
-                sustain.BaseScore = sustainScore;
-                EngineStats.PendingScore += (int) sustainScore;
+            }
+            if (totalSustainScore > 0)
+            {
+                AddScore(totalSustainScore);
             }
         }
 
@@ -1360,7 +1363,7 @@ namespace YARG.Core.Engine
             // Sustain points are awarded at a constant rate regardless of tempo
             // double deltaScore = CalculateBeatProgress(scoreTick, sustain.BaseTick, POINTS_PER_BEAT);
             double deltaScore = (scoreTick - sustain.BaseTick) / TicksPerSustainPoint;
-            return sustain.BaseScore + deltaScore;
+            return deltaScore;
         }
 
         protected void AdvanceToNextNote(TNoteType note)

--- a/YARG.Core/Engine/BaseEngine.Generic.cs
+++ b/YARG.Core/Engine/BaseEngine.Generic.cs
@@ -926,7 +926,7 @@ namespace YARG.Core.Engine
 
                         // It's ok to use multiplier here because PendingScore is only temporary to show the correct
                         // score on the UI.
-                        EngineStats.PendingScore += sustainPoints * EngineStats.ScoreMultiplier;
+                        EngineStats.PendingScore += sustainPoints * (EngineStats.ScoreMultiplier + EngineStats.BandBonusMultiplier);
                     }
                 }
 

--- a/YARG.Core/Engine/BaseEngine.cs
+++ b/YARG.Core/Engine/BaseEngine.cs
@@ -495,6 +495,8 @@ namespace YARG.Core.Engine
             YargLogger.LogFormatTrace("Activated at SP tick {0}, ends at SP tick {1}. Start time: {2}, End time: {3}",
                 StarPowerTickActivationPosition, StarPowerTickEndPosition, StarPowerActivationTime, StarPowerEndTime);
 
+            RebaseSustains(CurrentTick);
+
             BaseStats.IsStarPowerActive = true;
 
             UpdateMultiplier();
@@ -506,6 +508,8 @@ namespace YARG.Core.Engine
         {
             YargLogger.LogFormatTrace("Star Power ended at {0} (tick: {1})", CurrentTime,
                 StarPowerTickPosition);
+
+            RebaseSustains(CurrentTick);
 
             BaseStats.IsStarPowerActive = false;
 

--- a/YARG.Core/Engine/BaseStats.cs
+++ b/YARG.Core/Engine/BaseStats.cs
@@ -17,7 +17,8 @@ namespace YARG.Core.Engine
         /// <summary>
         /// Score that is currently pending addition (e.g. from active sustains).
         /// These points are recalculated every update, and only get added once their
-        /// final condition has been met.
+        /// final condition has been met. <br/>
+        /// Pending score exists only for the purpose of display, it is not used for any final score calculations.
         /// </summary>
         /// <remarks>
         /// These points are still earned, but their total value is not final yet.

--- a/YARG.Core/Engine/SustainList.cs
+++ b/YARG.Core/Engine/SustainList.cs
@@ -107,7 +107,6 @@ namespace YARG.Core.Engine
     {
         public TNoteType Note;
         public uint      BaseTick;
-        public double    BaseScore;
 
         public bool HasFinishedScoring;
         public bool IsLeniencyHeld;
@@ -118,7 +117,6 @@ namespace YARG.Core.Engine
         {
             Note = note;
             BaseTick = note.Tick;
-            BaseScore = 0;
 
             HasFinishedScoring = false;
             IsLeniencyHeld = false;


### PR DESCRIPTION
This also rebases sustains early when SP ends, so that it can capture the SP state in AddScore before it is actually disabled. This means it rebases twice here, but the second should be skipped.