### PR TITLE
fix(bot): rebuild guitar bot held-fret mask each tick to drop stale bits

### DIFF
--- a/YARG.Core.UnitTests/Engine/FiveFretBotSustainTests.cs
+++ b/YARG.Core.UnitTests/Engine/FiveFretBotSustainTests.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Guitar;
+using YARG.Core.Engine.Guitar.Engines;
+
+namespace YARG.Core.UnitTests.Engine;
+
+/// <summary>
+/// The stale-held-fret bug lived in the shared five-fret bot mask logic: a sustain
+/// bit OR'd in for an extended sustain lingered after that sustain ended. It only
+/// bites when the leftover fret is a higher fret than a still-held sustain (invalid
+/// anchor), which is what this descending-overlap case reproduces.
+/// </summary>
+public class FiveFretBotSustainTests
+{
+    private const double TICKS_PER_SEC = 960.0; // 480 tpr * 120 bpm / 60
+
+    private static GuitarNote Sus(FiveFretGuitarFret fret, uint tick, uint tickLen, bool extended)
+    {
+        return new GuitarNote(fret, GuitarNoteType.Strum,
+            extended ? GuitarNoteFlags.ExtendedSustain : GuitarNoteFlags.None,
+            NoteFlags.None,
+            tick / TICKS_PER_SEC, tickLen / TICKS_PER_SEC, tick, tickLen);
+    }
+
+    private static void LinkNotes(params GuitarNote[] notes)
+    {
+        for (int i = 0; i < notes.Length; i++)
+        {
+            if (i > 0) notes[i].PreviousNote = notes[i - 1];
+            if (i < notes.Length - 1) notes[i].NextNote = notes[i + 1];
+        }
+    }
+
+    private class TestBotFiveFretEngine : YargFiveFretGuitarEngine
+    {
+        public List<string> Drops = new();
+        public List<string> Misses = new();
+
+        public TestBotFiveFretEngine(InstrumentDifficulty<GuitarNote> chart, SyncTrack syncTrack,
+            GuitarEngineParameters engineParameters)
+            : base(chart, syncTrack, engineParameters, true)
+        {
+            OnSustainEnd += (note, time, finished) =>
+            {
+                if (!finished)
+                    Drops.Add($"sustain tick={note.Tick} dropped at {time:F3}");
+            };
+            OnNoteMissed += (index, note) => Misses.Add($"note index={index} tick={note.Tick} missed");
+        }
+    }
+
+    /// <summary>
+    /// Orange extended sustain (0..720), Blue sustain (480..1440). When the Orange
+    /// sustain ends at 720, the bot's mask still holds Orange, which is a higher
+    /// fret than Blue and therefore no valid anchor - the Blue sustain must survive.
+    /// </summary>
+    [Test]
+    public void Bot_KeepsSustain_WhenPreviousExtendedSustainEndsOnSameTick()
+    {
+        var first = Sus(FiveFretGuitarFret.Orange, 0, 720, true);
+        var second = Sus(FiveFretGuitarFret.Blue, 480, 960, false);
+        LinkNotes(first, second);
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.FiveFretGuitar, Difficulty.Expert,
+            new(new[] { first, second }), new(), new());
+
+        var engineParams = new GuitarEngineParameters(
+            new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4, 0, 0.05,
+            new[] { 0.08f, 0.17f, 0.28f, 0.41f, 0.55f, 0.71f, 0.88f, 1.0f },
+            new[] { 0.08f, 0.17f, 0.28f, 0.41f, 0.55f, 0.71f, 0.88f, 1.0f },
+            0.1, 0.1, 0.1,
+            false, true, false, false, true);
+
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new TestBotFiveFretEngine(difficulty, syncTrack, engineParams);
+
+        for (double t = 0; t <= 2.0; t += 1.0 / 60.0)
+            engine.Update(t);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engine.Misses, Is.Empty);
+            Assert.That(engine.Drops, Is.Empty);
+        }
+    }
+}

--- a/YARG.Core.UnitTests/Engine/SixFretBotSustainTests.cs
+++ b/YARG.Core.UnitTests/Engine/SixFretBotSustainTests.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using YARG.Core.Chart;
+using YARG.Core.Engine;
+using YARG.Core.Engine.Guitar;
+using YARG.Core.Engine.Guitar.Engines;
+
+namespace YARG.Core.UnitTests.Engine;
+
+/// <summary>
+/// Regression for the six-fret bot stale-held-fret bug (shared with five-fret in
+/// YargFiveFretGuitarEngine.UpdateBot): when an extended sustain ended on the exact
+/// tick a new sustain on the same fret number in the other row was pressed, the bot
+/// kept holding the finished sustain's fret until its next note press. The stale fret
+/// is not a valid six-fret anchor, so the fresh sustain was judged dropped the instant
+/// it started.
+/// </summary>
+public class SixFretBotSustainTests
+{
+    private const double TICKS_PER_SEC = 960.0; // 480 tpr * 120 bpm / 60
+
+    private static GuitarNote Sus(SixFretGuitarFret fret, uint tick, uint tickLen, bool extended)
+    {
+        return new GuitarNote(fret, GuitarNoteType.Strum,
+            extended ? GuitarNoteFlags.ExtendedSustain : GuitarNoteFlags.None,
+            NoteFlags.None,
+            tick / TICKS_PER_SEC, tickLen / TICKS_PER_SEC, tick, tickLen);
+    }
+
+    private static void LinkNotes(params GuitarNote[] notes)
+    {
+        for (int i = 0; i < notes.Length; i++)
+        {
+            if (i > 0) notes[i].PreviousNote = notes[i - 1];
+            if (i < notes.Length - 1) notes[i].NextNote = notes[i + 1];
+        }
+    }
+
+    private class TestBotSixFretEngine : YargSixFretGuitarEngine
+    {
+        public List<string> Drops = new();
+        public List<string> Misses = new();
+
+        public TestBotSixFretEngine(InstrumentDifficulty<GuitarNote> chart, SyncTrack syncTrack,
+            GuitarEngineParameters engineParameters)
+            : base(chart, syncTrack, engineParameters, true)
+        {
+            OnSustainEnd += (note, time, finished) =>
+            {
+                if (!finished)
+                    Drops.Add($"sustain tick={note.Tick} dropped at {time:F3}");
+            };
+            OnNoteMissed += (index, note) => Misses.Add($"note index={index} tick={note.Tick} missed");
+        }
+    }
+
+    [Test]
+    public void Bot_KeepsSustain_WhenPreviousExtendedSustainEndsOnSameTick()
+    {
+        // B3 extended sustain (0..720), W3 sustain (480..1440) - W3 is not extended.
+        var first = Sus(SixFretGuitarFret.Black3, 0, 720, true);
+        var second = Sus(SixFretGuitarFret.White3, 480, 960, false);
+        LinkNotes(first, second);
+
+        var difficulty = new InstrumentDifficulty<GuitarNote>(Instrument.SixFretGuitar, Difficulty.Expert,
+            new(new[] { first, second }), new(), new());
+
+        var engineParams = new GuitarEngineParameters(
+            new HitWindowSettings(0.1, 0.1, 1.0, false, 0, 1.0, 1.0, 0.15, 0.25),
+            4, 0, 0.05,
+            new[] { 0.08f, 0.17f, 0.28f, 0.41f, 0.55f, 0.71f, 0.88f, 1.0f },
+            new[] { 0.08f, 0.17f, 0.28f, 0.41f, 0.55f, 0.71f, 0.88f, 1.0f },
+            0.1, 0.1, 0.1,
+            false, true, false, false, true);
+
+        var syncTrack = new SyncTrack(480);
+        syncTrack.Tempos.Add(new TempoChange(120, 0, 0));
+
+        var engine = new TestBotSixFretEngine(difficulty, syncTrack, engineParams);
+
+        for (double t = 0; t <= 2.0; t += 1.0 / 60.0)
+            engine.Update(t);
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(engine.Misses, Is.Empty);
+            Assert.That(engine.Drops, Is.Empty);
+        }
+    }
+}

--- a/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
+++ b/YARG.Core/Engine/Guitar/Engines/YargFiveFretGuitarEngine.cs
@@ -12,6 +12,10 @@ namespace YARG.Core.Engine.Guitar.Engines
         // driven by GuitarActions, which don't include an explicit "open strum" value
         public const int OPEN_BRE_INPUT = int.MaxValue;
 
+        // The fret mask of the note the bot last pressed, without any extended sustain bits
+        // OR'd in. The bot's held-button mask is rebuilt from this on every update.
+        private byte _botBaseMask = OPEN_MASK;
+
         protected override int WildcardMask => 1 << ((int)FiveFretGuitarFret.Wildcard - 1);
 
         public YargFiveFretGuitarEngine(InstrumentDifficulty<GuitarNote> chart, SyncTrack syncTrack,
@@ -20,37 +24,56 @@ namespace YARG.Core.Engine.Guitar.Engines
         {
         }
 
+        public override void Reset(bool keepCurrentButtons = false)
+        {
+            base.Reset(keepCurrentButtons);
+
+            // Match the (possibly kept) button mask so the next mask rebuild does not
+            // resurrect frets from a previous run of the engine.
+            _botBaseMask = EffectiveButtonMask;
+        }
+
         protected override void UpdateBot(double time)
         {
-            if (!IsBot || NoteIndex >= Notes.Count)
+            if (!IsBot)
             {
                 return;
             }
 
-            IsStarPowerInputActive = CanStarPowerActivate && !IsStarPowerInputActive;
-
-            var note = Notes[NoteIndex];
-
-            if (time < note.Time)
+            if (NoteIndex < Notes.Count)
             {
-                return;
+                IsStarPowerInputActive = CanStarPowerActivate && !IsStarPowerInputActive;
+
+                var note = Notes[NoteIndex];
+
+                if (time >= note.Time)
+                {
+                    LastButtonMask = EffectiveButtonMask;
+                    _botBaseMask = (byte) note.NoteMask;
+                    EffectiveButtonMask = _botBaseMask;
+
+                    YargLogger.LogFormatTrace("[Bot] Set button mask to: {0}", EffectiveButtonMask);
+
+                    if (IsCodaActive)
+                    {
+                        HandleCodaFretChange(time);
+                    }
+
+                    HasTapped = EffectiveButtonMask != LastButtonMask;
+                    IsFretPress = true;
+                    HasStrummed = false;
+                    StrumLeniencyTimer.Start(time);
+                }
             }
 
-            LastButtonMask = EffectiveButtonMask;
-            EffectiveButtonMask = (byte) note.NoteMask;
-
-            YargLogger.LogFormatTrace("[Bot] Set button mask to: {0}", EffectiveButtonMask);
-
-            if (IsCodaActive)
-            {
-                HandleCodaFretChange(time);
-            }
-
-            HasTapped = EffectiveButtonMask != LastButtonMask;
-            IsFretPress = true;
-            HasStrummed = false;
-            StrumLeniencyTimer.Start(time);
-
+            // Rebuild the bot's held frets on every update: the last pressed note, plus the
+            // frets of extended sustains that are still active. Previously the mask was only
+            // rewritten on a new note press, so the fret of a sustain that ended in between
+            // was held down until the bot's next note. That stale fret matches neither a
+            // still-held overlapping sustain nor a valid anchor (in six-fret, a fret of the
+            // same fret number from the other row never is), which dropped the sustain the
+            // moment the previous one ended - exactly where a real player would let go.
+            byte mask = _botBaseMask;
             foreach (var sustain in ActiveSustains)
             {
                 var sustainNote = sustain.Note;
@@ -62,17 +85,15 @@ namespace YARG.Core.Engine.Guitar.Engines
 
                 if (sustainNote.IsDisjoint)
                 {
-                    EffectiveButtonMask |= (byte) sustainNote.DisjointMask;
-
-                    YargLogger.LogFormatTrace("[Bot] Added Disjoint Sustain Mask {0} to button mask. {1}", sustainNote.DisjointMask, EffectiveButtonMask);
+                    mask |= (byte) sustainNote.DisjointMask;
                 }
                 else
                 {
-                    EffectiveButtonMask |= (byte) sustainNote.NoteMask;
-
-                    YargLogger.LogFormatTrace("[Bot] Added Sustain Mask {0} to button mask. {1}", sustainNote.NoteMask, EffectiveButtonMask);
+                    mask |= (byte) sustainNote.NoteMask;
                 }
             }
+
+            EffectiveButtonMask = mask;
         }
 
         protected override void MutateStateWithInput(GameInput gameInput)


### PR DESCRIPTION
UpdateBot only rewrote EffectiveButtonMask on a new bot note press. An extended-sustain fret bit from a bot note whose sustain had ended lingered, breaking the hold check of a still-active overlapping sustain whose target fret was lower

Only affects bot code